### PR TITLE
Add project-aware vault selection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "knowledge-loom",
       "source": "./",
       "description": "Keep Codex and Claude inside clear boundaries when they read or update local Markdown notes.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Mike Xiao",
         "url": "https://github.com/magickaichen"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.3.0
+
+Projects can now select their registered vault automatically.
+
+### Added
+
+- Added preview-first `associate` CLI support for binding a canonical project directory to a
+  registered vault ID.
+- Added deterministic project-aware resolution: explicit selectors still win, a vault's own
+  nearest contract stays authoritative, and the nearest nested project association wins before the
+  single-vault fallback.
+- Added direct invocation examples for standalone and plugin installs in Codex and Claude Code.
+
+### Safety
+
+- Kept project associations in the local user registry instead of modifying project repositories.
+- Invalid or conflicting associations fail closed and do not expand a vault's declared authority.
+
 ## v0.2.0
 
 The deterministic tooling now runs on JavaScript instead of Python.

--- a/README.md
+++ b/README.md
@@ -70,13 +70,54 @@ Start a new Codex task after installation.
 Private repositories work when Git, GitHub CLI, or SSH credentials can read them. A public
 repository can be installed without GitHub authentication.
 
+## Invoke a skill directly
+
+Skills also load automatically when a request matches, but naming one is useful when you want a
+specific workflow. Invocation syntax depends on the agent and installation route:
+
+| Installed with | Codex | Claude Code |
+|---|---|---|
+| `npx skills` | `$use-knowledge-vault` | `/use-knowledge-vault` |
+| plugin | `$knowledge-loom:use-knowledge-vault` | `/knowledge-loom:use-knowledge-vault` |
+
+The same naming rule applies to `init-knowledge-vault`, `audit-knowledge-vault`, and
+`manage-current-focus`. These go in the agent prompt box, not in a shell. See the official
+[Codex skill guide](https://learn.chatgpt.com/docs/build-skills) and
+[Claude Code skill guide](https://code.claude.com/docs/en/slash-commands) for each runtime's
+invocation model.
+
+For example, with an `npx skills` install:
+
+Codex:
+
+```text
+$use-knowledge-vault Find the decision context relevant to this project, then answer my question.
+```
+
+Claude Code:
+
+```text
+/use-knowledge-vault Find the decision context relevant to this project, then answer my question.
+```
+
 ## Set up your first vault
 
 ### 1. Preview
 
-Open your Markdown folder in your agent and ask:
+Open your Markdown folder in your agent and paste the matching prompt. These examples assume an
+`npx skills` install; add the `knowledge-loom:` namespace shown above for a plugin install.
 
-> Initialize this folder as a knowledge vault. Show me the preview and do not write anything yet.
+Codex:
+
+```text
+$init-knowledge-vault Initialize this folder as a knowledge vault. Show me the preview and do not write anything yet.
+```
+
+Claude Code:
+
+```text
+/init-knowledge-vault Initialize this folder as a knowledge vault. Show me the preview and do not write anything yet.
+```
 
 Knowledge Loom proposes a vault ID, subject, write policy, and files. It stops at the preview.
 
@@ -87,15 +128,65 @@ permission to read your notes does not become permission to save every conversat
 
 ### 3. Use it
 
-Try any of these:
+Try any of these in Codex after setup. In Claude Code, replace `$` with `/`; add the plugin
+namespace when applicable.
 
-> Audit this knowledge vault without changing it.
+```text
+$audit-knowledge-vault Audit this knowledge vault without changing it.
+```
 
-> Use this vault to find the context relevant to my question.
+```text
+$use-knowledge-vault Use this vault to find the context relevant to my question.
+```
 
-> Remember this decision in the vault.
+```text
+$use-knowledge-vault Remember this decision in the vault.
+```
 
 The last request may need confirmation, depending on the vault's write policy.
+
+## Link a project to a vault once
+
+When you have several vaults, bind each project folder to its usual vault once. The skill can then
+resolve that vault from the active project directory, so later prompts do not need a vault ID.
+
+First make sure the vault is registered. Then open the project folder in Codex or Claude Code and
+preview the association:
+
+```text
+$init-knowledge-vault Associate this project with the registered vault example. Preview only.
+```
+
+In Claude Code, use `/init-knowledge-vault`; use the namespaced form for a plugin install. Approve
+the exact preview to save the association. After that, a prompt such as this resolves `example`
+automatically from anywhere inside the project:
+
+```text
+$use-knowledge-vault What did we previously decide about this project's architecture?
+```
+
+Knowledge Loom keeps vault IDs and project associations in the local user registry:
+
+```text
+~/.config/knowledge-vault/registry.yaml
+```
+
+Set `KNOWLEDGE_VAULT_REGISTRY` to use another registry file. The registry has this shape:
+
+```yaml
+schema_version: 1
+vaults:
+  example:
+    path: /Users/you/Documents/example-vault
+projects:
+  /Users/you/code/example-project:
+    vault_id: example
+```
+
+The registry stays outside both repositories. An explicit ID or path still wins. Inside a vault,
+the nearest `KNOWLEDGE_VAULT.md` wins. Otherwise, the nearest project association wins; nested
+projects can deliberately override a parent association. A broken association stops resolution
+instead of silently choosing another vault.
 
 ## Why this exists
 
@@ -186,8 +277,17 @@ npm run cli -- register example ~/Documents/example-vault
 npm run cli -- register example ~/Documents/example-vault --apply
 ```
 
-When more than one vault is registered, an unscoped request fails instead of guessing. Select a
-vault by ID or path:
+Associate a project with the registered vault. Both registration and association preview by
+default:
+
+```bash
+npm run cli -- associate example ~/code/example-project
+npm run cli -- associate example ~/code/example-project --apply
+```
+
+Use `--replace` only when deliberately changing an existing project binding. When no contract or
+project association applies and more than one vault is registered, an unscoped request fails
+instead of guessing. Select a vault by ID or path:
 
 ```bash
 npm run cli -- resolve example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-loom",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-loom",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Agent-neutral governance and skills for local Markdown knowledge vaults",
   "type": "module",

--- a/references/protocol.md
+++ b/references/protocol.md
@@ -25,11 +25,14 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise consult the registry.
-4. If the registry contains exactly one valid vault, use it.
-5. If multiple candidates remain, ask for a selection.
+3. Otherwise use the nearest project association in the registry.
+4. Otherwise, if the registry contains exactly one valid vault, use it.
+5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
+   and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
+Project associations select a registered vault; they do not extend that vault's read, write, sync,
+or backup authority.
 
 ## Retrieve
 

--- a/skills/audit-knowledge-vault/SKILL.md
+++ b/skills/audit-knowledge-vault/SKILL.md
@@ -13,8 +13,10 @@ destinations.
 
 Resolve this `SKILL.md` to its canonical path, following symlinks. Set `<skill-root>` to the
 directory containing that canonical file. Read `<skill-root>/references/contract-schema.md` and
-`<skill-root>/references/protocol.md` completely. Resolve one vault through **Select one vault**;
-ambiguity ends the audit before any vault is inspected.
+`<skill-root>/references/protocol.md` completely. From the active project directory, inspect
+`node "<skill-root>/scripts/knowledge-loom.mjs" resolve --help`, then run `resolve`, appending a
+selector only when one was supplied. Treat its returned canonical root as the only selected vault;
+any resolution error ends the audit before a vault is inspected.
 
 ## Run deterministic audit
 

--- a/skills/audit-knowledge-vault/references/protocol.md
+++ b/skills/audit-knowledge-vault/references/protocol.md
@@ -25,11 +25,14 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise consult the registry.
-4. If the registry contains exactly one valid vault, use it.
-5. If multiple candidates remain, ask for a selection.
+3. Otherwise use the nearest project association in the registry.
+4. Otherwise, if the registry contains exactly one valid vault, use it.
+5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
+   and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
+Project associations select a registered vault; they do not extend that vault's read, write, sync,
+or backup authority.
 
 ## Retrieve
 

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7976,19 +7976,6 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
-  if (data.projects !== void 0) {
-    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
-      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
-    }
-    for (const [projectRoot, record] of Object.entries(data.projects)) {
-      if (!path5.isAbsolute(expandHome(projectRoot))) {
-        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
-      }
-      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
-      }
-    }
-  }
   return data;
 }
 function renderRegistry(data) {
@@ -8045,15 +8032,28 @@ function registeredVault(vaultId, registry) {
   if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
     throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
   }
-  return loadVault(record.path);
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
 }
 function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
   for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
