### PR TITLE
Group installer skills and curate release notes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,11 @@
   "homepage": "https://github.com/magickaichen/knowledge-loom",
   "repository": "https://github.com/magickaichen/knowledge-loom",
   "license": "MIT",
-  "keywords": ["knowledge", "markdown", "vault", "context", "governance"]
+  "keywords": ["knowledge", "markdown", "vault", "context", "governance"],
+  "skills": [
+    "./skills/audit-knowledge-vault",
+    "./skills/init-knowledge-vault",
+    "./skills/manage-current-focus",
+    "./skills/use-knowledge-vault"
+  ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
           python-version: "3.11"
           enable-cache: true
       - run: uv sync --locked --all-groups
-      - run: uv run python scripts/check_release_version.py "$GITHUB_REF_NAME"
+      - run: >-
+          uv run python scripts/check_release_version.py "$GITHUB_REF_NAME"
+          --notes-output "dist/release-notes.md"
       - run: uv run python scripts/validate.py
       - name: Build versioned Claude Desktop skill
         run: >-
@@ -29,7 +31,7 @@ jobs:
           gh release create "$GITHUB_REF_NAME"
           "dist/knowledge-loom-claude-desktop-${GITHUB_REF_NAME}.zip#Claude Desktop skill"
           --verify-tag
-          --generate-notes
-          --title "Knowledge Loom ${GITHUB_REF_NAME}"
+          --notes-file dist/release-notes.md
+          --title "$GITHUB_REF_NAME"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## v0.1.1
+
+Initial public release.
+
+### Added
+
+- Four agent-neutral skills for initializing, auditing, using, and maintaining focus in governed
+  Markdown knowledge vaults.
+- One runtime-neutral protocol for vault selection, subject isolation, write authorization, and
+  lifecycle reporting.
+- Installation through `npx skills`, Claude Code and Codex plugins, and a Claude Desktop ZIP.
+- Deterministic Python commands for vault initialization, registration, resolution, and audit.
+- CI validation for generated skill packages, fictional fixtures, behavior cases, and distribution
+  artifacts.
+
+### Safety
+
+- Vaults, subjects, and focus views must be selected explicitly instead of inferred by topic.
+- Durable writes require the vault's declared authorization and lifecycle steps.
+- Missing information remains unknown, and one subject's facts never transfer to another.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,14 +32,15 @@ repository URL, and license. `tests/test_distribution.py` enforces those require
 
 ## Release
 
-1. Update the version in `pyproject.toml`, both plugin manifests, and the Claude marketplace.
-2. Run `uv run python scripts/validate.py --npx` and merge the change into `main`.
-3. Create and push an annotated tag that matches the package version:
+1. Add the release notes under `## vX.Y.Z` at the top of `CHANGELOG.md`.
+2. Update the version in `pyproject.toml`, both plugin manifests, and the Claude marketplace.
+3. Run `uv run python scripts/validate.py --npx` and merge the change into `main`.
+4. Create and push an annotated tag that matches the package version:
 
    ```bash
-   git tag -a v0.1.1 -m "Knowledge Loom v0.1.1"
+   git tag -a v0.1.1 -m "v0.1.1"
    git push origin v0.1.1
    ```
 
-The release workflow rejects a mismatched tag, runs the local validation suite, builds a versioned
-Claude Desktop ZIP, and publishes the GitHub Release with generated notes.
+The release workflow rejects a tag without matching package versions and changelog notes, runs the
+local validation suite, builds a versioned Claude Desktop ZIP, and publishes the curated notes.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ execution. A web chat without those capabilities cannot use a local vault direct
 <details open>
 <summary><strong>Codex and other supported agents: npx skills</strong></summary>
 
-Run one command. All four skills are selected automatically; choose only the agent or agents that
-should receive them:
+Run one command:
 
 ```bash
-npx skills add magickaichen/knowledge-loom --skill '*'
+npx skills@latest add magickaichen/knowledge-loom
 ```
+
+Select **Knowledge Loom** to install all four skills at once, or expand it to choose individual
+skills. Then choose the agent or agents that should receive them.
 
 The installer supports project and global installs. Each installed skill carries its own rules and
 runner, so it does not depend on the original repository checkout. Use `npx skills update` when you
@@ -218,9 +220,10 @@ for the contribution workflow.
 
 ## Releases
 
-Knowledge Loom uses semantic version tags such as `v0.1.1`. Pushing a matching tag runs the full
-local validation suite, checks that the tag matches every package manifest, and publishes a GitHub
-Release with generated notes and a versioned Claude Desktop ZIP.
+Knowledge Loom uses semantic version tags such as `v0.1.1`. Each version has a curated entry in the
+[changelog](CHANGELOG.md). Pushing a matching tag runs the full local validation suite, checks that
+the tag matches every package manifest and changelog entry, and publishes a GitHub Release with
+those notes and a versioned Claude Desktop ZIP.
 
 ## License
 

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -40,11 +40,38 @@ def validate_release_tag(tag: str) -> str:
     return version
 
 
+def changelog_notes(tag: str) -> str:
+    lines = (PACKAGE_ROOT / "CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+    heading = f"## {tag}"
+    try:
+        start = lines.index(heading) + 1
+    except ValueError as error:
+        raise ValueError(f"CHANGELOG.md has no {heading!r} section") from error
+
+    end = next(
+        (index for index in range(start, len(lines)) if lines[index].startswith("## ")),
+        len(lines),
+    )
+    notes = "\n".join(lines[start:end]).strip()
+    if not notes:
+        raise ValueError(f"CHANGELOG.md section {heading!r} is empty")
+    return f"{notes}\n"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("tag", help="release tag in vX.Y.Z form")
+    parser.add_argument(
+        "--notes-output",
+        type=Path,
+        help="write the matching CHANGELOG.md section to this file",
+    )
     args = parser.parse_args()
     version = validate_release_tag(args.tag)
+    notes = changelog_notes(args.tag)
+    if args.notes_output is not None:
+        args.notes_output.parent.mkdir(parents=True, exist_ok=True)
+        args.notes_output.write_text(notes, encoding="utf-8")
     print(f"PASS release tag v{version} matches every package manifest")
     return 0
 

--- a/scripts/test_npx_install.py
+++ b/scripts/test_npx_install.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 
 import json
 import os
+import pty
+import select
+import signal
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 SKILLS_CLI = os.environ.get("KNOWLEDGE_LOOM_SKILLS_CLI", "skills@1.5.22")
@@ -21,6 +25,7 @@ RUNNER_CHECK_ROOTS = (
     Path(".agents/skills"),
     Path(".claude/skills"),
 )
+INTERACTIVE_GROUP_PROMPT = "Select all 4 skills in Knowledge Loom."
 
 
 def run(command: list[str], *, cwd: Path, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
@@ -35,6 +40,53 @@ def run(command: list[str], *, cwd: Path, capture_output: bool = False) -> subpr
     )
 
 
+def terminate_child_process_group(child_pid: int) -> None:
+    try:
+        os.killpg(child_pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    os.waitpid(child_pid, 0)
+
+
+def assert_interactive_group(npx: str, package_root: Path, workspace: Path) -> None:
+    command = [npx, "--yes", SKILLS_CLI, "add", str(package_root)]
+    environment = {
+        key: value
+        for key, value in {**os.environ, "DISABLE_TELEMETRY": "1"}.items()
+        if not key.startswith("CODEX_")
+    }
+    child_pid, terminal = pty.fork()
+    if child_pid == 0:
+        os.chdir(workspace)
+        os.execvpe(command[0], command, environment)
+
+    output = bytearray()
+    deadline = time.monotonic() + 30
+    try:
+        while time.monotonic() < deadline:
+            readable, _, _ = select.select([terminal], [], [], 0.2)
+            if terminal not in readable:
+                continue
+            try:
+                chunk = os.read(terminal, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            output.extend(chunk)
+            if INTERACTIVE_GROUP_PROMPT.encode() in output:
+                terminate_child_process_group(child_pid)
+                return
+    finally:
+        os.close(terminal)
+
+    terminate_child_process_group(child_pid)
+    rendered = output.decode(errors="replace")
+    raise SystemExit(
+        f"bare npx installer omitted the Knowledge Loom all-skills group:\n{rendered}"
+    )
+
+
 def main() -> int:
     package_root = Path(__file__).resolve().parents[1]
     npx = shutil.which("npx")
@@ -45,6 +97,7 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="knowledge-loom-npx-") as temporary:
         workspace = Path(temporary)
+        assert_interactive_group(npx, package_root, workspace)
         listing = run(
             [npx, "--yes", SKILLS_CLI, "add", str(package_root), "--list"],
             cwd=workspace,
@@ -114,7 +167,8 @@ def main() -> int:
             raise SystemExit(f"installed skill mismatch: {sorted(names)}")
 
     print(
-        f"PASS npx {SKILLS_CLI} installed all four skills for every supported agent "
+        f"PASS npx {SKILLS_CLI} offered one interactive Knowledge Loom group and installed all "
+        f"four skills for every supported agent "
         f"across {len(installed_roots)} distinct roots; Codex and Claude Code runners passed"
     )
     return 0

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -7,6 +7,12 @@ from pathlib import Path
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY = "https://github.com/magickaichen/knowledge-loom"
 PLUGIN_NAME = "knowledge-loom"
+CLAUDE_PLUGIN_SKILLS = [
+    "./skills/audit-knowledge-vault",
+    "./skills/init-knowledge-vault",
+    "./skills/manage-current-focus",
+    "./skills/use-knowledge-vault",
+]
 
 
 def load_json(relative: str) -> dict[str, object]:
@@ -55,6 +61,12 @@ def test_claude_marketplace_points_to_the_root_plugin() -> None:
     assert entry["license"] == manifest["license"] == "MIT"
 
 
+def test_claude_plugin_groups_all_four_skills_for_interactive_installers() -> None:
+    manifest = load_json(".claude-plugin/plugin.json")
+
+    assert manifest["skills"] == CLAUDE_PLUGIN_SKILLS
+
+
 def test_readme_leads_with_the_user_outcome_and_names_supported_install_paths() -> None:
     readme = (PACKAGE_ROOT / "README.md").read_text(encoding="utf-8")
     opening = readme[:800]
@@ -66,8 +78,9 @@ def test_readme_leads_with_the_user_outcome_and_names_supported_install_paths() 
     assert readme.index("## Installation") < readme.index("## How it works")
     assert readme.index("## Set up your first vault") < readme.index("## How it works")
     assert "Installing through both `npx skills` and a plugin" in rendered_text
-    assert "npx skills add" in readme
-    assert "npx skills add magickaichen/knowledge-loom --skill '*'" in readme
+    assert "npx skills@latest add" in readme
+    assert "npx skills@latest add magickaichen/knowledge-loom" in readme
+    assert "--skill '*'" not in readme
     assert "other supported agents" in readme
     assert "codex plugin marketplace add" in readme
     assert "claude plugin marketplace add" in readme

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -13,9 +13,9 @@ def package_version() -> str:
     return project["version"]
 
 
-def run_checker(tag: str) -> subprocess.CompletedProcess[str]:
+def run_checker(tag: str, *extra_arguments: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [sys.executable, "scripts/check_release_version.py", tag],
+        [sys.executable, "scripts/check_release_version.py", tag, *extra_arguments],
         cwd=PACKAGE_ROOT,
         text=True,
         capture_output=True,
@@ -38,6 +38,17 @@ def test_release_version_checker_rejects_a_mismatched_tag() -> None:
     assert "does not match package version" in result.stderr
 
 
+def test_release_version_checker_writes_curated_changelog_notes(tmp_path: Path) -> None:
+    version = package_version()
+    notes = tmp_path / "release-notes.md"
+
+    result = run_checker(f"v{version}", "--notes-output", str(notes))
+
+    assert result.returncode == 0
+    assert notes.read_text(encoding="utf-8").startswith("Initial public release.")
+    assert "Full Changelog" not in notes.read_text(encoding="utf-8")
+
+
 def test_release_workflow_validates_and_publishes_the_desktop_zip() -> None:
     workflow = (PACKAGE_ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
 
@@ -47,4 +58,7 @@ def test_release_workflow_validates_and_publishes_the_desktop_zip() -> None:
     assert "knowledge-loom-claude-desktop-${GITHUB_REF_NAME}.zip" in workflow
     assert "gh release create" in workflow
     assert "--verify-tag" in workflow
-    assert "--generate-notes" in workflow
+    assert '--notes-output "dist/release-notes.md"' in workflow
+    assert "--notes-file dist/release-notes.md" in workflow
+    assert '--title "$GITHUB_REF_NAME"' in workflow
+    assert "--generate-notes" not in workflow


### PR DESCRIPTION
## Summary

- add a top-level Knowledge Loom selector for all four skills in the bare npx installer
- document the bare npx command and lock the interaction down with a real PTY regression
- publish curated CHANGELOG sections as release bodies with tag-only titles

## Validation

- uv run python scripts/validate.py --npx
- 51 tests passed
- real interactive skills@1.5.22 group check passed
- Standards review: no findings
- Spec review: interactive regression finding resolved; live v0.1.1 update follows merge