-    const root = canonicalPath(configuredRoot);
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
+    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
     matches.push({ record, distance });
@@ -8127,9 +8127,19 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
+  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   data.projects ??= {};
   for (const [configuredRoot, record] of Object.entries(data.projects)) {
-    if (canonicalPath(configuredRoot) !== root) continue;
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
+    }
+    if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7976,6 +7976,19 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
+  if (data.projects !== void 0) {
+    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
+      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
+    }
+    for (const [projectRoot, record] of Object.entries(data.projects)) {
+      if (!path5.isAbsolute(expandHome(projectRoot))) {
+        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
+      }
+      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
+      }
+    }
+  }
   return data;
 }
 function renderRegistry(data) {
@@ -8026,20 +8039,51 @@ function registeredCandidates(registry) {
   }
   return candidates;
 }
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  return loadVault(record.path);
+}
+function projectAssociation(start, registry) {
+  let current = canonicalPath(start);
+  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+    const root = canonicalPath(configuredRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path5.relative(root, current);
+    const distance = relative ? relative.split(path5.sep).length : 0;
+    matches.push({ record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
 function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  const registry = loadRegistry(registryPath);
   if (selector !== null && selector !== void 0) {
     const selectorPath = path5.resolve(expandHome(String(selector)));
     if (fs6.existsSync(selectorPath)) {
       const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
       return loadVault(root);
     }
-    const record = registry.vaults[String(selector)];
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
     if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
     throw new ResolutionError(`unknown vault selector: ${selector}`);
   }
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
   const candidates = registeredCandidates(registry);
   if (candidates.length === 1) return loadVault(candidates[0][1]);
   if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
@@ -8069,20 +8113,52 @@ function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), ap
   }
   return [resolvedRegistryPath, rendered];
 }
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs6.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+    if (canonicalPath(configuredRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete data.projects[configuredRoot];
+  }
+  data.projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
 
 // src/knowledge-loom/cli.mjs
-var HELP = `usage: knowledge-loom {audit,resolve,register,init} ...
+var HELP = `usage: knowledge-loom {audit,resolve,register,associate,init} ...
 
 commands:
   audit       run a read-only vault audit
   resolve     resolve one vault deterministically
   register    preview or register a vault
+  associate   preview or associate a project with a registered vault
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
   register: "usage: knowledge-loom register vault_id path [--registry PATH] [--apply]\n",
+  associate: "usage: knowledge-loom associate vault_id project_path [--registry PATH] [--replace] [--apply]\n",
   init: "usage: knowledge-loom init path --vault-id ID --title TITLE --subject SUBJECT [--subject SUBJECT ...] [--write-policy POLICY] [--current-state-policy POLICY] [--history TYPE] [--adopt] [--apply]\n"
 };
 function parseArguments(arguments_) {
@@ -8092,7 +8168,7 @@ function parseArguments(arguments_) {
   if (!Object.hasOwn(COMMAND_HELP, command)) throw new Error(`unknown command: ${command}`);
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) return { help: true, command };
   const options = { command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : []);
+  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
   if (command === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
@@ -8154,6 +8230,20 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
       if (options.apply) stdout.write(`registered ${options.positional[0]} in ${registryPath}
 `);
       else stdout.write(`DRY RUN would write ${registryPath}
+
+${rendered2}`);
+      return 0;
+    }
+    if (options.command === "associate") {
+      requirePositionals(options, 2, COMMAND_HELP.associate);
+      const [registryPath, rendered2, projectRoot] = associateProject(options.positional[0], options.positional[1], {
+        registryPath: options.registry,
+        apply: options.apply === true,
+        replace: options.replace === true
+      });
+      if (options.apply) stdout.write(`associated ${projectRoot} with ${options.positional[0]} in ${registryPath}
+`);
+      else stdout.write(`DRY RUN would associate ${projectRoot} with ${options.positional[0]} in ${registryPath}
 
 ${rendered2}`);
       return 0;

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8038,30 +8038,37 @@ function registeredVault(vaultId, registry) {
   }
   return vault;
 }
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
     throw new ResolutionError("registry projects must be a mapping");
   }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
-  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+  for (const [configuredRoot, record] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) continue;
     const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
-    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ record, distance });
+    matches.push({ configuredRoot, record, distance });
   }
   if (!matches.length) return null;
   const nearestDistance = Math.min(...matches.map((match) => match.distance));
   const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
   if (vaultIds.size > 1) {
     throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
   }
@@ -8127,25 +8134,21 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
-  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
   data.projects ??= {};
-  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) {
       throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
     }
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
-    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
     if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }
-    if (configuredRoot !== root) delete data.projects[configuredRoot];
+    if (configuredRoot !== root) delete projects[configuredRoot];
   }
-  data.projects[root] = { vault_id: normalizedVaultId };
+  projects[root] = { vault_id: normalizedVaultId };
   const rendered = renderRegistry(data);
   if (apply) {
     const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;

--- a/skills/init-knowledge-vault/SKILL.md
+++ b/skills/init-knowledge-vault/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: init-knowledge-vault
-description: Initialize a governed Markdown vault, conservatively adopt an existing one, or register a governed vault. Use when the user wants a vault contract, deterministic registration, or protocol adoption without bulk migration.
+description: Initialize a governed Markdown vault, conservatively adopt an existing one, register it, or associate a project with it. Use for vault contracts, deterministic registration or project linking, and protocol adoption without bulk migration.
 compatibility: Requires Node.js 20+ and local file/command access.
 ---
 
@@ -64,6 +64,14 @@ When registration is requested, inspect
 `node "<skill-root>/scripts/knowledge-loom.mjs" register --help`, preview the resolved ID and
 canonical path, then apply the same registry change only after confirmation. Preserve every
 existing registry entry; an ID already bound to another path is a conflict, not an update.
+
+## Associate a project
+
+When project association is requested, inspect
+`node "<skill-root>/scripts/knowledge-loom.mjs" associate --help`. Resolve the registered vault ID
+and canonical project directory, then run `associate` without `--apply`. Apply the same preview only
+after confirmation. Preserve other project associations; replace an existing binding only when the
+user explicitly approves `--replace`.
 
 ## Validate and report
 

--- a/skills/init-knowledge-vault/agents/openai.yaml
+++ b/skills/init-knowledge-vault/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Initialize Knowledge Vault"
-  short_description: "Create or adopt a governed Markdown vault"
-  default_prompt: "Use $init-knowledge-vault to create or safely adopt this Markdown vault."
+  short_description: "Create, register, or link a Markdown vault"
+  default_prompt: "Use $init-knowledge-vault to create, register, or link this governed Markdown vault."

--- a/skills/init-knowledge-vault/references/protocol.md
+++ b/skills/init-knowledge-vault/references/protocol.md
@@ -25,11 +25,14 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise consult the registry.
-4. If the registry contains exactly one valid vault, use it.
-5. If multiple candidates remain, ask for a selection.
+3. Otherwise use the nearest project association in the registry.
+4. Otherwise, if the registry contains exactly one valid vault, use it.
+5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
+   and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
+Project associations select a registered vault; they do not extend that vault's read, write, sync,
+or backup authority.
 
 ## Retrieve
 

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7976,19 +7976,6 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
-  if (data.projects !== void 0) {
-    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
-      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
-    }
-    for (const [projectRoot, record] of Object.entries(data.projects)) {
-      if (!path5.isAbsolute(expandHome(projectRoot))) {
-        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
-      }
-      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
-      }
-    }
-  }
   return data;
 }
 function renderRegistry(data) {
@@ -8045,15 +8032,28 @@ function registeredVault(vaultId, registry) {
   if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
     throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
   }
-  return loadVault(record.path);
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
 }
 function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
   for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
-    const root = canonicalPath(configuredRoot);
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
+    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
     matches.push({ record, distance });
@@ -8127,9 +8127,19 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
+  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   data.projects ??= {};
   for (const [configuredRoot, record] of Object.entries(data.projects)) {
-    if (canonicalPath(configuredRoot) !== root) continue;
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
+    }
+    if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7976,6 +7976,19 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
+  if (data.projects !== void 0) {
+    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
+      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
+    }
+    for (const [projectRoot, record] of Object.entries(data.projects)) {
+      if (!path5.isAbsolute(expandHome(projectRoot))) {
+        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
+      }
+      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
+      }
+    }
+  }
   return data;
 }
 function renderRegistry(data) {
@@ -8026,20 +8039,51 @@ function registeredCandidates(registry) {
   }
   return candidates;
 }
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  return loadVault(record.path);
+}
+function projectAssociation(start, registry) {
+  let current = canonicalPath(start);
+  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+    const root = canonicalPath(configuredRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path5.relative(root, current);
+    const distance = relative ? relative.split(path5.sep).length : 0;
+    matches.push({ record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
 function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  const registry = loadRegistry(registryPath);
   if (selector !== null && selector !== void 0) {
     const selectorPath = path5.resolve(expandHome(String(selector)));
     if (fs6.existsSync(selectorPath)) {
       const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
       return loadVault(root);
     }
-    const record = registry.vaults[String(selector)];
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
     if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
     throw new ResolutionError(`unknown vault selector: ${selector}`);
   }
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
   const candidates = registeredCandidates(registry);
   if (candidates.length === 1) return loadVault(candidates[0][1]);
   if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
@@ -8069,20 +8113,52 @@ function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), ap
   }
   return [resolvedRegistryPath, rendered];
 }
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs6.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+    if (canonicalPath(configuredRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete data.projects[configuredRoot];
+  }
+  data.projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
 
 // src/knowledge-loom/cli.mjs
-var HELP = `usage: knowledge-loom {audit,resolve,register,init} ...
+var HELP = `usage: knowledge-loom {audit,resolve,register,associate,init} ...
 
 commands:
   audit       run a read-only vault audit
   resolve     resolve one vault deterministically
   register    preview or register a vault
+  associate   preview or associate a project with a registered vault
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
   register: "usage: knowledge-loom register vault_id path [--registry PATH] [--apply]\n",
+  associate: "usage: knowledge-loom associate vault_id project_path [--registry PATH] [--replace] [--apply]\n",
   init: "usage: knowledge-loom init path --vault-id ID --title TITLE --subject SUBJECT [--subject SUBJECT ...] [--write-policy POLICY] [--current-state-policy POLICY] [--history TYPE] [--adopt] [--apply]\n"
 };
 function parseArguments(arguments_) {
@@ -8092,7 +8168,7 @@ function parseArguments(arguments_) {
   if (!Object.hasOwn(COMMAND_HELP, command)) throw new Error(`unknown command: ${command}`);
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) return { help: true, command };
   const options = { command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : []);
+  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
   if (command === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
@@ -8154,6 +8230,20 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
       if (options.apply) stdout.write(`registered ${options.positional[0]} in ${registryPath}
 `);
       else stdout.write(`DRY RUN would write ${registryPath}
+
+${rendered2}`);
+      return 0;
+    }
+    if (options.command === "associate") {
+      requirePositionals(options, 2, COMMAND_HELP.associate);
+      const [registryPath, rendered2, projectRoot] = associateProject(options.positional[0], options.positional[1], {
+        registryPath: options.registry,
+        apply: options.apply === true,
+        replace: options.replace === true
+      });
+      if (options.apply) stdout.write(`associated ${projectRoot} with ${options.positional[0]} in ${registryPath}
+`);
+      else stdout.write(`DRY RUN would associate ${projectRoot} with ${options.positional[0]} in ${registryPath}
 
 ${rendered2}`);
       return 0;

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8038,30 +8038,37 @@ function registeredVault(vaultId, registry) {
   }
   return vault;
 }
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
     throw new ResolutionError("registry projects must be a mapping");
   }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
-  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+  for (const [configuredRoot, record] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) continue;
     const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
-    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ record, distance });
+    matches.push({ configuredRoot, record, distance });
   }
   if (!matches.length) return null;
   const nearestDistance = Math.min(...matches.map((match) => match.distance));
   const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
   if (vaultIds.size > 1) {
     throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
   }
@@ -8127,25 +8134,21 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
-  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
   data.projects ??= {};
-  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) {
       throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
     }
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
-    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
     if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }
-    if (configuredRoot !== root) delete data.projects[configuredRoot];
+    if (configuredRoot !== root) delete projects[configuredRoot];
   }
-  data.projects[root] = { vault_id: normalizedVaultId };
+  projects[root] = { vault_id: normalizedVaultId };
   const rendered = renderRegistry(data);
   if (apply) {
     const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;

--- a/skills/manage-current-focus/SKILL.md
+++ b/skills/manage-current-focus/SKILL.md
@@ -12,9 +12,12 @@ parallel work.
 ## Load authority and resolve one view
 
 Resolve this `SKILL.md` to its canonical path, following symlinks. Set `<skill-root>` to the
-directory containing that canonical file. Read `<skill-root>/references/protocol.md` completely,
-then resolve one vault through **Select one vault**. Read its `KNOWLEDGE_VAULT.md`, the selected
-focus view, and only the linked current notes needed for the decision.
+directory containing that canonical file. Read `<skill-root>/references/protocol.md` completely.
+From the active project directory, inspect
+`node "<skill-root>/scripts/knowledge-loom.mjs" resolve --help`, then run `resolve`, appending a
+selector only when one was supplied. Treat its returned canonical root as the only selected vault,
+then read its `KNOWLEDGE_VAULT.md`, the selected focus view, and only the linked current notes needed
+for the decision. Stop vault work on any resolution error.
 
 - Use an explicitly named view when provided.
 - Use the only configured view when exactly one exists.

--- a/skills/manage-current-focus/references/protocol.md
+++ b/skills/manage-current-focus/references/protocol.md
@@ -25,11 +25,14 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise consult the registry.
-4. If the registry contains exactly one valid vault, use it.
-5. If multiple candidates remain, ask for a selection.
+3. Otherwise use the nearest project association in the registry.
+4. Otherwise, if the registry contains exactly one valid vault, use it.
+5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
+   and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
+Project associations select a registered vault; they do not extend that vault's read, write, sync,
+or backup authority.
 
 ## Retrieve
 

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7976,19 +7976,6 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
-  if (data.projects !== void 0) {
-    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
-      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
-    }
-    for (const [projectRoot, record] of Object.entries(data.projects)) {
-      if (!path5.isAbsolute(expandHome(projectRoot))) {
-        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
-      }
-      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
-      }
-    }
-  }
   return data;
 }
 function renderRegistry(data) {
@@ -8045,15 +8032,28 @@ function registeredVault(vaultId, registry) {
   if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
     throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
   }
-  return loadVault(record.path);
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
 }
 function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
   for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
-    const root = canonicalPath(configuredRoot);
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
+    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
     matches.push({ record, distance });
@@ -8127,9 +8127,19 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
+  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   data.projects ??= {};
   for (const [configuredRoot, record] of Object.entries(data.projects)) {
-    if (canonicalPath(configuredRoot) !== root) continue;
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
+    }
+    if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7976,6 +7976,19 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
+  if (data.projects !== void 0) {
+    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
+      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
+    }
+    for (const [projectRoot, record] of Object.entries(data.projects)) {
+      if (!path5.isAbsolute(expandHome(projectRoot))) {
+        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
+      }
+      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
+      }
+    }
+  }
   return data;
 }
 function renderRegistry(data) {
@@ -8026,20 +8039,51 @@ function registeredCandidates(registry) {
   }
   return candidates;
 }
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  return loadVault(record.path);
+}
+function projectAssociation(start, registry) {
+  let current = canonicalPath(start);
+  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+    const root = canonicalPath(configuredRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path5.relative(root, current);
+    const distance = relative ? relative.split(path5.sep).length : 0;
+    matches.push({ record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
 function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  const registry = loadRegistry(registryPath);
   if (selector !== null && selector !== void 0) {
     const selectorPath = path5.resolve(expandHome(String(selector)));
     if (fs6.existsSync(selectorPath)) {
       const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
       return loadVault(root);
     }
-    const record = registry.vaults[String(selector)];
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
     if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
     throw new ResolutionError(`unknown vault selector: ${selector}`);
   }
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
   const candidates = registeredCandidates(registry);
   if (candidates.length === 1) return loadVault(candidates[0][1]);
   if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
@@ -8069,20 +8113,52 @@ function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), ap
   }
   return [resolvedRegistryPath, rendered];
 }
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs6.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+    if (canonicalPath(configuredRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete data.projects[configuredRoot];
+  }
+  data.projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
 
 // src/knowledge-loom/cli.mjs
-var HELP = `usage: knowledge-loom {audit,resolve,register,init} ...
+var HELP = `usage: knowledge-loom {audit,resolve,register,associate,init} ...
 
 commands:
   audit       run a read-only vault audit
   resolve     resolve one vault deterministically
   register    preview or register a vault
+  associate   preview or associate a project with a registered vault
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
   register: "usage: knowledge-loom register vault_id path [--registry PATH] [--apply]\n",
+  associate: "usage: knowledge-loom associate vault_id project_path [--registry PATH] [--replace] [--apply]\n",
   init: "usage: knowledge-loom init path --vault-id ID --title TITLE --subject SUBJECT [--subject SUBJECT ...] [--write-policy POLICY] [--current-state-policy POLICY] [--history TYPE] [--adopt] [--apply]\n"
 };
 function parseArguments(arguments_) {
@@ -8092,7 +8168,7 @@ function parseArguments(arguments_) {
   if (!Object.hasOwn(COMMAND_HELP, command)) throw new Error(`unknown command: ${command}`);
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) return { help: true, command };
   const options = { command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : []);
+  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
   if (command === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
@@ -8154,6 +8230,20 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
       if (options.apply) stdout.write(`registered ${options.positional[0]} in ${registryPath}
 `);
       else stdout.write(`DRY RUN would write ${registryPath}
+
+${rendered2}`);
+      return 0;
+    }
+    if (options.command === "associate") {
+      requirePositionals(options, 2, COMMAND_HELP.associate);
+      const [registryPath, rendered2, projectRoot] = associateProject(options.positional[0], options.positional[1], {
+        registryPath: options.registry,
+        apply: options.apply === true,
+        replace: options.replace === true
+      });
+      if (options.apply) stdout.write(`associated ${projectRoot} with ${options.positional[0]} in ${registryPath}
+`);
+      else stdout.write(`DRY RUN would associate ${projectRoot} with ${options.positional[0]} in ${registryPath}
 
 ${rendered2}`);
       return 0;

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -8038,30 +8038,37 @@ function registeredVault(vaultId, registry) {
   }
   return vault;
 }
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
     throw new ResolutionError("registry projects must be a mapping");
   }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
-  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+  for (const [configuredRoot, record] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) continue;
     const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
-    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ record, distance });
+    matches.push({ configuredRoot, record, distance });
   }
   if (!matches.length) return null;
   const nearestDistance = Math.min(...matches.map((match) => match.distance));
   const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
   if (vaultIds.size > 1) {
     throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
   }
@@ -8127,25 +8134,21 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
-  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
   data.projects ??= {};
-  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) {
       throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
     }
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
-    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
     if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }
-    if (configuredRoot !== root) delete data.projects[configuredRoot];
+    if (configuredRoot !== root) delete projects[configuredRoot];
   }
-  data.projects[root] = { vault_id: normalizedVaultId };
+  projects[root] = { vault_id: normalizedVaultId };
   const rendered = renderRegistry(data);
   if (apply) {
     const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;

--- a/skills/use-knowledge-vault/SKILL.md
+++ b/skills/use-knowledge-vault/SKILL.md
@@ -18,8 +18,11 @@ policy, lifecycle, and failure behavior.
 
 ## Run the loop
 
-1. Complete **Select one vault** from the protocol. Continue only with one resolved contract; on
-   ambiguity, pause vault work and request a selection.
+1. From the active project directory, inspect
+   `node "<skill-root>/scripts/knowledge-loom.mjs" resolve --help`, then run `resolve`. Append a
+   selector only when the user or invoking wrapper supplied one. Treat the returned canonical root
+   as the only selected vault, read its contract completely, and pause vault work on any resolution
+   error.
 2. Complete **Retrieve**, then finish the primary task using only context that materially affects
    its result.
 3. Evaluate **Write authorization** after the primary task. Enter **Distill** only when the selected

--- a/skills/use-knowledge-vault/references/protocol.md
+++ b/skills/use-knowledge-vault/references/protocol.md
@@ -25,11 +25,14 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise consult the registry.
-4. If the registry contains exactly one valid vault, use it.
-5. If multiple candidates remain, ask for a selection.
+3. Otherwise use the nearest project association in the registry.
+4. Otherwise, if the registry contains exactly one valid vault, use it.
+5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
+   and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
+Project associations select a registered vault; they do not extend that vault's read, write, sync,
+or backup authority.
 
 ## Retrieve
 

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7976,19 +7976,6 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
-  if (data.projects !== void 0) {
-    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
-      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
-    }
-    for (const [projectRoot, record] of Object.entries(data.projects)) {
-      if (!path5.isAbsolute(expandHome(projectRoot))) {
-        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
-      }
-      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
-      }
-    }
-  }
   return data;
 }
 function renderRegistry(data) {
@@ -8045,15 +8032,28 @@ function registeredVault(vaultId, registry) {
   if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
     throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
   }
-  return loadVault(record.path);
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
 }
 function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
   for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
-    const root = canonicalPath(configuredRoot);
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
+    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
     matches.push({ record, distance });
@@ -8127,9 +8127,19 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
+  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   data.projects ??= {};
   for (const [configuredRoot, record] of Object.entries(data.projects)) {
-    if (canonicalPath(configuredRoot) !== root) continue;
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path5.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
+    }
+    if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7976,6 +7976,19 @@ function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
+  if (data.projects !== void 0) {
+    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
+      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
+    }
+    for (const [projectRoot, record] of Object.entries(data.projects)) {
+      if (!path5.isAbsolute(expandHome(projectRoot))) {
+        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
+      }
+      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
+      }
+    }
+  }
   return data;
 }
 function renderRegistry(data) {
@@ -8026,20 +8039,51 @@ function registeredCandidates(registry) {
   }
   return candidates;
 }
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  return loadVault(record.path);
+}
+function projectAssociation(start, registry) {
+  let current = canonicalPath(start);
+  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+    const root = canonicalPath(configuredRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path5.relative(root, current);
+    const distance = relative ? relative.split(path5.sep).length : 0;
+    matches.push({ record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
 function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  const registry = loadRegistry(registryPath);
   if (selector !== null && selector !== void 0) {
     const selectorPath = path5.resolve(expandHome(String(selector)));
     if (fs6.existsSync(selectorPath)) {
       const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
       return loadVault(root);
     }
-    const record = registry.vaults[String(selector)];
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
     if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
     throw new ResolutionError(`unknown vault selector: ${selector}`);
   }
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
   const candidates = registeredCandidates(registry);
   if (candidates.length === 1) return loadVault(candidates[0][1]);
   if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
@@ -8069,20 +8113,52 @@ function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), ap
   }
   return [resolvedRegistryPath, rendered];
 }
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs6.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+    if (canonicalPath(configuredRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete data.projects[configuredRoot];
+  }
+  data.projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
 
 // src/knowledge-loom/cli.mjs
-var HELP = `usage: knowledge-loom {audit,resolve,register,init} ...
+var HELP = `usage: knowledge-loom {audit,resolve,register,associate,init} ...
 
 commands:
   audit       run a read-only vault audit
   resolve     resolve one vault deterministically
   register    preview or register a vault
+  associate   preview or associate a project with a registered vault
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
   register: "usage: knowledge-loom register vault_id path [--registry PATH] [--apply]\n",
+  associate: "usage: knowledge-loom associate vault_id project_path [--registry PATH] [--replace] [--apply]\n",
   init: "usage: knowledge-loom init path --vault-id ID --title TITLE --subject SUBJECT [--subject SUBJECT ...] [--write-policy POLICY] [--current-state-policy POLICY] [--history TYPE] [--adopt] [--apply]\n"
 };
 function parseArguments(arguments_) {
@@ -8092,7 +8168,7 @@ function parseArguments(arguments_) {
   if (!Object.hasOwn(COMMAND_HELP, command)) throw new Error(`unknown command: ${command}`);
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) return { help: true, command };
   const options = { command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : []);
+  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
   if (command === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
@@ -8154,6 +8230,20 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
       if (options.apply) stdout.write(`registered ${options.positional[0]} in ${registryPath}
 `);
       else stdout.write(`DRY RUN would write ${registryPath}
+
+${rendered2}`);
+      return 0;
+    }
+    if (options.command === "associate") {
+      requirePositionals(options, 2, COMMAND_HELP.associate);
+      const [registryPath, rendered2, projectRoot] = associateProject(options.positional[0], options.positional[1], {
+        registryPath: options.registry,
+        apply: options.apply === true,
+        replace: options.replace === true
+      });
+      if (options.apply) stdout.write(`associated ${projectRoot} with ${options.positional[0]} in ${registryPath}
+`);
+      else stdout.write(`DRY RUN would associate ${projectRoot} with ${options.positional[0]} in ${registryPath}
 
 ${rendered2}`);
       return 0;

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8038,30 +8038,37 @@ function registeredVault(vaultId, registry) {
   }
   return vault;
 }
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
     throw new ResolutionError("registry projects must be a mapping");
   }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
   let current = canonicalPath(start);
   if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
   const matches = [];
-  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+  for (const [configuredRoot, record] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) continue;
     const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
-    }
     const relative = path5.relative(root, current);
     const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ record, distance });
+    matches.push({ configuredRoot, record, distance });
   }
   if (!matches.length) return null;
   const nearestDistance = Math.min(...matches.map((match) => match.distance));
   const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
   if (vaultIds.size > 1) {
     throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
   }
@@ -8127,25 +8134,21 @@ function associateProject(vaultId, projectRoot, {
   if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
-  if (data.projects !== void 0 && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
   data.projects ??= {};
-  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path5.isAbsolute(expandedRoot)) {
       throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
     }
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
-    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
     if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }
-    if (configuredRoot !== root) delete data.projects[configuredRoot];
+    if (configuredRoot !== root) delete projects[configuredRoot];
   }
-  data.projects[root] = { vault_id: normalizedVaultId };
+  projects[root] = { vault_id: normalizedVaultId };
   const rendered = renderRegistry(data);
   if (apply) {
     const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;

--- a/src/knowledge-loom/cli.mjs
+++ b/src/knowledge-loom/cli.mjs
@@ -4,14 +4,15 @@ import { auditVault } from "./audit.mjs";
 import { validateContractData } from "./contract.mjs";
 import { buildContract, initializeVault } from "./initializer.mjs";
 import { expandHome } from "./pathing.mjs";
-import { registerVault, resolveVault } from "./registry.mjs";
+import { associateProject, registerVault, resolveVault } from "./registry.mjs";
 
-const HELP = `usage: knowledge-loom {audit,resolve,register,init} ...
+const HELP = `usage: knowledge-loom {audit,resolve,register,associate,init} ...
 
 commands:
   audit       run a read-only vault audit
   resolve     resolve one vault deterministically
   register    preview or register a vault
+  associate   preview or associate a project with a registered vault
   init        preview or initialize a vault contract
 `;
 
@@ -19,6 +20,7 @@ const COMMAND_HELP = {
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
   register: "usage: knowledge-loom register vault_id path [--registry PATH] [--apply]\n",
+  associate: "usage: knowledge-loom associate vault_id project_path [--registry PATH] [--replace] [--apply]\n",
   init: "usage: knowledge-loom init path --vault-id ID --title TITLE --subject SUBJECT [--subject SUBJECT ...] [--write-policy POLICY] [--current-state-policy POLICY] [--history TYPE] [--adopt] [--apply]\n",
 };
 
@@ -30,7 +32,15 @@ function parseArguments(arguments_) {
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) return { help: true, command };
 
   const options = { command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : []);
+  const flags = new Set(command === "audit"
+    ? ["--json"]
+    : command === "init"
+      ? ["--adopt", "--apply"]
+      : command === "register"
+        ? ["--apply"]
+        : command === "associate"
+          ? ["--replace", "--apply"]
+          : []);
   const valueOptions = new Set(["--registry"]);
   if (command === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
@@ -92,6 +102,17 @@ export function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd()
       const [registryPath, rendered] = registerVault(options.positional[0], options.positional[1], { registryPath: options.registry, apply: options.apply === true });
       if (options.apply) stdout.write(`registered ${options.positional[0]} in ${registryPath}\n`);
       else stdout.write(`DRY RUN would write ${registryPath}\n\n${rendered}`);
+      return 0;
+    }
+    if (options.command === "associate") {
+      requirePositionals(options, 2, COMMAND_HELP.associate);
+      const [registryPath, rendered, projectRoot] = associateProject(options.positional[0], options.positional[1], {
+        registryPath: options.registry,
+        apply: options.apply === true,
+        replace: options.replace === true,
+      });
+      if (options.apply) stdout.write(`associated ${projectRoot} with ${options.positional[0]} in ${registryPath}\n`);
+      else stdout.write(`DRY RUN would associate ${projectRoot} with ${options.positional[0]} in ${registryPath}\n\n${rendered}`);
       return 0;
     }
 

--- a/src/knowledge-loom/registry.mjs
+++ b/src/knowledge-loom/registry.mjs
@@ -93,30 +93,39 @@ function registeredVault(vaultId, registry) {
   return vault;
 }
 
-function projectAssociation(start, registry) {
-  if (registry.projects === undefined) return null;
-  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
     throw new ResolutionError("registry projects must be a mapping");
   }
+  return projects;
+}
+
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+
+function projectAssociation(start, registry) {
+  if (registry.projects === undefined) return null;
+  const projects = requireProjectsMapping(registry.projects);
   let current = canonicalPath(start);
   if (fs.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path.dirname(current);
   const matches = [];
-  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+  for (const [configuredRoot, record] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path.isAbsolute(expandedRoot)) continue;
     const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
-    }
     const relative = path.relative(root, current);
     const distance = relative ? relative.split(path.sep).length : 0;
-    matches.push({ record, distance });
+    matches.push({ configuredRoot, record, distance });
   }
   if (!matches.length) return null;
   const nearestDistance = Math.min(...matches.map((match) => match.distance));
   const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
   if (vaultIds.size > 1) {
     throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
   }
@@ -188,25 +197,21 @@ export function associateProject(vaultId, projectRoot, {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
 
-  if (data.projects !== undefined && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
   data.projects ??= {};
-  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
     const expandedRoot = expandHome(configuredRoot);
     if (!path.isAbsolute(expandedRoot)) {
       throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
     }
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
-    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
     if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }
-    if (configuredRoot !== root) delete data.projects[configuredRoot];
+    if (configuredRoot !== root) delete projects[configuredRoot];
   }
-  data.projects[root] = { vault_id: normalizedVaultId };
+  projects[root] = { vault_id: normalizedVaultId };
 
   const rendered = renderRegistry(data);
   if (apply) {

--- a/src/knowledge-loom/registry.mjs
+++ b/src/knowledge-loom/registry.mjs
@@ -6,7 +6,7 @@ import YAML from "yaml";
 
 import { CONTRACT_NAME, loadVault } from "./contract.mjs";
 import { ContractError, ResolutionError } from "./errors.mjs";
-import { canonicalPath, expandHome } from "./pathing.mjs";
+import { canonicalPath, expandHome, isWithin } from "./pathing.mjs";
 
 export { ResolutionError } from "./errors.mjs";
 
@@ -27,6 +27,19 @@ export function loadRegistry(registryPath = defaultRegistryPath()) {
   }
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
+  }
+  if (data.projects !== undefined) {
+    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
+      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
+    }
+    for (const [projectRoot, record] of Object.entries(data.projects)) {
+      if (!path.isAbsolute(expandHome(projectRoot))) {
+        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
+      }
+      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
+      }
+    }
   }
   return data;
 }
@@ -80,14 +93,44 @@ function registeredCandidates(registry) {
   return candidates;
 }
 
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  return loadVault(record.path);
+}
+
+function projectAssociation(start, registry) {
+  let current = canonicalPath(start);
+  if (fs.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
+    const root = canonicalPath(configuredRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path.relative(root, current);
+    const distance = relative ? relative.split(path.sep).length : 0;
+    matches.push({ record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => match.record.vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
+
 export function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  const registry = loadRegistry(registryPath);
   if (selector !== null && selector !== undefined) {
     const selectorPath = path.resolve(expandHome(String(selector)));
     if (fs.existsSync(selectorPath)) {
       const root = fs.statSync(selectorPath).isDirectory() ? selectorPath : path.dirname(selectorPath);
       return loadVault(root);
     }
+    const registry = loadRegistry(registryPath);
     const record = registry.vaults[String(selector)];
     if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
     throw new ResolutionError(`unknown vault selector: ${selector}`);
@@ -95,6 +138,9 @@ export function resolveVault(selector = null, { cwd = process.cwd(), registryPat
 
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
   const candidates = registeredCandidates(registry);
   if (candidates.length === 1) return loadVault(candidates[0][1]);
   if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
@@ -124,4 +170,38 @@ export function registerVault(vaultId, root, { registryPath = defaultRegistryPat
     if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
   }
   return [resolvedRegistryPath, rendered];
+}
+
+export function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs.renameSync,
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+
+  const root = canonicalPath(projectRoot);
+  if (!fs.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+
+  data.projects ??= {};
+  for (const [configuredRoot, record] of Object.entries(data.projects)) {
+    if (canonicalPath(configuredRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete data.projects[configuredRoot];
+  }
+  data.projects[root] = { vault_id: normalizedVaultId };
+
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs.existsSync(resolvedRegistryPath) ? fs.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
 }

--- a/src/knowledge-loom/registry.mjs
+++ b/src/knowledge-loom/registry.mjs
@@ -28,19 +28,6 @@ export function loadRegistry(registryPath = defaultRegistryPath()) {
   if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
     throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
   }
-  if (data.projects !== undefined) {
-    if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
-      throw new ResolutionError(`${resolved}: registry projects must be a mapping`);
-    }
-    for (const [projectRoot, record] of Object.entries(data.projects)) {
-      if (!path.isAbsolute(expandHome(projectRoot))) {
-        throw new ResolutionError(`${resolved}: project association path must be absolute: ${projectRoot}`);
-      }
-      if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-        throw new ResolutionError(`${resolved}: project association ${projectRoot} must contain a vault_id`);
-      }
-    }
-  }
   return data;
 }
 
@@ -99,16 +86,29 @@ function registeredVault(vaultId, registry) {
   if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
     throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
   }
-  return loadVault(record.path);
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
 }
 
 function projectAssociation(start, registry) {
+  if (registry.projects === undefined) return null;
+  if (!registry.projects || typeof registry.projects !== "object" || Array.isArray(registry.projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   let current = canonicalPath(start);
   if (fs.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path.dirname(current);
   const matches = [];
   for (const [configuredRoot, record] of Object.entries(registry.projects ?? {})) {
-    const root = canonicalPath(configuredRoot);
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
     if (!isWithin(root, current)) continue;
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`matching project association \`${configuredRoot}\` must contain a vault_id`);
+    }
     const relative = path.relative(root, current);
     const distance = relative ? relative.split(path.sep).length : 0;
     matches.push({ record, distance });
@@ -188,9 +188,19 @@ export function associateProject(vaultId, projectRoot, {
     throw new ResolutionError(`project path is not an existing directory: ${root}`);
   }
 
+  if (data.projects !== undefined && (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects))) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
   data.projects ??= {};
   for (const [configuredRoot, record] of Object.entries(data.projects)) {
-    if (canonicalPath(configuredRoot) !== root) continue;
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+      throw new ResolutionError(`project association \`${configuredRoot}\` must contain a vault_id`);
+    }
+    if (canonicalPath(expandedRoot) !== root) continue;
     if (record.vault_id !== normalizedVaultId && !replace) {
       throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
     }

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import YAML from "yaml";
 
 import { runCli } from "../src/knowledge-loom/cli.mjs";
+import { FIXTURES, temporaryDirectory } from "./helpers.mjs";
 
 function memoryStream() {
   let contents = "";
@@ -38,4 +41,27 @@ test("init expands a literal home path before previewing", () => {
   ], { stdout, stderr });
   assert.equal(status, 0, stderr.toString());
   assert.match(stdout.toString(), new RegExp(`DRY RUN would create ${path.join(os.homedir(), relative).replaceAll("\\", "\\\\")}`));
+});
+
+test("associate previews and applies a project-to-vault binding", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  fs.writeFileSync(registry, YAML.stringify({
+    schema_version: 1,
+    vaults: { "acme-work": { path: path.join(FIXTURES, "single-proactive") } },
+  }));
+
+  let stdout = memoryStream();
+  let stderr = memoryStream();
+  assert.equal(runCli(["associate", "acme-work", project, "--registry", registry], { stdout, stderr }), 0, stderr.toString());
+  assert.match(stdout.toString(), /DRY RUN would associate/);
+  assert.equal(YAML.parse(fs.readFileSync(registry, "utf8")).projects, undefined);
+
+  stdout = memoryStream();
+  stderr = memoryStream();
+  assert.equal(runCli(["associate", "acme-work", project, "--registry", registry, "--apply"], { stdout, stderr }), 0, stderr.toString());
+  assert.match(stdout.toString(), /associated .* with acme-work/);
+  assert.deepEqual(Object.values(YAML.parse(fs.readFileSync(registry, "utf8")).projects), [{ vault_id: "acme-work" }]);
 });

--- a/tests/distribution.test.mjs
+++ b/tests/distribution.test.mjs
@@ -83,6 +83,12 @@ test("README leads with the outcome and explains the no-install runner", () => {
   assert.match(rendered, /Installing through both `npx skills` and a plugin/);
   assert.match(readme, /npx skills@latest add magickaichen\/knowledge-loom/);
   assert.doesNotMatch(readme, /--skill '\*'/);
+  assert.match(readme, /\$use-knowledge-vault/);
+  assert.match(readme, /\/use-knowledge-vault/);
+  assert.match(readme, /\$knowledge-loom:use-knowledge-vault/);
+  assert.match(readme, /\/knowledge-loom:use-knowledge-vault/);
+  assert.match(readme, /~\/\.config\/knowledge-vault\/registry\.yaml/);
+  assert.match(readme, /associate example ~\/code\/example-project --apply/);
   assert.match(readme, /Node\.js 20\+/);
   assert.match(readme, /does not run `npm install`/);
   assert.match(readme, /Claude Desktop custom skills use a ZIP upload/);

--- a/tests/registry.test.mjs
+++ b/tests/registry.test.mjs
@@ -100,6 +100,23 @@ test("nearest nested project association wins", (t) => {
   assert.equal(resolveVault(null, { cwd: nested, registryPath: registry }).contract.vault_id, "acme-work");
 });
 
+test("valid nearest association wins over a malformed parent association", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const packages = path.join(project, "packages");
+  const nested = path.join(packages, "app");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(nested, { recursive: true });
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+  }, {
+    [project]: 42,
+    [packages]: { vault_id: "acme-work" },
+  });
+
+  assert.equal(resolveVault(null, { cwd: nested, registryPath: registry }).contract.vault_id, "acme-work");
+});
+
 test("nearest vault contract takes precedence over a project association", (t) => {
   const temporary = temporaryDirectory(t);
   const vault = path.join(temporary, "vault");

--- a/tests/registry.test.mjs
+++ b/tests/registry.test.mjs
@@ -64,6 +64,25 @@ test("explicit selector takes precedence over a project association", (t) => {
   assert.equal(resolveVault("shared-home", { cwd: project, registryPath: registry }).contract.vault_id, "shared-home");
 });
 
+test("explicit registry ID ignores malformed unrelated project associations", (t) => {
+  const temporary = temporaryDirectory(t);
+  const registry = path.join(temporary, "registry.yaml");
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+  }, {
+    [path.join(temporary, "unrelated")]: 42,
+  });
+
+  assert.equal(resolveVault("acme-work", { cwd: temporary, registryPath: registry }).contract.vault_id, "acme-work");
+
+  fs.writeFileSync(registry, YAML.stringify({
+    schema_version: 1,
+    vaults: { "acme-work": { path: path.join(FIXTURES, "single-proactive") } },
+    projects: [],
+  }));
+  assert.equal(resolveVault("acme-work", { cwd: temporary, registryPath: registry }).contract.vault_id, "acme-work");
+});
+
 test("nearest nested project association wins", (t) => {
   const temporary = temporaryDirectory(t);
   const project = path.join(temporary, "project");
@@ -123,6 +142,23 @@ test("a matching association with an unknown vault ID fails instead of falling b
   assert.throws(
     () => resolveVault(null, { cwd: project, registryPath: registry }),
     (error) => error instanceof ResolutionError && /unknown registered vault ID `missing`/.test(error.message),
+  );
+});
+
+test("a malformed matching project association fails instead of falling back", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+  }, {
+    [project]: 42,
+  });
+
+  assert.throws(
+    () => resolveVault(null, { cwd: project, registryPath: registry }),
+    (error) => error instanceof ResolutionError && /matching project association .* must contain a vault_id/.test(error.message),
   );
 });
 

--- a/tests/registry.test.mjs
+++ b/tests/registry.test.mjs
@@ -4,11 +4,13 @@ import path from "node:path";
 import test from "node:test";
 import YAML from "yaml";
 
-import { registerVault, ResolutionError, resolveVault } from "../src/knowledge-loom/registry.mjs";
+import { associateProject, registerVault, ResolutionError, resolveVault } from "../src/knowledge-loom/registry.mjs";
 import { FIXTURES, temporaryDirectory } from "./helpers.mjs";
 
-function writeRegistry(target, vaults) {
-  fs.writeFileSync(target, YAML.stringify({ schema_version: 1, vaults }));
+function writeRegistry(target, vaults, projects = undefined) {
+  const data = { schema_version: 1, vaults };
+  if (projects !== undefined) data.projects = projects;
+  fs.writeFileSync(target, YAML.stringify(data));
 }
 
 test("explicit registry ID resolves", (t) => {
@@ -29,6 +31,171 @@ test("multiple registry candidates are ambiguous", (t) => {
     home: { path: path.join(FIXTURES, "shared-explicit") },
   });
   assert.throws(() => resolveVault(null, { cwd: temporary, registryPath: registry }), (error) => error instanceof ResolutionError && /ambiguous/.test(error.message));
+});
+
+test("project association selects one vault when the registry has multiple candidates", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const nested = path.join(project, "packages", "app");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(nested, { recursive: true });
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+    "shared-home": { path: path.join(FIXTURES, "shared-explicit") },
+  }, {
+    [project]: { vault_id: "acme-work" },
+  });
+
+  assert.equal(resolveVault(null, { cwd: nested, registryPath: registry }).contract.vault_id, "acme-work");
+});
+
+test("explicit selector takes precedence over a project association", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+    "shared-home": { path: path.join(FIXTURES, "shared-explicit") },
+  }, {
+    [project]: { vault_id: "acme-work" },
+  });
+
+  assert.equal(resolveVault("shared-home", { cwd: project, registryPath: registry }).contract.vault_id, "shared-home");
+});
+
+test("nearest nested project association wins", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const nested = path.join(project, "packages", "app");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(nested, { recursive: true });
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+    "shared-home": { path: path.join(FIXTURES, "shared-explicit") },
+  }, {
+    [project]: { vault_id: "shared-home" },
+    [path.join(project, "packages")]: { vault_id: "acme-work" },
+  });
+
+  assert.equal(resolveVault(null, { cwd: nested, registryPath: registry }).contract.vault_id, "acme-work");
+});
+
+test("nearest vault contract takes precedence over a project association", (t) => {
+  const temporary = temporaryDirectory(t);
+  const vault = path.join(temporary, "vault");
+  const nested = path.join(vault, "notes");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.cpSync(path.join(FIXTURES, "single-proactive"), vault, { recursive: true });
+  fs.mkdirSync(nested);
+  writeRegistry(registry, {
+    "acme-work": { path: vault },
+    "shared-home": { path: path.join(FIXTURES, "shared-explicit") },
+  }, {
+    [vault]: { vault_id: "shared-home" },
+  });
+
+  assert.equal(resolveVault(null, { cwd: nested, registryPath: registry }).contract.vault_id, "acme-work");
+});
+
+test("nearest vault contract resolves even when the unrelated registry is malformed", (t) => {
+  const temporary = temporaryDirectory(t);
+  const vault = path.join(temporary, "vault");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.cpSync(path.join(FIXTURES, "single-proactive"), vault, { recursive: true });
+  fs.writeFileSync(registry, YAML.stringify({ schema_version: 1, vaults: {}, projects: [] }));
+
+  assert.equal(resolveVault(null, { cwd: vault, registryPath: registry }).contract.vault_id, "acme-work");
+  assert.equal(resolveVault(vault, { cwd: temporary, registryPath: registry }).contract.vault_id, "acme-work");
+});
+
+test("a matching association with an unknown vault ID fails instead of falling back", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+  }, {
+    [project]: { vault_id: "missing" },
+  });
+
+  assert.throws(
+    () => resolveVault(null, { cwd: project, registryPath: registry }),
+    (error) => error instanceof ResolutionError && /unknown registered vault ID `missing`/.test(error.message),
+  );
+});
+
+test("project association follows canonical paths", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const linked = path.join(temporary, "linked-project");
+  const nested = path.join(project, "src");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(nested, { recursive: true });
+  fs.symlinkSync(project, linked, "dir");
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+  }, {
+    [project]: { vault_id: "acme-work" },
+  });
+
+  assert.equal(resolveVault(null, { cwd: path.join(linked, "src"), registryPath: registry }).contract.vault_id, "acme-work");
+});
+
+test("association previews, applies, and is idempotent", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+  });
+
+  const [registryPath, preview] = associateProject("acme-work", project, { registryPath: registry });
+  const canonicalProject = fs.realpathSync(project);
+  assert.equal(registryPath, registry);
+  assert.deepEqual(YAML.parse(preview).projects, { [canonicalProject]: { vault_id: "acme-work" } });
+  assert.equal(YAML.parse(fs.readFileSync(registry, "utf8")).projects, undefined);
+
+  associateProject("acme-work", project, { registryPath: registry, apply: true });
+  const original = fs.readFileSync(registry);
+  associateProject("acme-work", project, { registryPath: registry, apply: true });
+  assert.ok(fs.readFileSync(registry).equals(original));
+  assert.equal(resolveVault(null, { cwd: project, registryPath: registry }).contract.vault_id, "acme-work");
+});
+
+test("association refuses to replace an existing project binding without --replace", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+    "shared-home": { path: path.join(FIXTURES, "shared-explicit") },
+  }, {
+    [project]: { vault_id: "shared-home" },
+  });
+
+  assert.throws(() => associateProject("acme-work", project, { registryPath: registry, apply: true }), /refusing to replace/);
+  associateProject("acme-work", project, { registryPath: registry, apply: true, replace: true });
+  assert.deepEqual(Object.values(YAML.parse(fs.readFileSync(registry, "utf8")).projects), [{ vault_id: "acme-work" }]);
+});
+
+test("atomic association failure preserves the registry", (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  writeRegistry(registry, {
+    "acme-work": { path: path.join(FIXTURES, "single-proactive") },
+  });
+  const original = fs.readFileSync(registry, "utf8");
+  const rename = () => { throw new Error("simulated replace failure"); };
+
+  assert.throws(() => associateProject("acme-work", project, { registryPath: registry, apply: true, rename }), /simulated replace failure/);
+  assert.equal(fs.readFileSync(registry, "utf8"), original);
+  assert.deepEqual(fs.readdirSync(temporary).filter((name) => name.endsWith(".tmp")), []);
 });
 
 test("registration refuses to replace an existing ID", (t) => {

--- a/tests/release.test.mjs
+++ b/tests/release.test.mjs
@@ -33,7 +33,7 @@ test("release checker writes curated changelog notes", (t) => {
   const result = runChecker(`v${version}`, "--notes-output", notes);
   assert.equal(result.status, 0, result.stderr);
   const contents = fs.readFileSync(notes, "utf8");
-  assert.ok(contents.startsWith("The deterministic tooling now runs on JavaScript instead of Python."));
+  assert.ok(contents.startsWith("Projects can now select their registered vault automatically."));
   assert.doesNotMatch(contents, /Full Changelog/);
 });
 


### PR DESCRIPTION
## Outcome

Projects can bind their canonical directory to one registered vault, so Knowledge Loom resolves the right context without a vault ID in every prompt. Vault-local conversations still prefer the nearest `KNOWLEDGE_VAULT.md`.

The new `associate` command previews before writing, requires explicit replacement for an existing binding, and keeps project metadata in the user registry. The README now documents the registry, linking flow, and copyable Codex/Claude invocation examples.

## Verification

- `npm run validate:npx` — 70/70 tests plus real all-agent installation and Codex/Claude runner checks
- `npm audit --audit-level=high` — 0 vulnerabilities
- Independent Standards and Spec reviews — no findings

Closes #6