### PR TITLE
Add vault-specific content checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "knowledge-loom",
       "source": "./",
       "description": "Keep Codex and Claude inside clear boundaries when they read or update local Markdown notes.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Mike Xiao",
         "url": "https://github.com/magickaichen"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.4.0
+
+One audit can now enforce both portable vault structure and local content rules.
+
+### Added
+
+- Added optional `content_checks.adapter` declarations to vault contracts and trusted executable
+  mappings to the local user registry.
+- Merged declared checker results into the existing `knowledge-loom audit` report with observable
+  adapter source, validation date, file path, and line information.
+- Documented one checker result interface for vault-specific rules without adding a second audit or
+  validation command.
+
+### Safety
+
+- Kept executable commands and private paths outside vault contracts and reusable skill packages.
+- Started checkers directly without a shell and bounded their runtime and output.
+- Failed closed when a checker is missing, invalid, timed out, inconsistent, or requested by an
+  invalid contract.
+- Kept compatibility requirements in skill bodies so every package uses portable skill
+  frontmatter.
+
 ## v0.3.0
 
 Projects can now select their registered vault automatically.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,38 @@ the nearest `KNOWLEDGE_VAULT.md` wins. Otherwise, the nearest project associatio
 projects can deliberately override a parent association. A broken association stops resolution
 instead of silently choosing another vault.
 
+### Optional vault-specific content checks
+
+The normal audit can also run one trusted, read-only checker for rules that belong to a particular
+vault, such as its date or summary conventions. There is no second validation command: both the
+skill and CLI still use `knowledge-loom audit` and return one combined report.
+
+Name the checker in `KNOWLEDGE_VAULT.md`:
+
+```yaml
+content_checks:
+  adapter: example-content-check
+```
+
+Keep its executable configuration in the local registry rather than the vault:
+
+```yaml
+content_check_adapters:
+  example-content-check:
+    executable: node
+    arguments:
+      - "{vault_root}/scripts/check-content.mjs"
+      - "--root={vault_root}"
+      - --json
+```
+
+The runner executes this argument list directly without a shell. Register only a checker you trust
+to remain read-only. A missing, invalid, timed-out, or failed declared checker makes the audit fail
+instead of being silently skipped. See the [contract schema](references/contract-schema.md) for its
+JSON result interface. Custom checkers require a command-capable runtime such as Codex, Claude Code,
+or the CLI. The instruction-only Claude Desktop adapter reports the combined audit as incomplete
+when a checker is declared; it never pretends the checker ran.
+
 ## Why this exists
 
 An agent with access to your notes is useful only when its boundaries are clear. Knowledge Loom
@@ -211,7 +243,8 @@ provider, and backup provider still have their own access and privacy rules.
 - [`init-knowledge-vault`](skills/init-knowledge-vault/SKILL.md) previews and initializes a new
   vault, or carefully adopts an existing folder.
 - [`audit-knowledge-vault`](skills/audit-knowledge-vault/SKILL.md) checks the rules file, metadata,
-  privacy paths, Git state, and focus views without modifying the vault.
+  privacy paths, Git state, focus views, and any locally configured content checker without
+  modifying the vault.
 - [`use-knowledge-vault`](skills/use-knowledge-vault/SKILL.md) retrieves the smallest useful set of
   notes and handles approved updates.
 - [`manage-current-focus`](skills/manage-current-focus/SKILL.md) maintains one short list of what
@@ -239,7 +272,9 @@ To use local notes, start a Cowork session and connect exactly one folder contai
 
 Regular Claude Chat cannot read an unconnected local folder. The Desktop adapter refuses local
 vault claims without a connected Cowork folder and refuses writes when the session cannot complete
-the lifecycle steps required by the vault.
+the lifecycle steps required by the vault. If a vault declares a custom content checker, the
+Desktop adapter can report its manual checks but requires Codex, Claude Code, or the CLI to complete
+the combined audit.
 
 ## Use the CLI from a checkout
 
@@ -296,8 +331,9 @@ npm run cli -- resolve example
 ## How it works
 
 The rules file is a versioned `KNOWLEDGE_VAULT.md` contract. It declares the vault identity,
-subjects, write rules, metadata profiles, focus views, Git history, sync, backup, and paths that
-must never be tracked. Every installation route uses the same runtime-neutral protocol.
+subjects, write rules, metadata profiles, focus views, Git history, sync, backup, optional content
+checker, and paths that must never be tracked. Every installation route uses the same
+runtime-neutral protocol.
 
 Read the [protocol](references/protocol.md) and
 [contract schema](references/contract-schema.md) when you need the exact rules.

--- a/adapters/claude-desktop/knowledge-loom/SKILL.md
+++ b/adapters/claude-desktop/knowledge-loom/SKILL.md
@@ -61,6 +61,11 @@ For an audit, check the contract schema, declared paths, subject values, metadat
 patterns, focus invariants, and declared lifecycle. Distinguish deterministic errors from semantic
 warnings and operational information.
 
+If the contract declares `content_checks`, do not claim that the combined audit passed. This
+instruction-only adapter cannot execute the locally registered checker. Report the checks you could
+perform, mark the combined audit incomplete, and tell the user to run the same audit through Codex,
+Claude Code, or the Knowledge Loom CLI.
+
 For a focus view:
 
 - select exactly one named view;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-loom",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-loom",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Agent-neutral governance and skills for local Markdown knowledge vaults",
   "type": "module",

--- a/references/contract-schema.md
+++ b/references/contract-schema.md
@@ -66,6 +66,50 @@ patterns, focus views, and privacy patterns.
 Treat a boundary failure as an audit error before reading the target. Provider destinations and
 registry locations are configured outside these contract path fields.
 
+## Vault-specific content checks
+
+Declare one optional read-only content checker by its kebab-case adapter ID:
+
+```yaml
+content_checks:
+  adapter: example-content-check
+```
+
+The contract names the requirement but contains no executable command. Configure the adapter in
+the local user registry, outside the vault:
+
+```yaml
+content_check_adapters:
+  example-content-check:
+    executable: node
+    arguments:
+      - "{vault_root}/scripts/check-content.mjs"
+      - "--root={vault_root}"
+      - --json
+```
+
+`{vault_root}` expands to the selected canonical vault root and is the only supported placeholder.
+The runner starts the executable directly without a shell, from that root, with a 30-second timeout
+and a 1 MiB output limit. Register only trusted adapters whose interface is read-only.
+
+The checker writes one JSON object to stdout and uses exit `0` for `pass`, `1` for `fail`, or `2`
+for `error`:
+
+```json
+{
+  "status": "pass",
+  "root": "/absolute/canonical/vault",
+  "validationDate": "2026-08-12",
+  "findings": []
+}
+```
+
+Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and a
+vault-relative `path` or `null`; `line` is an optional positive integer. The status, exit code,
+root, and findings must agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON,
+timeout, and inconsistent results are audit errors. Built-in contract errors stop the checker from
+running.
+
 ## Privacy paths
 
 List paths that must never be tracked:

--- a/references/contract-schema.md
+++ b/references/contract-schema.md
@@ -104,11 +104,12 @@ for `error`:
 }
 ```
 
-Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and a
-vault-relative `path` or `null`; `line` is an optional positive integer. The status, exit code,
-root, and findings must agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON,
-timeout, and inconsistent results are audit errors. Built-in contract errors stop the checker from
-running.
+Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and an explicit
+vault-relative `path` or `null`; `line` is an optional positive integer. `root` must be the exact
+absolute canonical vault root, and `validationDate` must be a real calendar date. Merged findings
+retain their adapter `source` and `validationDate`. The status, exit code, root, and findings must
+agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON, timeout, and inconsistent
+results are audit errors. Built-in contract errors stop the checker from running.
 
 ## Privacy paths
 

--- a/references/protocol.md
+++ b/references/protocol.md
@@ -83,7 +83,9 @@ one subject's facts to another.
 Before a write, record repository status. Preserve unrelated changes and pre-existing target-file
 hunks. After a write:
 
-1. Validate the affected contract, metadata profile, links, privacy boundary, and focus invariants.
+1. Run the deterministic audit, including any read-only content checker declared by the contract
+   and configured in the local registry. Treat a missing or failed declared checker as incomplete
+   validation; do not run it separately from the audit.
 2. Review the diff.
 3. Stage only task-owned paths or hunks.
 4. Commit only when the contract requires it.
@@ -103,4 +105,6 @@ by the contract.
 - If selection is ambiguous, stop vault work and ask.
 - If a target file has unrelated uncommitted changes that cannot be isolated safely, leave the new
   capture uncommitted and report the conflict.
+- If a declared content checker is missing, invalid, timed out, or failed, preserve the write and
+  report it as saved but not validated.
 - Never imply that retrieval, validation, commit, sync, or backup succeeded when it did not.

--- a/scripts/run-behavior-evals.mjs
+++ b/scripts/run-behavior-evals.mjs
@@ -7,6 +7,8 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import YAML from "yaml";
 
+import { loadVault, renderContract } from "../src/knowledge-loom/contract.mjs";
+
 const PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 export function treeDigest(root) {
@@ -57,11 +59,12 @@ function runCodex(packageRoot, workspace, prompt, schema, model) {
   return JSON.parse(fs.readFileSync(output, "utf8"));
 }
 
-function runClaude(packageRoot, workspace, prompt, schema, model, maxBudgetUsd) {
+function runClaude(packageRoot, workspace, prompt, schema, model, maxBudgetUsd, commandAccess) {
   const command = [
     "--print", "--no-session-persistence", "--setting-sources", "project", "--system-prompt",
     "You are evaluating local knowledge-vault skill routing or execution. Follow the evaluation prompt, use read-only tools, and return the requested JSON.",
-    "--plugin-dir", packageRoot, "--add-dir", packageRoot, "--permission-mode", "dontAsk", "--tools", "Read,Glob,Grep",
+    "--plugin-dir", packageRoot, "--add-dir", packageRoot, "--permission-mode", "dontAsk", "--tools",
+    commandAccess ? "Read,Glob,Grep,Bash" : "Read,Glob,Grep",
     "--output-format", "json", "--json-schema", fs.readFileSync(schema, "utf8"), "--max-budget-usd", String(maxBudgetUsd),
     "--effort", "low", "--model", model ?? "haiku", prompt,
   ];
@@ -156,7 +159,27 @@ export function main(arguments_ = process.argv.slice(2)) {
           const vaultId = readFrontmatter(path.join(destination, "KNOWLEDGE_VAULT.md")).vault_id;
           registry.vaults[vaultId] = { path: destination };
         }
-        if (Object.keys(registry.vaults).length) {
+        if (case_.content_check) {
+          if (!case_.fixture) throw new Error(`${case_.id}: content_check requires one fixture`);
+          const vault = loadVault(workspace);
+          const contract = structuredClone(vault.contract);
+          contract.content_checks = { adapter: case_.content_check.adapter };
+          fs.writeFileSync(vault.contractPath, renderContract(contract, vault.body));
+          const checkerPath = path.join(workspace, ".behavior-content-check.mjs");
+          const result = case_.content_check.result;
+          const exitCodes = { pass: 0, fail: 1, error: 2 };
+          fs.writeFileSync(
+            checkerPath,
+            `process.stdout.write(JSON.stringify({ ...${JSON.stringify(result)}, root: process.argv[2] })); process.exitCode = ${exitCodes[result.status]};\n`,
+          );
+          registry.content_check_adapters = {
+            [case_.content_check.adapter]: {
+              executable: process.execPath,
+              arguments: [checkerPath, "{vault_root}"],
+            },
+          };
+        }
+        if (Object.keys(registry.vaults).length || registry.content_check_adapters) {
           const registryPath = path.join(workspace, "registry.yaml");
           fs.writeFileSync(registryPath, YAML.stringify(registry));
           variables.registry = registryPath;
@@ -192,7 +215,15 @@ export function main(arguments_ = process.argv.slice(2)) {
         }
         const result = runtime === "codex"
           ? runCodex(PACKAGE_ROOT, workspace, prompt, schema, options.model)
-          : runClaude(PACKAGE_ROOT, workspace, prompt, schema, options.model, options.claudeMaxBudgetUsd);
+          : runClaude(
+            PACKAGE_ROOT,
+            workspace,
+            prompt,
+            schema,
+            options.model,
+            options.claudeMaxBudgetUsd,
+            case_.command_access === true,
+          );
         const errors = validateCase(case_, result, PACKAGE_ROOT);
         if (treeDigest(workspace) !== before) errors.push("read-only behavior case modified the fixture");
         if (errors.length) {

--- a/skills/audit-knowledge-vault/SKILL.md
+++ b/skills/audit-knowledge-vault/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: audit-knowledge-vault
-description: Audit one governed Markdown vault without modifying it. Use for contract, registry, metadata, subject, focus, privacy, Git, link, or lifecycle validation.
-compatibility: Requires Node.js 20+ and local file/command access.
+description: Audit one governed Markdown vault without modifying it. Use for contract, registry, metadata, subject, focus, privacy, Git, content-check, link, or lifecycle validation.
 ---
 
 # Audit Knowledge Vault
+
+Requires Node.js 20+ and local file/command access.
 
 Inspect one vault without changing files, Git state, registry state, external systems, or lifecycle
 destinations.
@@ -18,14 +19,17 @@ directory containing that canonical file. Read `<skill-root>/references/contract
 selector only when one was supplied. Treat its returned canonical root as the only selected vault;
 any resolution error ends the audit before a vault is inspected.
 
-## Run deterministic audit
+## Run one deterministic audit
 
 Use `node "<skill-root>/scripts/knowledge-loom.mjs" audit --help` as the command source, then audit
 the selected path or ID with that runner. Use `--json` only when another tool will consume the
-result. Treat the command output and exit status as the source of truth for deterministic coverage
-rather than restating its implementation here.
+result. Pass the same non-default registry path used during resolution. The runner performs the
+built-in checks and any read-only content checker declared by the contract and configured in the
+local registry. Treat its combined output and exit status as the source of truth; do not locate or
+invoke the checker separately.
 
-A dirty tree is operational context for later writes, not an audit failure by itself.
+A missing, invalid, timed-out, or failed declared checker is an audit error. A dirty tree is
+operational context for later writes, not an audit failure by itself.
 
 ## Inspect semantic risks
 

--- a/skills/audit-knowledge-vault/agents/openai.yaml
+++ b/skills/audit-knowledge-vault/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Audit Knowledge Vault"
-  short_description: "Audit vault policy, structure, and Git safety"
+  short_description: "Audit vault rules and custom content checks"
   default_prompt: "Use $audit-knowledge-vault to run a read-only audit of this vault."

--- a/skills/audit-knowledge-vault/references/contract-schema.md
+++ b/skills/audit-knowledge-vault/references/contract-schema.md
@@ -66,6 +66,50 @@ patterns, focus views, and privacy patterns.
 Treat a boundary failure as an audit error before reading the target. Provider destinations and
 registry locations are configured outside these contract path fields.
 
+## Vault-specific content checks
+
+Declare one optional read-only content checker by its kebab-case adapter ID:
+
+```yaml
+content_checks:
+  adapter: example-content-check
+```
+
+The contract names the requirement but contains no executable command. Configure the adapter in
+the local user registry, outside the vault:
+
+```yaml
+content_check_adapters:
+  example-content-check:
+    executable: node
+    arguments:
+      - "{vault_root}/scripts/check-content.mjs"
+      - "--root={vault_root}"
+      - --json
+```
+
+`{vault_root}` expands to the selected canonical vault root and is the only supported placeholder.
+The runner starts the executable directly without a shell, from that root, with a 30-second timeout
+and a 1 MiB output limit. Register only trusted adapters whose interface is read-only.
+
+The checker writes one JSON object to stdout and uses exit `0` for `pass`, `1` for `fail`, or `2`
+for `error`:
+
+```json
+{
+  "status": "pass",
+  "root": "/absolute/canonical/vault",
+  "validationDate": "2026-08-12",
+  "findings": []
+}
+```
+
+Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and a
+vault-relative `path` or `null`; `line` is an optional positive integer. The status, exit code,
+root, and findings must agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON,
+timeout, and inconsistent results are audit errors. Built-in contract errors stop the checker from
+running.
+
 ## Privacy paths
 
 List paths that must never be tracked:

--- a/skills/audit-knowledge-vault/references/contract-schema.md
+++ b/skills/audit-knowledge-vault/references/contract-schema.md
@@ -104,11 +104,12 @@ for `error`:
 }
 ```
 
-Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and a
-vault-relative `path` or `null`; `line` is an optional positive integer. The status, exit code,
-root, and findings must agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON,
-timeout, and inconsistent results are audit errors. Built-in contract errors stop the checker from
-running.
+Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and an explicit
+vault-relative `path` or `null`; `line` is an optional positive integer. `root` must be the exact
+absolute canonical vault root, and `validationDate` must be a real calendar date. Merged findings
+retain their adapter `source` and `validationDate`. The status, exit code, root, and findings must
+agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON, timeout, and inconsistent
+results are audit errors. Built-in contract errors stop the checker from running.
 
 ## Privacy paths
 

--- a/skills/audit-knowledge-vault/references/protocol.md
+++ b/skills/audit-knowledge-vault/references/protocol.md
@@ -83,7 +83,9 @@ one subject's facts to another.
 Before a write, record repository status. Preserve unrelated changes and pre-existing target-file
 hunks. After a write:
 
-1. Validate the affected contract, metadata profile, links, privacy boundary, and focus invariants.
+1. Run the deterministic audit, including any read-only content checker declared by the contract
+   and configured in the local registry. Treat a missing or failed declared checker as incomplete
+   validation; do not run it separately from the audit.
 2. Review the diff.
 3. Stage only task-owned paths or hunks.
 4. Commit only when the contract requires it.
@@ -103,4 +105,6 @@ by the contract.
 - If selection is ambiguous, stop vault work and ask.
 - If a target file has unrelated uncommitted changes that cannot be isolated safely, leave the new
   capture uncommitted and report the conflict.
+- If a declared content checker is missing, invalid, timed out, or failed, preserve the write and
+  report it as saved but not validated.
 - Never imply that retrieval, validation, commit, sync, or backup succeeded when it did not.

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7449,7 +7449,7 @@ function toPosixRelative(root, candidate) {
 
 // src/knowledge-loom/contract.mjs
 var CONTRACT_NAME = "KNOWLEDGE_VAULT.md";
-var VAULT_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var KEBAB_CASE_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 function finding(severity, code, message, findingPath = null) {
   return { severity, code, message, path: findingPath };
 }
@@ -7527,7 +7527,7 @@ function validateContractData(contract) {
   const findings = [];
   if (contract.schema_version !== 1) findings.push(finding("error", "contract.schema-version", "`schema_version` must equal 1"));
   const vaultId = contract.vault_id;
-  if (typeof vaultId !== "string" || !VAULT_ID_RE.test(vaultId)) {
+  if (typeof vaultId !== "string" || !KEBAB_CASE_ID_RE.test(vaultId)) {
     findings.push(finding("error", "contract.vault-id", "`vault_id` must be stable kebab-case"));
   }
   if (typeof contract.title !== "string" || !contract.title.trim()) {
@@ -7582,7 +7582,7 @@ function validateContractData(contract) {
   }
   if (Object.hasOwn(contract, "content_checks")) {
     const contentChecks = mapping(contract, "content_checks", findings);
-    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !KEBAB_CASE_ID_RE.test(contentChecks.adapter))) {
       findings.push(
         finding(
           "error",
@@ -7851,7 +7851,6 @@ function associateProject(vaultId, projectRoot, {
 }
 
 // src/knowledge-loom/content-checks.mjs
-var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -7948,7 +7947,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7969,11 +7968,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
 }
 function runDeclaredContentCheck(vault, {
   registryPath,
-  timeoutMs = ADAPTER_TIMEOUT_MS,
-  maxBuffer = ADAPTER_MAX_BUFFER
+  timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
   const adapterId = vault.contract.content_checks?.adapter;
-  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  if (!adapterId || !KEBAB_CASE_ID_RE.test(adapterId)) return [];
   let registry;
   try {
     registry = loadRegistry(registryPath);
@@ -7998,7 +7996,7 @@ function runDeclaredContentCheck(vault, {
       encoding: "utf8",
       shell: false,
       timeout: timeoutMs,
-      maxBuffer
+      maxBuffer: ADAPTER_MAX_BUFFER
     }
   );
   if (completed.error) {

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path7) {
-      const ctrl = callVisitor(key, node, visitor, path7);
+    function visit_(key, node, visitor, path8) {
+      const ctrl = callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visit_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visit_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path7);
+            const ci = visit_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = visit_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = visit_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path7);
+          const cv = visit_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path7) {
-      const ctrl = await callVisitor(key, node, visitor, path7);
+    async function visitAsync_(key, node, visitor, path8) {
+      const ctrl = await callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visitAsync_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visitAsync_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path7);
+            const ci = await visitAsync_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path7);
+          const cv = await visitAsync_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path7) {
+    function callVisitor(key, node, visitor, path8) {
       if (typeof visitor === "function")
-        return visitor(key, node, path7);
+        return visitor(key, node, path8);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path7);
+        return visitor.Map?.(key, node, path8);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path7);
+        return visitor.Seq?.(key, node, path8);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path7);
+        return visitor.Pair?.(key, node, path8);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path7);
+        return visitor.Scalar?.(key, node, path8);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path7);
+        return visitor.Alias?.(key, node, path8);
       return void 0;
     }
-    function replaceNode(key, path7, node) {
-      const parent = path7[path7.length - 1];
+    function replaceNode(key, path8, node) {
+      const parent = path8[path8.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path7, value) {
+    function collectionFromPath(schema, path8, value) {
       let v = value;
-      for (let i = path7.length - 1; i >= 0; --i) {
-        const k = path7[i];
+      for (let i = path8.length - 1; i >= 0; --i) {
+        const k = path8[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path7) => path7 == null || typeof path7 === "object" && !!path7[Symbol.iterator]().next().done;
+    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path7, value) {
-        if (isEmptyPath(path7))
+      addIn(path8, value) {
+        if (isEmptyPath(path8))
           this.add(value);
         else {
-          const [key, ...rest] = path7;
+          const [key, ...rest] = path8;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        const [key, ...rest] = path7;
+      deleteIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        const [key, ...rest] = path7;
+      getIn(path8, keepScalar) {
+        const [key, ...rest] = path8;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path7) {
-        const [key, ...rest] = path7;
+      hasIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        const [key, ...rest] = path7;
+      setIn(path8, value) {
+        const [key, ...rest] = path8;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path7, value) {
+      addIn(path8, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path7, value);
+          this.contents.addIn(path8, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        if (Collection.isEmptyPath(path7)) {
+      deleteIn(path8) {
+        if (Collection.isEmptyPath(path8)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path7) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        if (Collection.isEmptyPath(path7))
+      getIn(path8, keepScalar) {
+        if (Collection.isEmptyPath(path8))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path7, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path7) {
-        if (Collection.isEmptyPath(path7))
+      hasIn(path8) {
+        if (Collection.isEmptyPath(path8))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path7) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        if (Collection.isEmptyPath(path7)) {
+      setIn(path8, value) {
+        if (Collection.isEmptyPath(path8)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path7), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path7, value);
+          this.contents.setIn(path8, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path7) => {
+    visit.itemAtPath = (cst, path8) => {
       let item = cst;
-      for (const [field, index] of path7) {
+      for (const [field, index] of path8) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path7) => {
-      const parent = visit.itemAtPath(cst, path7.slice(0, -1));
-      const field = path7[path7.length - 1][0];
+    visit.parentCollection = (cst, path8) => {
+      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
+      const field = path8[path8.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path7, item, visitor) {
-      let ctrl = visitor(item, path7);
+    function _visit(path8, item, visitor) {
+      let ctrl = visitor(item, path8);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path7.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path7);
+            ctrl = ctrl(item, path8);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path7) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
     }
     exports.visit = visit;
   }
@@ -7366,12 +7366,12 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.mjs
-import path6 from "node:path";
+import path7 from "node:path";
 
 // src/knowledge-loom/audit.mjs
 import fs5 from "node:fs";
-import path4 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import path5 from "node:path";
+import { spawnSync } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7646,7 +7646,8 @@ function validateContractData(contract) {
 }
 
 // src/knowledge-loom/content-checks.mjs
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import path4 from "node:path";
 
 // src/knowledge-loom/registry.mjs
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7868,8 +7869,14 @@ function passedFinding(adapterId, validationDate) {
     code: `content-check.${adapterId}.passed`,
     message: `content check passed (${validationDate})`,
     path: null,
-    source: `content-check:${adapterId}`
+    source: `content-check:${adapterId}`,
+    validationDate
   };
+}
+function validValidationDate(value) {
+  if (typeof value !== "string" || !VALIDATION_DATE_RE.test(value)) return false;
+  const parsed = /* @__PURE__ */ new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
 }
 function adapterConfiguration(registry, adapterId) {
   const adapters = registry.content_check_adapters;
@@ -7930,16 +7937,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  let resultRoot;
-  try {
-    resultRoot = canonicalPath(result.root);
-  } catch {
-    return invalid("content checker returned an unreadable root", "root");
-  }
-  if (resultRoot !== canonicalPath(vaultRoot)) {
+  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
-  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+  if (!validValidationDate(result.validationDate)) {
     return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
   }
   if (!Array.isArray(result.findings)) {
@@ -7947,7 +7948,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || !Object.hasOwn(item, "path") || item.path !== null && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7955,7 +7956,8 @@ function normalizedResult(adapterId, result, vaultRoot) {
       code: `content-check.${adapterId}.${item.code}`,
       message: item.message,
       path: item.path ?? null,
-      source: `content-check:${adapterId}`
+      source: `content-check:${adapterId}`,
+      validationDate: result.validationDate
     };
     if (item.line !== void 0) normalized.line = item.line;
     findings.push(normalized);
@@ -7966,7 +7968,86 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   return { status: result.status, validationDate: result.validationDate, findings };
 }
-function runDeclaredContentCheck(vault, {
+function killProcessTree(child) {
+  if (!child.pid) return;
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    killer.once("error", () => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    });
+    killer.unref();
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+    }
+  }
+}
+function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(executable, arguments_, {
+        cwd,
+        shell: false,
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true
+      });
+    } catch (error) {
+      resolve({ error });
+      return;
+    }
+    let settled = false;
+    let timer;
+    let stdout = "";
+    let outputBytes = 0;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const terminate = (error) => {
+      killProcessTree(child);
+      child.stdout.destroy();
+      child.stderr.destroy();
+      finish({ error });
+    };
+    const collect = (chunk, { capture = false } = {}) => {
+      outputBytes += Buffer.byteLength(chunk, "utf8");
+      if (outputBytes > ADAPTER_MAX_BUFFER) {
+        const error = new Error("output exceeded the 1 MiB limit");
+        error.code = "ENOBUFS";
+        terminate(error);
+        return;
+      }
+      if (capture) stdout += chunk;
+    };
+    child.once("error", (error) => finish({ error }));
+    child.stdout.on("data", (chunk) => collect(chunk, { capture: true }));
+    child.stderr.on("data", (chunk) => collect(chunk));
+    child.once("close", (status, signal) => finish({ stdout, status, signal }));
+    timer = setTimeout(() => {
+      const error = new Error("timed out");
+      error.code = "ETIMEDOUT";
+      terminate(error);
+    }, timeoutMs);
+  });
+}
+async function runDeclaredContentCheck(vault, {
   registryPath,
   timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
@@ -7988,19 +8069,16 @@ function runDeclaredContentCheck(vault, {
   const invalidConfiguration = configurationError(adapterId, configuration);
   if (invalidConfiguration) return [invalidConfiguration];
   const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
-  const completed = spawnSync(
+  const completed = await executeAdapter(
     substitute(configuration.executable),
     configuration.arguments.map(substitute),
     {
       cwd: vault.root,
-      encoding: "utf8",
-      shell: false,
-      timeout: timeoutMs,
-      maxBuffer: ADAPTER_MAX_BUFFER
+      timeoutMs
     }
   );
   if (completed.error) {
-    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : completed.error.code === "ENOBUFS" ? "exceeded the 1 MiB output limit" : `could not start: ${completed.error.message}`;
     return [
       adapterFinding(
         adapterId,
@@ -8153,7 +8231,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -8179,7 +8257,7 @@ function walk(root) {
   if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
     for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path4.join(current, entry.name);
+      const candidate = path5.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
@@ -8190,14 +8268,14 @@ function walk(root) {
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path4.join(root, ...patternValue.split("/"));
+    const candidate = path5.join(root, ...patternValue.split("/"));
     return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path4.join(root, ...prefix);
+  const searchRoot = path5.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault, { registryPath } = {}) {
+async function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -8241,7 +8319,7 @@ function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8289,14 +8367,14 @@ function auditVault(vault, { registryPath } = {}) {
     findings.push(...checkFocusView(root, name, view));
   }
   if (!findings.some((item) => item.severity === "error")) {
-    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+    findings.push(...await runDeclaredContentCheck(vault, { registryPath }));
   }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
 import fs6 from "node:fs";
-import path5 from "node:path";
+import path6 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8318,13 +8396,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8354,7 +8432,7 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  const contractPath = path6.join(rootPath, CONTRACT_NAME);
   if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
   if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
@@ -8363,7 +8441,7 @@ function initializeVault(root, { contract, adopt, apply }) {
   if (apply) {
     fs6.mkdirSync(rootPath, { recursive: true });
     fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path5.join(rootPath, "INDEX.md");
+    const indexPath = path6.join(rootPath, "INDEX.md");
     if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
@@ -8429,7 +8507,7 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
@@ -8439,7 +8517,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault, { registryPath: options.registry });
+      const findings2 = await auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }
@@ -8482,7 +8560,7 @@ ${rendered2}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "proactive-durable-capture"])).has(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "maintain-after-material-change"])).has(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!(/* @__PURE__ */ new Set(["git", "none"])).has(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path6.resolve(expandHome(options.positional[0]));
+    const root = path7.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,
@@ -8512,4 +8590,4 @@ ${rendered}`);
 }
 
 // src/knowledge-loom/runner.mjs
-process.exitCode = runCli();
+process.exitCode = await runCli();

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7369,9 +7369,9 @@ var require_dist = __commonJS({
 import path6 from "node:path";
 
 // src/knowledge-loom/audit.mjs
-import fs4 from "node:fs";
-import path3 from "node:path";
-import { spawnSync } from "node:child_process";
+import fs5 from "node:fs";
+import path4 from "node:path";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7580,6 +7580,18 @@ function validateContractData(contract) {
   if (backup.mode === "lifecycle-hook" && !backup.adapter) {
     findings.push(finding("error", "contract.backup-adapter", "lifecycle backup requires `adapter`"));
   }
+  if (Object.hasOwn(contract, "content_checks")) {
+    const contentChecks = mapping(contract, "content_checks", findings);
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+      findings.push(
+        finding(
+          "error",
+          "contract.content-check-adapter",
+          "`content_checks.adapter` must be a kebab-case ID"
+        )
+      );
+    }
+  }
   validatePathValues(contract.instruction_roots, { field: "instruction_roots", findings });
   const navigation = mapping(contract, "navigation", findings);
   validatePathValues(navigation.entrypoints, { field: "navigation.entrypoints", findings, requireNonempty: true });
@@ -7633,8 +7645,409 @@ function validateContractData(contract) {
   return findings;
 }
 
-// src/knowledge-loom/focus.mjs
+// src/knowledge-loom/content-checks.mjs
+import { spawnSync } from "node:child_process";
+
+// src/knowledge-loom/registry.mjs
+var import_yaml2 = __toESM(require_dist(), 1);
+import crypto from "node:crypto";
 import fs3 from "node:fs";
+import os2 from "node:os";
+import path3 from "node:path";
+function defaultRegistryPath() {
+  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
+}
+function loadRegistry(registryPath = defaultRegistryPath()) {
+  const resolved = path3.resolve(expandHome(String(registryPath)));
+  if (!fs3.existsSync(resolved)) return { schema_version: 1, vaults: {} };
+  let data;
+  try {
+    data = import_yaml2.default.parse(fs3.readFileSync(resolved, "utf8")) ?? {};
+  } catch (error) {
+    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
+    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
+  }
+  return data;
+}
+function renderRegistry(data) {
+  return import_yaml2.default.stringify(data, { lineWidth: 0 });
+}
+function atomicWriteText(targetPath, rendered, { rename = fs3.renameSync } = {}) {
+  fs3.mkdirSync(path3.dirname(targetPath), { recursive: true });
+  const temporary = path3.join(path3.dirname(targetPath), `.${path3.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
+  let descriptor;
+  try {
+    const existing = fs3.statSync(targetPath, { throwIfNoEntry: false });
+    descriptor = fs3.openSync(temporary, "wx", existing?.mode & 511 || 384);
+    fs3.writeFileSync(descriptor, rendered, "utf8");
+    fs3.fsyncSync(descriptor);
+    fs3.closeSync(descriptor);
+    descriptor = void 0;
+    rename(temporary, targetPath);
+    try {
+      const directory = fs3.openSync(path3.dirname(targetPath), "r");
+      try {
+        fs3.fsyncSync(directory);
+      } finally {
+        fs3.closeSync(directory);
+      }
+    } catch {
+    }
+  } finally {
+    if (descriptor !== void 0) fs3.closeSync(descriptor);
+    fs3.rmSync(temporary, { force: true });
+  }
+}
+function findAncestorVault(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  while (true) {
+    if (fs3.statSync(path3.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
+    const parent = path3.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+function registeredCandidates(registry) {
+  const candidates = [];
+  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
+    const root = canonicalPath(record.path);
+    if (fs3.statSync(path3.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
+  }
+  return candidates;
+}
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
+}
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path3.relative(root, current);
+    const distance = relative ? relative.split(path3.sep).length : 0;
+    matches.push({ configuredRoot, record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
+function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
+  if (selector !== null && selector !== void 0) {
+    const selectorPath = path3.resolve(expandHome(String(selector)));
+    if (fs3.existsSync(selectorPath)) {
+      const root = fs3.statSync(selectorPath).isDirectory() ? selectorPath : path3.dirname(selectorPath);
+      return loadVault(root);
+    }
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
+    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
+    throw new ResolutionError(`unknown vault selector: ${selector}`);
+  }
+  const ancestor = findAncestorVault(cwd);
+  if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
+  const candidates = registeredCandidates(registry);
+  if (candidates.length === 1) return loadVault(candidates[0][1]);
+  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
+  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
+}
+function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs3.renameSync } = {}) {
+  const vault = loadVault(root);
+  const contractId = vault.contract.vault_id;
+  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  const existing = data.vaults[vaultId];
+  if (existing !== void 0) {
+    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
+    }
+    const existingRoot = canonicalPath(existing.path);
+    if (existingRoot !== vault.root) {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
+    }
+  }
+  data.vaults[vaultId] = { path: vault.root };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered];
+}
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs3.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs3.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
+    if (canonicalPath(expandedRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete projects[configuredRoot];
+  }
+  projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
+
+// src/knowledge-loom/content-checks.mjs
+var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
+var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
+var ADAPTER_TIMEOUT_MS = 3e4;
+var ADAPTER_MAX_BUFFER = 1024 * 1024;
+function adapterFinding(adapterId, code, message, findingPath = null) {
+  return {
+    ...finding("error", `content-check.${code}`, message, findingPath),
+    source: adapterId ? `content-check:${adapterId}` : "content-check"
+  };
+}
+function passedFinding(adapterId, validationDate) {
+  return {
+    severity: "info",
+    code: `content-check.${adapterId}.passed`,
+    message: `content check passed (${validationDate})`,
+    path: null,
+    source: `content-check:${adapterId}`
+  };
+}
+function adapterConfiguration(registry, adapterId) {
+  const adapters = registry.content_check_adapters;
+  if (!adapters || typeof adapters !== "object" || Array.isArray(adapters)) return null;
+  return adapters[adapterId] ?? null;
+}
+function configurationError(adapterId, configuration) {
+  if (!configuration) {
+    return adapterFinding(
+      adapterId,
+      "adapter-missing",
+      `content check adapter \`${adapterId}\` is not configured in the local registry`
+    );
+  }
+  if (typeof configuration !== "object" || Array.isArray(configuration)) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` must be a mapping`
+    );
+  }
+  if (typeof configuration.executable !== "string" || !configuration.executable.trim()) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a non-empty \`executable\``
+    );
+  }
+  if (!Array.isArray(configuration.arguments) || configuration.arguments.some((value) => typeof value !== "string")) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a string \`arguments\` list`
+    );
+  }
+  for (const value of [configuration.executable, ...configuration.arguments]) {
+    const placeholders = value.match(/\{[^}]+\}/g) ?? [];
+    if (placeholders.some((placeholder) => placeholder !== "{vault_root}")) {
+      return adapterFinding(
+        adapterId,
+        "adapter-config",
+        `content check adapter \`${adapterId}\` uses an unsupported placeholder`
+      );
+    }
+  }
+  return null;
+}
+function normalizedResult(adapterId, result, vaultRoot) {
+  const invalid = (message, code = "output") => ({
+    error: adapterFinding(adapterId, code, message)
+  });
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("content checker output must be a JSON object");
+  }
+  if (!Object.hasOwn(STATUS_EXIT_CODES, result.status)) {
+    return invalid("content checker returned an unsupported status");
+  }
+  if (typeof result.root !== "string") {
+    return invalid("content checker output requires `root`");
+  }
+  let resultRoot;
+  try {
+    resultRoot = canonicalPath(result.root);
+  } catch {
+    return invalid("content checker returned an unreadable root", "root");
+  }
+  if (resultRoot !== canonicalPath(vaultRoot)) {
+    return invalid("content checker root does not match the selected vault", "root");
+  }
+  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+    return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
+  }
+  if (!Array.isArray(result.findings)) {
+    return invalid("content checker output requires a `findings` list");
+  }
+  const findings = [];
+  for (const item of result.findings) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+      return invalid("content checker returned an invalid finding");
+    }
+    const normalized = {
+      severity: item.severity,
+      code: `content-check.${adapterId}.${item.code}`,
+      message: item.message,
+      path: item.path ?? null,
+      source: `content-check:${adapterId}`
+    };
+    if (item.line !== void 0) normalized.line = item.line;
+    findings.push(normalized);
+  }
+  const hasError = findings.some((item) => item.severity === "error");
+  if (result.status === "pass" && hasError || result.status !== "pass" && !hasError) {
+    return invalid("content checker status is inconsistent with its findings");
+  }
+  return { status: result.status, validationDate: result.validationDate, findings };
+}
+function runDeclaredContentCheck(vault, {
+  registryPath,
+  timeoutMs = ADAPTER_TIMEOUT_MS,
+  maxBuffer = ADAPTER_MAX_BUFFER
+} = {}) {
+  const adapterId = vault.contract.content_checks?.adapter;
+  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  let registry;
+  try {
+    registry = loadRegistry(registryPath);
+  } catch (error) {
+    return [
+      adapterFinding(
+        adapterId,
+        "registry",
+        `cannot load the local adapter registry: ${error.message}`
+      )
+    ];
+  }
+  const configuration = adapterConfiguration(registry, adapterId);
+  const invalidConfiguration = configurationError(adapterId, configuration);
+  if (invalidConfiguration) return [invalidConfiguration];
+  const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
+  const completed = spawnSync(
+    substitute(configuration.executable),
+    configuration.arguments.map(substitute),
+    {
+      cwd: vault.root,
+      encoding: "utf8",
+      shell: false,
+      timeout: timeoutMs,
+      maxBuffer
+    }
+  );
+  if (completed.error) {
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ${reason}`
+      )
+    ];
+  }
+  if (completed.signal) {
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ended with signal ${completed.signal}`
+      )
+    ];
+  }
+  let result;
+  try {
+    result = JSON.parse(completed.stdout);
+  } catch {
+    return [
+      adapterFinding(
+        adapterId,
+        "output",
+        `content check adapter \`${adapterId}\` did not return valid JSON`
+      )
+    ];
+  }
+  const normalized = normalizedResult(adapterId, result, vault.root);
+  if (normalized.error) return [normalized.error];
+  if (completed.status !== STATUS_EXIT_CODES[normalized.status]) {
+    return [
+      adapterFinding(
+        adapterId,
+        "exit-status",
+        `content check adapter \`${adapterId}\` exit status does not match its result`
+      )
+    ];
+  }
+  return normalized.status === "pass" ? [passedFinding(adapterId, normalized.validationDate), ...normalized.findings] : normalized.findings;
+}
+
+// src/knowledge-loom/focus.mjs
+import fs4 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -7656,12 +8069,12 @@ function checkFocusView(root, name, view) {
   if (typeof relative !== "string") return [];
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs3.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
   if (typeof section !== "string") return [];
-  const items = activeItems(fs3.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top ?? 3;
   const maxActive = view.max_active ?? maxTop;
   if (!Number.isInteger(maxTop) || !Number.isInteger(maxActive)) return [];
@@ -7742,7 +8155,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -7751,7 +8164,7 @@ function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missi
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -7765,28 +8178,28 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs4.existsSync(root)) return result;
+  if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs4.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path3.join(current, entry.name);
+    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path4.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs4.lstatSync(root).isDirectory() && !fs4.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path3.join(root, ...patternValue.split("/"));
-    return fs4.existsSync(candidate) ? [candidate] : [];
+    const candidate = path4.join(root, ...patternValue.split("/"));
+    return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path3.join(root, ...prefix);
+  const searchRoot = path4.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault) {
+function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -7830,7 +8243,7 @@ function auditVault(vault) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs4.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path3.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -7877,12 +8290,15 @@ function auditVault(vault) {
     if (!view || typeof view !== "object" || Array.isArray(view) || typeof view.path !== "string" || !isVaultRelativePath(view.path)) continue;
     findings.push(...checkFocusView(root, name, view));
   }
+  if (!findings.some((item) => item.severity === "error")) {
+    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+  }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
-import fs5 from "node:fs";
-import path4 from "node:path";
+import fs6 from "node:fs";
+import path5 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -7904,13 +8320,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -7940,221 +8356,19 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path4.join(rootPath, CONTRACT_NAME);
-  if (fs5.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs5.existsSync(rootPath) && fs5.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs5.mkdirSync(rootPath, { recursive: true });
-    fs5.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path4.join(rootPath, "INDEX.md");
-    if (!adopt && !fs5.existsSync(indexPath)) fs5.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs6.mkdirSync(rootPath, { recursive: true });
+    fs6.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path5.join(rootPath, "INDEX.md");
+    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
-}
-
-// src/knowledge-loom/registry.mjs
-var import_yaml2 = __toESM(require_dist(), 1);
-import crypto from "node:crypto";
-import fs6 from "node:fs";
-import os2 from "node:os";
-import path5 from "node:path";
-function defaultRegistryPath() {
-  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path5.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path5.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
-}
-function loadRegistry(registryPath = defaultRegistryPath()) {
-  const resolved = path5.resolve(expandHome(String(registryPath)));
-  if (!fs6.existsSync(resolved)) return { schema_version: 1, vaults: {} };
-  let data;
-  try {
-    data = import_yaml2.default.parse(fs6.readFileSync(resolved, "utf8")) ?? {};
-  } catch (error) {
-    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
-  }
-  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
-    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
-  }
-  return data;
-}
-function renderRegistry(data) {
-  return import_yaml2.default.stringify(data, { lineWidth: 0 });
-}
-function atomicWriteText(targetPath, rendered, { rename = fs6.renameSync } = {}) {
-  fs6.mkdirSync(path5.dirname(targetPath), { recursive: true });
-  const temporary = path5.join(path5.dirname(targetPath), `.${path5.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
-  let descriptor;
-  try {
-    const existing = fs6.statSync(targetPath, { throwIfNoEntry: false });
-    descriptor = fs6.openSync(temporary, "wx", existing?.mode & 511 || 384);
-    fs6.writeFileSync(descriptor, rendered, "utf8");
-    fs6.fsyncSync(descriptor);
-    fs6.closeSync(descriptor);
-    descriptor = void 0;
-    rename(temporary, targetPath);
-    try {
-      const directory = fs6.openSync(path5.dirname(targetPath), "r");
-      try {
-        fs6.fsyncSync(directory);
-      } finally {
-        fs6.closeSync(directory);
-      }
-    } catch {
-    }
-  } finally {
-    if (descriptor !== void 0) fs6.closeSync(descriptor);
-    fs6.rmSync(temporary, { force: true });
-  }
-}
-function findAncestorVault(start) {
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  while (true) {
-    if (fs6.statSync(path5.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
-    const parent = path5.dirname(current);
-    if (parent === current) return null;
-    current = parent;
-  }
-}
-function registeredCandidates(registry) {
-  const candidates = [];
-  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
-    const root = canonicalPath(record.path);
-    if (fs6.statSync(path5.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
-  }
-  return candidates;
-}
-function registeredVault(vaultId, registry) {
-  const record = registry.vaults[vaultId];
-  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
-  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
-    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
-  }
-  const vault = loadVault(record.path);
-  if (vault.contract.vault_id !== vaultId) {
-    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
-  }
-  return vault;
-}
-function requireProjectsMapping(projects) {
-  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
-  return projects;
-}
-function projectRecord(configuredRoot, record, { matching = false } = {}) {
-  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
-  }
-  return record;
-}
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  const projects = requireProjectsMapping(registry.projects);
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  const matches = [];
-  for (const [configuredRoot, record] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) continue;
-    const root = canonicalPath(expandedRoot);
-    if (!isWithin(root, current)) continue;
-    const relative = path5.relative(root, current);
-    const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ configuredRoot, record, distance });
-  }
-  if (!matches.length) return null;
-  const nearestDistance = Math.min(...matches.map((match) => match.distance));
-  const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
-  if (vaultIds.size > 1) {
-    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
-  }
-  return nearest[0];
-}
-function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  if (selector !== null && selector !== void 0) {
-    const selectorPath = path5.resolve(expandHome(String(selector)));
-    if (fs6.existsSync(selectorPath)) {
-      const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
-      return loadVault(root);
-    }
-    const registry2 = loadRegistry(registryPath);
-    const record = registry2.vaults[String(selector)];
-    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
-    throw new ResolutionError(`unknown vault selector: ${selector}`);
-  }
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return loadVault(ancestor);
-  const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
-  if (association) return registeredVault(association.record.vault_id, registry);
-  const candidates = registeredCandidates(registry);
-  if (candidates.length === 1) return loadVault(candidates[0][1]);
-  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
-  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
-}
-function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs6.renameSync } = {}) {
-  const vault = loadVault(root);
-  const contractId = vault.contract.vault_id;
-  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  const existing = data.vaults[vaultId];
-  if (existing !== void 0) {
-    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
-    }
-    const existingRoot = canonicalPath(existing.path);
-    if (existingRoot !== vault.root) {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
-    }
-  }
-  data.vaults[vaultId] = { path: vault.root };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered];
-}
-function associateProject(vaultId, projectRoot, {
-  registryPath = defaultRegistryPath(),
-  apply = false,
-  replace = false,
-  rename = fs6.renameSync
-} = {}) {
-  const normalizedVaultId = String(vaultId);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  registeredVault(normalizedVaultId, data);
-  const root = canonicalPath(projectRoot);
-  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
-    throw new ResolutionError(`project path is not an existing directory: ${root}`);
-  }
-  data.projects ??= {};
-  const projects = requireProjectsMapping(data.projects);
-  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) {
-      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
-    }
-    const record = projectRecord(configuredRoot, unvalidatedRecord);
-    if (canonicalPath(expandedRoot) !== root) continue;
-    if (record.vault_id !== normalizedVaultId && !replace) {
-      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
-    }
-    if (configuredRoot !== root) delete projects[configuredRoot];
-  }
-  projects[root] = { vault_id: normalizedVaultId };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered, root];
 }
 
 // src/knowledge-loom/cli.mjs
@@ -8211,7 +8425,7 @@ function formatFindings(findings, { json = false } = {}) {
   if (json) return `${JSON.stringify(findings, null, 2)}
 `;
   if (!findings.length) return "PASS no findings\n";
-  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}]` : ""}: ${item.message}`).join("\n")}
+  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}${item.line ? `:${item.line}` : ""}]` : ""}: ${item.message}`).join("\n")}
 `;
 }
 function requirePositionals(options, count, usage) {
@@ -8227,7 +8441,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault);
+      const findings2 = auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }

--- a/skills/init-knowledge-vault/SKILL.md
+++ b/skills/init-knowledge-vault/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: init-knowledge-vault
 description: Initialize a governed Markdown vault, conservatively adopt an existing one, register it, or associate a project with it. Use for vault contracts, deterministic registration or project linking, and protocol adoption without bulk migration.
-compatibility: Requires Node.js 20+ and local file/command access.
 ---
 
 # Initialize Knowledge Vault
+
+Requires Node.js 20+ and local file/command access.
 
 Create or adopt one vault through a previewed contract change.
 

--- a/skills/init-knowledge-vault/references/contract-schema.md
+++ b/skills/init-knowledge-vault/references/contract-schema.md
@@ -66,6 +66,50 @@ patterns, focus views, and privacy patterns.
 Treat a boundary failure as an audit error before reading the target. Provider destinations and
 registry locations are configured outside these contract path fields.
 
+## Vault-specific content checks
+
+Declare one optional read-only content checker by its kebab-case adapter ID:
+
+```yaml
+content_checks:
+  adapter: example-content-check
+```
+
+The contract names the requirement but contains no executable command. Configure the adapter in
+the local user registry, outside the vault:
+
+```yaml
+content_check_adapters:
+  example-content-check:
+    executable: node
+    arguments:
+      - "{vault_root}/scripts/check-content.mjs"
+      - "--root={vault_root}"
+      - --json
+```
+
+`{vault_root}` expands to the selected canonical vault root and is the only supported placeholder.
+The runner starts the executable directly without a shell, from that root, with a 30-second timeout
+and a 1 MiB output limit. Register only trusted adapters whose interface is read-only.
+
+The checker writes one JSON object to stdout and uses exit `0` for `pass`, `1` for `fail`, or `2`
+for `error`:
+
+```json
+{
+  "status": "pass",
+  "root": "/absolute/canonical/vault",
+  "validationDate": "2026-08-12",
+  "findings": []
+}
+```
+
+Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and a
+vault-relative `path` or `null`; `line` is an optional positive integer. The status, exit code,
+root, and findings must agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON,
+timeout, and inconsistent results are audit errors. Built-in contract errors stop the checker from
+running.
+
 ## Privacy paths
 
 List paths that must never be tracked:

--- a/skills/init-knowledge-vault/references/contract-schema.md
+++ b/skills/init-knowledge-vault/references/contract-schema.md
@@ -104,11 +104,12 @@ for `error`:
 }
 ```
 
-Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and a
-vault-relative `path` or `null`; `line` is an optional positive integer. The status, exit code,
-root, and findings must agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON,
-timeout, and inconsistent results are audit errors. Built-in contract errors stop the checker from
-running.
+Each finding requires `severity` (`error`, `warning`, or `info`), `code`, `message`, and an explicit
+vault-relative `path` or `null`; `line` is an optional positive integer. `root` must be the exact
+absolute canonical vault root, and `validationDate` must be a real calendar date. Merged findings
+retain their adapter `source` and `validationDate`. The status, exit code, root, and findings must
+agree. Adapter absence, invalid configuration, unsafe paths, invalid JSON, timeout, and inconsistent
+results are audit errors. Built-in contract errors stop the checker from running.
 
 ## Privacy paths
 

--- a/skills/init-knowledge-vault/references/protocol.md
+++ b/skills/init-knowledge-vault/references/protocol.md
@@ -83,7 +83,9 @@ one subject's facts to another.
 Before a write, record repository status. Preserve unrelated changes and pre-existing target-file
 hunks. After a write:
 
-1. Validate the affected contract, metadata profile, links, privacy boundary, and focus invariants.
+1. Run the deterministic audit, including any read-only content checker declared by the contract
+   and configured in the local registry. Treat a missing or failed declared checker as incomplete
+   validation; do not run it separately from the audit.
 2. Review the diff.
 3. Stage only task-owned paths or hunks.
 4. Commit only when the contract requires it.
@@ -103,4 +105,6 @@ by the contract.
 - If selection is ambiguous, stop vault work and ask.
 - If a target file has unrelated uncommitted changes that cannot be isolated safely, leave the new
   capture uncommitted and report the conflict.
+- If a declared content checker is missing, invalid, timed out, or failed, preserve the write and
+  report it as saved but not validated.
 - Never imply that retrieval, validation, commit, sync, or backup succeeded when it did not.

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7449,7 +7449,7 @@ function toPosixRelative(root, candidate) {
 
 // src/knowledge-loom/contract.mjs
 var CONTRACT_NAME = "KNOWLEDGE_VAULT.md";
-var VAULT_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var KEBAB_CASE_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 function finding(severity, code, message, findingPath = null) {
   return { severity, code, message, path: findingPath };
 }
@@ -7527,7 +7527,7 @@ function validateContractData(contract) {
   const findings = [];
   if (contract.schema_version !== 1) findings.push(finding("error", "contract.schema-version", "`schema_version` must equal 1"));
   const vaultId = contract.vault_id;
-  if (typeof vaultId !== "string" || !VAULT_ID_RE.test(vaultId)) {
+  if (typeof vaultId !== "string" || !KEBAB_CASE_ID_RE.test(vaultId)) {
     findings.push(finding("error", "contract.vault-id", "`vault_id` must be stable kebab-case"));
   }
   if (typeof contract.title !== "string" || !contract.title.trim()) {
@@ -7582,7 +7582,7 @@ function validateContractData(contract) {
   }
   if (Object.hasOwn(contract, "content_checks")) {
     const contentChecks = mapping(contract, "content_checks", findings);
-    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !KEBAB_CASE_ID_RE.test(contentChecks.adapter))) {
       findings.push(
         finding(
           "error",
@@ -7851,7 +7851,6 @@ function associateProject(vaultId, projectRoot, {
 }
 
 // src/knowledge-loom/content-checks.mjs
-var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -7948,7 +7947,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7969,11 +7968,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
 }
 function runDeclaredContentCheck(vault, {
   registryPath,
-  timeoutMs = ADAPTER_TIMEOUT_MS,
-  maxBuffer = ADAPTER_MAX_BUFFER
+  timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
   const adapterId = vault.contract.content_checks?.adapter;
-  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  if (!adapterId || !KEBAB_CASE_ID_RE.test(adapterId)) return [];
   let registry;
   try {
     registry = loadRegistry(registryPath);
@@ -7998,7 +7996,7 @@ function runDeclaredContentCheck(vault, {
       encoding: "utf8",
       shell: false,
       timeout: timeoutMs,
-      maxBuffer
+      maxBuffer: ADAPTER_MAX_BUFFER
     }
   );
   if (completed.error) {

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path7) {
-      const ctrl = callVisitor(key, node, visitor, path7);
+    function visit_(key, node, visitor, path8) {
+      const ctrl = callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visit_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visit_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path7);
+            const ci = visit_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = visit_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = visit_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path7);
+          const cv = visit_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path7) {
-      const ctrl = await callVisitor(key, node, visitor, path7);
+    async function visitAsync_(key, node, visitor, path8) {
+      const ctrl = await callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visitAsync_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visitAsync_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path7);
+            const ci = await visitAsync_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path7);
+          const cv = await visitAsync_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path7) {
+    function callVisitor(key, node, visitor, path8) {
       if (typeof visitor === "function")
-        return visitor(key, node, path7);
+        return visitor(key, node, path8);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path7);
+        return visitor.Map?.(key, node, path8);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path7);
+        return visitor.Seq?.(key, node, path8);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path7);
+        return visitor.Pair?.(key, node, path8);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path7);
+        return visitor.Scalar?.(key, node, path8);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path7);
+        return visitor.Alias?.(key, node, path8);
       return void 0;
     }
-    function replaceNode(key, path7, node) {
-      const parent = path7[path7.length - 1];
+    function replaceNode(key, path8, node) {
+      const parent = path8[path8.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path7, value) {
+    function collectionFromPath(schema, path8, value) {
       let v = value;
-      for (let i = path7.length - 1; i >= 0; --i) {
-        const k = path7[i];
+      for (let i = path8.length - 1; i >= 0; --i) {
+        const k = path8[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path7) => path7 == null || typeof path7 === "object" && !!path7[Symbol.iterator]().next().done;
+    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path7, value) {
-        if (isEmptyPath(path7))
+      addIn(path8, value) {
+        if (isEmptyPath(path8))
           this.add(value);
         else {
-          const [key, ...rest] = path7;
+          const [key, ...rest] = path8;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        const [key, ...rest] = path7;
+      deleteIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        const [key, ...rest] = path7;
+      getIn(path8, keepScalar) {
+        const [key, ...rest] = path8;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path7) {
-        const [key, ...rest] = path7;
+      hasIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        const [key, ...rest] = path7;
+      setIn(path8, value) {
+        const [key, ...rest] = path8;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path7, value) {
+      addIn(path8, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path7, value);
+          this.contents.addIn(path8, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        if (Collection.isEmptyPath(path7)) {
+      deleteIn(path8) {
+        if (Collection.isEmptyPath(path8)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path7) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        if (Collection.isEmptyPath(path7))
+      getIn(path8, keepScalar) {
+        if (Collection.isEmptyPath(path8))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path7, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path7) {
-        if (Collection.isEmptyPath(path7))
+      hasIn(path8) {
+        if (Collection.isEmptyPath(path8))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path7) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        if (Collection.isEmptyPath(path7)) {
+      setIn(path8, value) {
+        if (Collection.isEmptyPath(path8)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path7), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path7, value);
+          this.contents.setIn(path8, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path7) => {
+    visit.itemAtPath = (cst, path8) => {
       let item = cst;
-      for (const [field, index] of path7) {
+      for (const [field, index] of path8) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path7) => {
-      const parent = visit.itemAtPath(cst, path7.slice(0, -1));
-      const field = path7[path7.length - 1][0];
+    visit.parentCollection = (cst, path8) => {
+      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
+      const field = path8[path8.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path7, item, visitor) {
-      let ctrl = visitor(item, path7);
+    function _visit(path8, item, visitor) {
+      let ctrl = visitor(item, path8);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path7.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path7);
+            ctrl = ctrl(item, path8);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path7) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
     }
     exports.visit = visit;
   }
@@ -7366,12 +7366,12 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.mjs
-import path6 from "node:path";
+import path7 from "node:path";
 
 // src/knowledge-loom/audit.mjs
 import fs5 from "node:fs";
-import path4 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import path5 from "node:path";
+import { spawnSync } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7646,7 +7646,8 @@ function validateContractData(contract) {
 }
 
 // src/knowledge-loom/content-checks.mjs
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import path4 from "node:path";
 
 // src/knowledge-loom/registry.mjs
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7868,8 +7869,14 @@ function passedFinding(adapterId, validationDate) {
     code: `content-check.${adapterId}.passed`,
     message: `content check passed (${validationDate})`,
     path: null,
-    source: `content-check:${adapterId}`
+    source: `content-check:${adapterId}`,
+    validationDate
   };
+}
+function validValidationDate(value) {
+  if (typeof value !== "string" || !VALIDATION_DATE_RE.test(value)) return false;
+  const parsed = /* @__PURE__ */ new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
 }
 function adapterConfiguration(registry, adapterId) {
   const adapters = registry.content_check_adapters;
@@ -7930,16 +7937,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  let resultRoot;
-  try {
-    resultRoot = canonicalPath(result.root);
-  } catch {
-    return invalid("content checker returned an unreadable root", "root");
-  }
-  if (resultRoot !== canonicalPath(vaultRoot)) {
+  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
-  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+  if (!validValidationDate(result.validationDate)) {
     return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
   }
   if (!Array.isArray(result.findings)) {
@@ -7947,7 +7948,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || !Object.hasOwn(item, "path") || item.path !== null && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7955,7 +7956,8 @@ function normalizedResult(adapterId, result, vaultRoot) {
       code: `content-check.${adapterId}.${item.code}`,
       message: item.message,
       path: item.path ?? null,
-      source: `content-check:${adapterId}`
+      source: `content-check:${adapterId}`,
+      validationDate: result.validationDate
     };
     if (item.line !== void 0) normalized.line = item.line;
     findings.push(normalized);
@@ -7966,7 +7968,86 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   return { status: result.status, validationDate: result.validationDate, findings };
 }
-function runDeclaredContentCheck(vault, {
+function killProcessTree(child) {
+  if (!child.pid) return;
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    killer.once("error", () => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    });
+    killer.unref();
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+    }
+  }
+}
+function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(executable, arguments_, {
+        cwd,
+        shell: false,
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true
+      });
+    } catch (error) {
+      resolve({ error });
+      return;
+    }
+    let settled = false;
+    let timer;
+    let stdout = "";
+    let outputBytes = 0;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const terminate = (error) => {
+      killProcessTree(child);
+      child.stdout.destroy();
+      child.stderr.destroy();
+      finish({ error });
+    };
+    const collect = (chunk, { capture = false } = {}) => {
+      outputBytes += Buffer.byteLength(chunk, "utf8");
+      if (outputBytes > ADAPTER_MAX_BUFFER) {
+        const error = new Error("output exceeded the 1 MiB limit");
+        error.code = "ENOBUFS";
+        terminate(error);
+        return;
+      }
+      if (capture) stdout += chunk;
+    };
+    child.once("error", (error) => finish({ error }));
+    child.stdout.on("data", (chunk) => collect(chunk, { capture: true }));
+    child.stderr.on("data", (chunk) => collect(chunk));
+    child.once("close", (status, signal) => finish({ stdout, status, signal }));
+    timer = setTimeout(() => {
+      const error = new Error("timed out");
+      error.code = "ETIMEDOUT";
+      terminate(error);
+    }, timeoutMs);
+  });
+}
+async function runDeclaredContentCheck(vault, {
   registryPath,
   timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
@@ -7988,19 +8069,16 @@ function runDeclaredContentCheck(vault, {
   const invalidConfiguration = configurationError(adapterId, configuration);
   if (invalidConfiguration) return [invalidConfiguration];
   const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
-  const completed = spawnSync(
+  const completed = await executeAdapter(
     substitute(configuration.executable),
     configuration.arguments.map(substitute),
     {
       cwd: vault.root,
-      encoding: "utf8",
-      shell: false,
-      timeout: timeoutMs,
-      maxBuffer: ADAPTER_MAX_BUFFER
+      timeoutMs
     }
   );
   if (completed.error) {
-    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : completed.error.code === "ENOBUFS" ? "exceeded the 1 MiB output limit" : `could not start: ${completed.error.message}`;
     return [
       adapterFinding(
         adapterId,
@@ -8153,7 +8231,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -8179,7 +8257,7 @@ function walk(root) {
   if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
     for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path4.join(current, entry.name);
+      const candidate = path5.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
@@ -8190,14 +8268,14 @@ function walk(root) {
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path4.join(root, ...patternValue.split("/"));
+    const candidate = path5.join(root, ...patternValue.split("/"));
     return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path4.join(root, ...prefix);
+  const searchRoot = path5.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault, { registryPath } = {}) {
+async function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -8241,7 +8319,7 @@ function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8289,14 +8367,14 @@ function auditVault(vault, { registryPath } = {}) {
     findings.push(...checkFocusView(root, name, view));
   }
   if (!findings.some((item) => item.severity === "error")) {
-    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+    findings.push(...await runDeclaredContentCheck(vault, { registryPath }));
   }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
 import fs6 from "node:fs";
-import path5 from "node:path";
+import path6 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8318,13 +8396,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8354,7 +8432,7 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  const contractPath = path6.join(rootPath, CONTRACT_NAME);
   if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
   if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
@@ -8363,7 +8441,7 @@ function initializeVault(root, { contract, adopt, apply }) {
   if (apply) {
     fs6.mkdirSync(rootPath, { recursive: true });
     fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path5.join(rootPath, "INDEX.md");
+    const indexPath = path6.join(rootPath, "INDEX.md");
     if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
@@ -8429,7 +8507,7 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
@@ -8439,7 +8517,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault, { registryPath: options.registry });
+      const findings2 = await auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }
@@ -8482,7 +8560,7 @@ ${rendered2}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "proactive-durable-capture"])).has(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "maintain-after-material-change"])).has(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!(/* @__PURE__ */ new Set(["git", "none"])).has(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path6.resolve(expandHome(options.positional[0]));
+    const root = path7.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,
@@ -8512,4 +8590,4 @@ ${rendered}`);
 }
 
 // src/knowledge-loom/runner.mjs
-process.exitCode = runCli();
+process.exitCode = await runCli();

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7369,9 +7369,9 @@ var require_dist = __commonJS({
 import path6 from "node:path";
 
 // src/knowledge-loom/audit.mjs
-import fs4 from "node:fs";
-import path3 from "node:path";
-import { spawnSync } from "node:child_process";
+import fs5 from "node:fs";
+import path4 from "node:path";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7580,6 +7580,18 @@ function validateContractData(contract) {
   if (backup.mode === "lifecycle-hook" && !backup.adapter) {
     findings.push(finding("error", "contract.backup-adapter", "lifecycle backup requires `adapter`"));
   }
+  if (Object.hasOwn(contract, "content_checks")) {
+    const contentChecks = mapping(contract, "content_checks", findings);
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+      findings.push(
+        finding(
+          "error",
+          "contract.content-check-adapter",
+          "`content_checks.adapter` must be a kebab-case ID"
+        )
+      );
+    }
+  }
   validatePathValues(contract.instruction_roots, { field: "instruction_roots", findings });
   const navigation = mapping(contract, "navigation", findings);
   validatePathValues(navigation.entrypoints, { field: "navigation.entrypoints", findings, requireNonempty: true });
@@ -7633,8 +7645,409 @@ function validateContractData(contract) {
   return findings;
 }
 
-// src/knowledge-loom/focus.mjs
+// src/knowledge-loom/content-checks.mjs
+import { spawnSync } from "node:child_process";
+
+// src/knowledge-loom/registry.mjs
+var import_yaml2 = __toESM(require_dist(), 1);
+import crypto from "node:crypto";
 import fs3 from "node:fs";
+import os2 from "node:os";
+import path3 from "node:path";
+function defaultRegistryPath() {
+  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
+}
+function loadRegistry(registryPath = defaultRegistryPath()) {
+  const resolved = path3.resolve(expandHome(String(registryPath)));
+  if (!fs3.existsSync(resolved)) return { schema_version: 1, vaults: {} };
+  let data;
+  try {
+    data = import_yaml2.default.parse(fs3.readFileSync(resolved, "utf8")) ?? {};
+  } catch (error) {
+    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
+    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
+  }
+  return data;
+}
+function renderRegistry(data) {
+  return import_yaml2.default.stringify(data, { lineWidth: 0 });
+}
+function atomicWriteText(targetPath, rendered, { rename = fs3.renameSync } = {}) {
+  fs3.mkdirSync(path3.dirname(targetPath), { recursive: true });
+  const temporary = path3.join(path3.dirname(targetPath), `.${path3.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
+  let descriptor;
+  try {
+    const existing = fs3.statSync(targetPath, { throwIfNoEntry: false });
+    descriptor = fs3.openSync(temporary, "wx", existing?.mode & 511 || 384);
+    fs3.writeFileSync(descriptor, rendered, "utf8");
+    fs3.fsyncSync(descriptor);
+    fs3.closeSync(descriptor);
+    descriptor = void 0;
+    rename(temporary, targetPath);
+    try {
+      const directory = fs3.openSync(path3.dirname(targetPath), "r");
+      try {
+        fs3.fsyncSync(directory);
+      } finally {
+        fs3.closeSync(directory);
+      }
+    } catch {
+    }
+  } finally {
+    if (descriptor !== void 0) fs3.closeSync(descriptor);
+    fs3.rmSync(temporary, { force: true });
+  }
+}
+function findAncestorVault(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  while (true) {
+    if (fs3.statSync(path3.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
+    const parent = path3.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+function registeredCandidates(registry) {
+  const candidates = [];
+  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
+    const root = canonicalPath(record.path);
+    if (fs3.statSync(path3.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
+  }
+  return candidates;
+}
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
+}
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path3.relative(root, current);
+    const distance = relative ? relative.split(path3.sep).length : 0;
+    matches.push({ configuredRoot, record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
+function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
+  if (selector !== null && selector !== void 0) {
+    const selectorPath = path3.resolve(expandHome(String(selector)));
+    if (fs3.existsSync(selectorPath)) {
+      const root = fs3.statSync(selectorPath).isDirectory() ? selectorPath : path3.dirname(selectorPath);
+      return loadVault(root);
+    }
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
+    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
+    throw new ResolutionError(`unknown vault selector: ${selector}`);
+  }
+  const ancestor = findAncestorVault(cwd);
+  if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
+  const candidates = registeredCandidates(registry);
+  if (candidates.length === 1) return loadVault(candidates[0][1]);
+  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
+  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
+}
+function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs3.renameSync } = {}) {
+  const vault = loadVault(root);
+  const contractId = vault.contract.vault_id;
+  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  const existing = data.vaults[vaultId];
+  if (existing !== void 0) {
+    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
+    }
+    const existingRoot = canonicalPath(existing.path);
+    if (existingRoot !== vault.root) {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
+    }
+  }
+  data.vaults[vaultId] = { path: vault.root };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered];
+}
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs3.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs3.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
+    if (canonicalPath(expandedRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete projects[configuredRoot];
+  }
+  projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
+
+// src/knowledge-loom/content-checks.mjs
+var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
+var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
+var ADAPTER_TIMEOUT_MS = 3e4;
+var ADAPTER_MAX_BUFFER = 1024 * 1024;
+function adapterFinding(adapterId, code, message, findingPath = null) {
+  return {
+    ...finding("error", `content-check.${code}`, message, findingPath),
+    source: adapterId ? `content-check:${adapterId}` : "content-check"
+  };
+}
+function passedFinding(adapterId, validationDate) {
+  return {
+    severity: "info",
+    code: `content-check.${adapterId}.passed`,
+    message: `content check passed (${validationDate})`,
+    path: null,
+    source: `content-check:${adapterId}`
+  };
+}
+function adapterConfiguration(registry, adapterId) {
+  const adapters = registry.content_check_adapters;
+  if (!adapters || typeof adapters !== "object" || Array.isArray(adapters)) return null;
+  return adapters[adapterId] ?? null;
+}
+function configurationError(adapterId, configuration) {
+  if (!configuration) {
+    return adapterFinding(
+      adapterId,
+      "adapter-missing",
+      `content check adapter \`${adapterId}\` is not configured in the local registry`
+    );
+  }
+  if (typeof configuration !== "object" || Array.isArray(configuration)) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` must be a mapping`
+    );
+  }
+  if (typeof configuration.executable !== "string" || !configuration.executable.trim()) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a non-empty \`executable\``
+    );
+  }
+  if (!Array.isArray(configuration.arguments) || configuration.arguments.some((value) => typeof value !== "string")) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a string \`arguments\` list`
+    );
+  }
+  for (const value of [configuration.executable, ...configuration.arguments]) {
+    const placeholders = value.match(/\{[^}]+\}/g) ?? [];
+    if (placeholders.some((placeholder) => placeholder !== "{vault_root}")) {
+      return adapterFinding(
+        adapterId,
+        "adapter-config",
+        `content check adapter \`${adapterId}\` uses an unsupported placeholder`
+      );
+    }
+  }
+  return null;
+}
+function normalizedResult(adapterId, result, vaultRoot) {
+  const invalid = (message, code = "output") => ({
+    error: adapterFinding(adapterId, code, message)
+  });
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("content checker output must be a JSON object");
+  }
+  if (!Object.hasOwn(STATUS_EXIT_CODES, result.status)) {
+    return invalid("content checker returned an unsupported status");
+  }
+  if (typeof result.root !== "string") {
+    return invalid("content checker output requires `root`");
+  }
+  let resultRoot;
+  try {
+    resultRoot = canonicalPath(result.root);
+  } catch {
+    return invalid("content checker returned an unreadable root", "root");
+  }
+  if (resultRoot !== canonicalPath(vaultRoot)) {
+    return invalid("content checker root does not match the selected vault", "root");
+  }
+  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+    return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
+  }
+  if (!Array.isArray(result.findings)) {
+    return invalid("content checker output requires a `findings` list");
+  }
+  const findings = [];
+  for (const item of result.findings) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+      return invalid("content checker returned an invalid finding");
+    }
+    const normalized = {
+      severity: item.severity,
+      code: `content-check.${adapterId}.${item.code}`,
+      message: item.message,
+      path: item.path ?? null,
+      source: `content-check:${adapterId}`
+    };
+    if (item.line !== void 0) normalized.line = item.line;
+    findings.push(normalized);
+  }
+  const hasError = findings.some((item) => item.severity === "error");
+  if (result.status === "pass" && hasError || result.status !== "pass" && !hasError) {
+    return invalid("content checker status is inconsistent with its findings");
+  }
+  return { status: result.status, validationDate: result.validationDate, findings };
+}
+function runDeclaredContentCheck(vault, {
+  registryPath,
+  timeoutMs = ADAPTER_TIMEOUT_MS,
+  maxBuffer = ADAPTER_MAX_BUFFER
+} = {}) {
+  const adapterId = vault.contract.content_checks?.adapter;
+  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  let registry;
+  try {
+    registry = loadRegistry(registryPath);
+  } catch (error) {
+    return [
+      adapterFinding(
+        adapterId,
+        "registry",
+        `cannot load the local adapter registry: ${error.message}`
+      )
+    ];
+  }
+  const configuration = adapterConfiguration(registry, adapterId);
+  const invalidConfiguration = configurationError(adapterId, configuration);
+  if (invalidConfiguration) return [invalidConfiguration];
+  const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
+  const completed = spawnSync(
+    substitute(configuration.executable),
+    configuration.arguments.map(substitute),
+    {
+      cwd: vault.root,
+      encoding: "utf8",
+      shell: false,
+      timeout: timeoutMs,
+      maxBuffer
+    }
+  );
+  if (completed.error) {
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ${reason}`
+      )
+    ];
+  }
+  if (completed.signal) {
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ended with signal ${completed.signal}`
+      )
+    ];
+  }
+  let result;
+  try {
+    result = JSON.parse(completed.stdout);
+  } catch {
+    return [
+      adapterFinding(
+        adapterId,
+        "output",
+        `content check adapter \`${adapterId}\` did not return valid JSON`
+      )
+    ];
+  }
+  const normalized = normalizedResult(adapterId, result, vault.root);
+  if (normalized.error) return [normalized.error];
+  if (completed.status !== STATUS_EXIT_CODES[normalized.status]) {
+    return [
+      adapterFinding(
+        adapterId,
+        "exit-status",
+        `content check adapter \`${adapterId}\` exit status does not match its result`
+      )
+    ];
+  }
+  return normalized.status === "pass" ? [passedFinding(adapterId, normalized.validationDate), ...normalized.findings] : normalized.findings;
+}
+
+// src/knowledge-loom/focus.mjs
+import fs4 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -7656,12 +8069,12 @@ function checkFocusView(root, name, view) {
   if (typeof relative !== "string") return [];
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs3.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
   if (typeof section !== "string") return [];
-  const items = activeItems(fs3.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top ?? 3;
   const maxActive = view.max_active ?? maxTop;
   if (!Number.isInteger(maxTop) || !Number.isInteger(maxActive)) return [];
@@ -7742,7 +8155,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -7751,7 +8164,7 @@ function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missi
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -7765,28 +8178,28 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs4.existsSync(root)) return result;
+  if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs4.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path3.join(current, entry.name);
+    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path4.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs4.lstatSync(root).isDirectory() && !fs4.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path3.join(root, ...patternValue.split("/"));
-    return fs4.existsSync(candidate) ? [candidate] : [];
+    const candidate = path4.join(root, ...patternValue.split("/"));
+    return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path3.join(root, ...prefix);
+  const searchRoot = path4.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault) {
+function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -7830,7 +8243,7 @@ function auditVault(vault) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs4.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path3.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -7877,12 +8290,15 @@ function auditVault(vault) {
     if (!view || typeof view !== "object" || Array.isArray(view) || typeof view.path !== "string" || !isVaultRelativePath(view.path)) continue;
     findings.push(...checkFocusView(root, name, view));
   }
+  if (!findings.some((item) => item.severity === "error")) {
+    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+  }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
-import fs5 from "node:fs";
-import path4 from "node:path";
+import fs6 from "node:fs";
+import path5 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -7904,13 +8320,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -7940,221 +8356,19 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path4.join(rootPath, CONTRACT_NAME);
-  if (fs5.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs5.existsSync(rootPath) && fs5.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs5.mkdirSync(rootPath, { recursive: true });
-    fs5.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path4.join(rootPath, "INDEX.md");
-    if (!adopt && !fs5.existsSync(indexPath)) fs5.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs6.mkdirSync(rootPath, { recursive: true });
+    fs6.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path5.join(rootPath, "INDEX.md");
+    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
-}
-
-// src/knowledge-loom/registry.mjs
-var import_yaml2 = __toESM(require_dist(), 1);
-import crypto from "node:crypto";
-import fs6 from "node:fs";
-import os2 from "node:os";
-import path5 from "node:path";
-function defaultRegistryPath() {
-  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path5.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path5.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
-}
-function loadRegistry(registryPath = defaultRegistryPath()) {
-  const resolved = path5.resolve(expandHome(String(registryPath)));
-  if (!fs6.existsSync(resolved)) return { schema_version: 1, vaults: {} };
-  let data;
-  try {
-    data = import_yaml2.default.parse(fs6.readFileSync(resolved, "utf8")) ?? {};
-  } catch (error) {
-    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
-  }
-  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
-    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
-  }
-  return data;
-}
-function renderRegistry(data) {
-  return import_yaml2.default.stringify(data, { lineWidth: 0 });
-}
-function atomicWriteText(targetPath, rendered, { rename = fs6.renameSync } = {}) {
-  fs6.mkdirSync(path5.dirname(targetPath), { recursive: true });
-  const temporary = path5.join(path5.dirname(targetPath), `.${path5.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
-  let descriptor;
-  try {
-    const existing = fs6.statSync(targetPath, { throwIfNoEntry: false });
-    descriptor = fs6.openSync(temporary, "wx", existing?.mode & 511 || 384);
-    fs6.writeFileSync(descriptor, rendered, "utf8");
-    fs6.fsyncSync(descriptor);
-    fs6.closeSync(descriptor);
-    descriptor = void 0;
-    rename(temporary, targetPath);
-    try {
-      const directory = fs6.openSync(path5.dirname(targetPath), "r");
-      try {
-        fs6.fsyncSync(directory);
-      } finally {
-        fs6.closeSync(directory);
-      }
-    } catch {
-    }
-  } finally {
-    if (descriptor !== void 0) fs6.closeSync(descriptor);
-    fs6.rmSync(temporary, { force: true });
-  }
-}
-function findAncestorVault(start) {
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  while (true) {
-    if (fs6.statSync(path5.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
-    const parent = path5.dirname(current);
-    if (parent === current) return null;
-    current = parent;
-  }
-}
-function registeredCandidates(registry) {
-  const candidates = [];
-  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
-    const root = canonicalPath(record.path);
-    if (fs6.statSync(path5.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
-  }
-  return candidates;
-}
-function registeredVault(vaultId, registry) {
-  const record = registry.vaults[vaultId];
-  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
-  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
-    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
-  }
-  const vault = loadVault(record.path);
-  if (vault.contract.vault_id !== vaultId) {
-    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
-  }
-  return vault;
-}
-function requireProjectsMapping(projects) {
-  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
-  return projects;
-}
-function projectRecord(configuredRoot, record, { matching = false } = {}) {
-  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
-  }
-  return record;
-}
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  const projects = requireProjectsMapping(registry.projects);
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  const matches = [];
-  for (const [configuredRoot, record] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) continue;
-    const root = canonicalPath(expandedRoot);
-    if (!isWithin(root, current)) continue;
-    const relative = path5.relative(root, current);
-    const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ configuredRoot, record, distance });
-  }
-  if (!matches.length) return null;
-  const nearestDistance = Math.min(...matches.map((match) => match.distance));
-  const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
-  if (vaultIds.size > 1) {
-    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
-  }
-  return nearest[0];
-}
-function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  if (selector !== null && selector !== void 0) {
-    const selectorPath = path5.resolve(expandHome(String(selector)));
-    if (fs6.existsSync(selectorPath)) {
-      const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
-      return loadVault(root);
-    }
-    const registry2 = loadRegistry(registryPath);
-    const record = registry2.vaults[String(selector)];
-    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
-    throw new ResolutionError(`unknown vault selector: ${selector}`);
-  }
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return loadVault(ancestor);
-  const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
-  if (association) return registeredVault(association.record.vault_id, registry);
-  const candidates = registeredCandidates(registry);
-  if (candidates.length === 1) return loadVault(candidates[0][1]);
-  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
-  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
-}
-function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs6.renameSync } = {}) {
-  const vault = loadVault(root);
-  const contractId = vault.contract.vault_id;
-  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  const existing = data.vaults[vaultId];
-  if (existing !== void 0) {
-    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
-    }
-    const existingRoot = canonicalPath(existing.path);
-    if (existingRoot !== vault.root) {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
-    }
-  }
-  data.vaults[vaultId] = { path: vault.root };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered];
-}
-function associateProject(vaultId, projectRoot, {
-  registryPath = defaultRegistryPath(),
-  apply = false,
-  replace = false,
-  rename = fs6.renameSync
-} = {}) {
-  const normalizedVaultId = String(vaultId);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  registeredVault(normalizedVaultId, data);
-  const root = canonicalPath(projectRoot);
-  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
-    throw new ResolutionError(`project path is not an existing directory: ${root}`);
-  }
-  data.projects ??= {};
-  const projects = requireProjectsMapping(data.projects);
-  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) {
-      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
-    }
-    const record = projectRecord(configuredRoot, unvalidatedRecord);
-    if (canonicalPath(expandedRoot) !== root) continue;
-    if (record.vault_id !== normalizedVaultId && !replace) {
-      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
-    }
-    if (configuredRoot !== root) delete projects[configuredRoot];
-  }
-  projects[root] = { vault_id: normalizedVaultId };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered, root];
 }
 
 // src/knowledge-loom/cli.mjs
@@ -8211,7 +8425,7 @@ function formatFindings(findings, { json = false } = {}) {
   if (json) return `${JSON.stringify(findings, null, 2)}
 `;
   if (!findings.length) return "PASS no findings\n";
-  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}]` : ""}: ${item.message}`).join("\n")}
+  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}${item.line ? `:${item.line}` : ""}]` : ""}: ${item.message}`).join("\n")}
 `;
 }
 function requirePositionals(options, count, usage) {
@@ -8227,7 +8441,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault);
+      const findings2 = auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }

--- a/skills/manage-current-focus/SKILL.md
+++ b/skills/manage-current-focus/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: manage-current-focus
 description: Prioritize or update one declared current-focus view in a governed vault. Use to accept, complete, block, defer, or reorder commitments, or reconcile sourced status with current attention.
-compatibility: Requires Node.js 20+ and local file/command access.
 ---
 
 # Manage Current Focus
+
+Requires Node.js 20+ and local file/command access.
 
 Maintain one operational attention view without turning it into a full backlog or silently adding
 parallel work.

--- a/skills/manage-current-focus/references/protocol.md
+++ b/skills/manage-current-focus/references/protocol.md
@@ -83,7 +83,9 @@ one subject's facts to another.
 Before a write, record repository status. Preserve unrelated changes and pre-existing target-file
 hunks. After a write:
 
-1. Validate the affected contract, metadata profile, links, privacy boundary, and focus invariants.
+1. Run the deterministic audit, including any read-only content checker declared by the contract
+   and configured in the local registry. Treat a missing or failed declared checker as incomplete
+   validation; do not run it separately from the audit.
 2. Review the diff.
 3. Stage only task-owned paths or hunks.
 4. Commit only when the contract requires it.
@@ -103,4 +105,6 @@ by the contract.
 - If selection is ambiguous, stop vault work and ask.
 - If a target file has unrelated uncommitted changes that cannot be isolated safely, leave the new
   capture uncommitted and report the conflict.
+- If a declared content checker is missing, invalid, timed out, or failed, preserve the write and
+  report it as saved but not validated.
 - Never imply that retrieval, validation, commit, sync, or backup succeeded when it did not.

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7449,7 +7449,7 @@ function toPosixRelative(root, candidate) {
 
 // src/knowledge-loom/contract.mjs
 var CONTRACT_NAME = "KNOWLEDGE_VAULT.md";
-var VAULT_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var KEBAB_CASE_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 function finding(severity, code, message, findingPath = null) {
   return { severity, code, message, path: findingPath };
 }
@@ -7527,7 +7527,7 @@ function validateContractData(contract) {
   const findings = [];
   if (contract.schema_version !== 1) findings.push(finding("error", "contract.schema-version", "`schema_version` must equal 1"));
   const vaultId = contract.vault_id;
-  if (typeof vaultId !== "string" || !VAULT_ID_RE.test(vaultId)) {
+  if (typeof vaultId !== "string" || !KEBAB_CASE_ID_RE.test(vaultId)) {
     findings.push(finding("error", "contract.vault-id", "`vault_id` must be stable kebab-case"));
   }
   if (typeof contract.title !== "string" || !contract.title.trim()) {
@@ -7582,7 +7582,7 @@ function validateContractData(contract) {
   }
   if (Object.hasOwn(contract, "content_checks")) {
     const contentChecks = mapping(contract, "content_checks", findings);
-    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !KEBAB_CASE_ID_RE.test(contentChecks.adapter))) {
       findings.push(
         finding(
           "error",
@@ -7851,7 +7851,6 @@ function associateProject(vaultId, projectRoot, {
 }
 
 // src/knowledge-loom/content-checks.mjs
-var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -7948,7 +7947,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7969,11 +7968,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
 }
 function runDeclaredContentCheck(vault, {
   registryPath,
-  timeoutMs = ADAPTER_TIMEOUT_MS,
-  maxBuffer = ADAPTER_MAX_BUFFER
+  timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
   const adapterId = vault.contract.content_checks?.adapter;
-  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  if (!adapterId || !KEBAB_CASE_ID_RE.test(adapterId)) return [];
   let registry;
   try {
     registry = loadRegistry(registryPath);
@@ -7998,7 +7996,7 @@ function runDeclaredContentCheck(vault, {
       encoding: "utf8",
       shell: false,
       timeout: timeoutMs,
-      maxBuffer
+      maxBuffer: ADAPTER_MAX_BUFFER
     }
   );
   if (completed.error) {

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path7) {
-      const ctrl = callVisitor(key, node, visitor, path7);
+    function visit_(key, node, visitor, path8) {
+      const ctrl = callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visit_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visit_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path7);
+            const ci = visit_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = visit_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = visit_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path7);
+          const cv = visit_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path7) {
-      const ctrl = await callVisitor(key, node, visitor, path7);
+    async function visitAsync_(key, node, visitor, path8) {
+      const ctrl = await callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visitAsync_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visitAsync_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path7);
+            const ci = await visitAsync_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path7);
+          const cv = await visitAsync_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path7) {
+    function callVisitor(key, node, visitor, path8) {
       if (typeof visitor === "function")
-        return visitor(key, node, path7);
+        return visitor(key, node, path8);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path7);
+        return visitor.Map?.(key, node, path8);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path7);
+        return visitor.Seq?.(key, node, path8);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path7);
+        return visitor.Pair?.(key, node, path8);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path7);
+        return visitor.Scalar?.(key, node, path8);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path7);
+        return visitor.Alias?.(key, node, path8);
       return void 0;
     }
-    function replaceNode(key, path7, node) {
-      const parent = path7[path7.length - 1];
+    function replaceNode(key, path8, node) {
+      const parent = path8[path8.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path7, value) {
+    function collectionFromPath(schema, path8, value) {
       let v = value;
-      for (let i = path7.length - 1; i >= 0; --i) {
-        const k = path7[i];
+      for (let i = path8.length - 1; i >= 0; --i) {
+        const k = path8[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path7) => path7 == null || typeof path7 === "object" && !!path7[Symbol.iterator]().next().done;
+    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path7, value) {
-        if (isEmptyPath(path7))
+      addIn(path8, value) {
+        if (isEmptyPath(path8))
           this.add(value);
         else {
-          const [key, ...rest] = path7;
+          const [key, ...rest] = path8;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        const [key, ...rest] = path7;
+      deleteIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        const [key, ...rest] = path7;
+      getIn(path8, keepScalar) {
+        const [key, ...rest] = path8;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path7) {
-        const [key, ...rest] = path7;
+      hasIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        const [key, ...rest] = path7;
+      setIn(path8, value) {
+        const [key, ...rest] = path8;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path7, value) {
+      addIn(path8, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path7, value);
+          this.contents.addIn(path8, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        if (Collection.isEmptyPath(path7)) {
+      deleteIn(path8) {
+        if (Collection.isEmptyPath(path8)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path7) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        if (Collection.isEmptyPath(path7))
+      getIn(path8, keepScalar) {
+        if (Collection.isEmptyPath(path8))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path7, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path7) {
-        if (Collection.isEmptyPath(path7))
+      hasIn(path8) {
+        if (Collection.isEmptyPath(path8))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path7) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        if (Collection.isEmptyPath(path7)) {
+      setIn(path8, value) {
+        if (Collection.isEmptyPath(path8)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path7), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path7, value);
+          this.contents.setIn(path8, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path7) => {
+    visit.itemAtPath = (cst, path8) => {
       let item = cst;
-      for (const [field, index] of path7) {
+      for (const [field, index] of path8) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path7) => {
-      const parent = visit.itemAtPath(cst, path7.slice(0, -1));
-      const field = path7[path7.length - 1][0];
+    visit.parentCollection = (cst, path8) => {
+      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
+      const field = path8[path8.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path7, item, visitor) {
-      let ctrl = visitor(item, path7);
+    function _visit(path8, item, visitor) {
+      let ctrl = visitor(item, path8);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path7.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path7);
+            ctrl = ctrl(item, path8);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path7) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
     }
     exports.visit = visit;
   }
@@ -7366,12 +7366,12 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.mjs
-import path6 from "node:path";
+import path7 from "node:path";
 
 // src/knowledge-loom/audit.mjs
 import fs5 from "node:fs";
-import path4 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import path5 from "node:path";
+import { spawnSync } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7646,7 +7646,8 @@ function validateContractData(contract) {
 }
 
 // src/knowledge-loom/content-checks.mjs
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import path4 from "node:path";
 
 // src/knowledge-loom/registry.mjs
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7868,8 +7869,14 @@ function passedFinding(adapterId, validationDate) {
     code: `content-check.${adapterId}.passed`,
     message: `content check passed (${validationDate})`,
     path: null,
-    source: `content-check:${adapterId}`
+    source: `content-check:${adapterId}`,
+    validationDate
   };
+}
+function validValidationDate(value) {
+  if (typeof value !== "string" || !VALIDATION_DATE_RE.test(value)) return false;
+  const parsed = /* @__PURE__ */ new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
 }
 function adapterConfiguration(registry, adapterId) {
   const adapters = registry.content_check_adapters;
@@ -7930,16 +7937,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  let resultRoot;
-  try {
-    resultRoot = canonicalPath(result.root);
-  } catch {
-    return invalid("content checker returned an unreadable root", "root");
-  }
-  if (resultRoot !== canonicalPath(vaultRoot)) {
+  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
-  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+  if (!validValidationDate(result.validationDate)) {
     return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
   }
   if (!Array.isArray(result.findings)) {
@@ -7947,7 +7948,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || !Object.hasOwn(item, "path") || item.path !== null && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7955,7 +7956,8 @@ function normalizedResult(adapterId, result, vaultRoot) {
       code: `content-check.${adapterId}.${item.code}`,
       message: item.message,
       path: item.path ?? null,
-      source: `content-check:${adapterId}`
+      source: `content-check:${adapterId}`,
+      validationDate: result.validationDate
     };
     if (item.line !== void 0) normalized.line = item.line;
     findings.push(normalized);
@@ -7966,7 +7968,86 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   return { status: result.status, validationDate: result.validationDate, findings };
 }
-function runDeclaredContentCheck(vault, {
+function killProcessTree(child) {
+  if (!child.pid) return;
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    killer.once("error", () => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    });
+    killer.unref();
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+    }
+  }
+}
+function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(executable, arguments_, {
+        cwd,
+        shell: false,
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true
+      });
+    } catch (error) {
+      resolve({ error });
+      return;
+    }
+    let settled = false;
+    let timer;
+    let stdout = "";
+    let outputBytes = 0;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const terminate = (error) => {
+      killProcessTree(child);
+      child.stdout.destroy();
+      child.stderr.destroy();
+      finish({ error });
+    };
+    const collect = (chunk, { capture = false } = {}) => {
+      outputBytes += Buffer.byteLength(chunk, "utf8");
+      if (outputBytes > ADAPTER_MAX_BUFFER) {
+        const error = new Error("output exceeded the 1 MiB limit");
+        error.code = "ENOBUFS";
+        terminate(error);
+        return;
+      }
+      if (capture) stdout += chunk;
+    };
+    child.once("error", (error) => finish({ error }));
+    child.stdout.on("data", (chunk) => collect(chunk, { capture: true }));
+    child.stderr.on("data", (chunk) => collect(chunk));
+    child.once("close", (status, signal) => finish({ stdout, status, signal }));
+    timer = setTimeout(() => {
+      const error = new Error("timed out");
+      error.code = "ETIMEDOUT";
+      terminate(error);
+    }, timeoutMs);
+  });
+}
+async function runDeclaredContentCheck(vault, {
   registryPath,
   timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
@@ -7988,19 +8069,16 @@ function runDeclaredContentCheck(vault, {
   const invalidConfiguration = configurationError(adapterId, configuration);
   if (invalidConfiguration) return [invalidConfiguration];
   const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
-  const completed = spawnSync(
+  const completed = await executeAdapter(
     substitute(configuration.executable),
     configuration.arguments.map(substitute),
     {
       cwd: vault.root,
-      encoding: "utf8",
-      shell: false,
-      timeout: timeoutMs,
-      maxBuffer: ADAPTER_MAX_BUFFER
+      timeoutMs
     }
   );
   if (completed.error) {
-    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : completed.error.code === "ENOBUFS" ? "exceeded the 1 MiB output limit" : `could not start: ${completed.error.message}`;
     return [
       adapterFinding(
         adapterId,
@@ -8153,7 +8231,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -8179,7 +8257,7 @@ function walk(root) {
   if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
     for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path4.join(current, entry.name);
+      const candidate = path5.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
@@ -8190,14 +8268,14 @@ function walk(root) {
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path4.join(root, ...patternValue.split("/"));
+    const candidate = path5.join(root, ...patternValue.split("/"));
     return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path4.join(root, ...prefix);
+  const searchRoot = path5.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault, { registryPath } = {}) {
+async function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -8241,7 +8319,7 @@ function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8289,14 +8367,14 @@ function auditVault(vault, { registryPath } = {}) {
     findings.push(...checkFocusView(root, name, view));
   }
   if (!findings.some((item) => item.severity === "error")) {
-    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+    findings.push(...await runDeclaredContentCheck(vault, { registryPath }));
   }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
 import fs6 from "node:fs";
-import path5 from "node:path";
+import path6 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8318,13 +8396,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8354,7 +8432,7 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  const contractPath = path6.join(rootPath, CONTRACT_NAME);
   if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
   if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
@@ -8363,7 +8441,7 @@ function initializeVault(root, { contract, adopt, apply }) {
   if (apply) {
     fs6.mkdirSync(rootPath, { recursive: true });
     fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path5.join(rootPath, "INDEX.md");
+    const indexPath = path6.join(rootPath, "INDEX.md");
     if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
@@ -8429,7 +8507,7 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
@@ -8439,7 +8517,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault, { registryPath: options.registry });
+      const findings2 = await auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }
@@ -8482,7 +8560,7 @@ ${rendered2}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "proactive-durable-capture"])).has(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "maintain-after-material-change"])).has(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!(/* @__PURE__ */ new Set(["git", "none"])).has(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path6.resolve(expandHome(options.positional[0]));
+    const root = path7.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,
@@ -8512,4 +8590,4 @@ ${rendered}`);
 }
 
 // src/knowledge-loom/runner.mjs
-process.exitCode = runCli();
+process.exitCode = await runCli();

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7369,9 +7369,9 @@ var require_dist = __commonJS({
 import path6 from "node:path";
 
 // src/knowledge-loom/audit.mjs
-import fs4 from "node:fs";
-import path3 from "node:path";
-import { spawnSync } from "node:child_process";
+import fs5 from "node:fs";
+import path4 from "node:path";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7580,6 +7580,18 @@ function validateContractData(contract) {
   if (backup.mode === "lifecycle-hook" && !backup.adapter) {
     findings.push(finding("error", "contract.backup-adapter", "lifecycle backup requires `adapter`"));
   }
+  if (Object.hasOwn(contract, "content_checks")) {
+    const contentChecks = mapping(contract, "content_checks", findings);
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+      findings.push(
+        finding(
+          "error",
+          "contract.content-check-adapter",
+          "`content_checks.adapter` must be a kebab-case ID"
+        )
+      );
+    }
+  }
   validatePathValues(contract.instruction_roots, { field: "instruction_roots", findings });
   const navigation = mapping(contract, "navigation", findings);
   validatePathValues(navigation.entrypoints, { field: "navigation.entrypoints", findings, requireNonempty: true });
@@ -7633,8 +7645,409 @@ function validateContractData(contract) {
   return findings;
 }
 
-// src/knowledge-loom/focus.mjs
+// src/knowledge-loom/content-checks.mjs
+import { spawnSync } from "node:child_process";
+
+// src/knowledge-loom/registry.mjs
+var import_yaml2 = __toESM(require_dist(), 1);
+import crypto from "node:crypto";
 import fs3 from "node:fs";
+import os2 from "node:os";
+import path3 from "node:path";
+function defaultRegistryPath() {
+  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
+}
+function loadRegistry(registryPath = defaultRegistryPath()) {
+  const resolved = path3.resolve(expandHome(String(registryPath)));
+  if (!fs3.existsSync(resolved)) return { schema_version: 1, vaults: {} };
+  let data;
+  try {
+    data = import_yaml2.default.parse(fs3.readFileSync(resolved, "utf8")) ?? {};
+  } catch (error) {
+    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
+    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
+  }
+  return data;
+}
+function renderRegistry(data) {
+  return import_yaml2.default.stringify(data, { lineWidth: 0 });
+}
+function atomicWriteText(targetPath, rendered, { rename = fs3.renameSync } = {}) {
+  fs3.mkdirSync(path3.dirname(targetPath), { recursive: true });
+  const temporary = path3.join(path3.dirname(targetPath), `.${path3.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
+  let descriptor;
+  try {
+    const existing = fs3.statSync(targetPath, { throwIfNoEntry: false });
+    descriptor = fs3.openSync(temporary, "wx", existing?.mode & 511 || 384);
+    fs3.writeFileSync(descriptor, rendered, "utf8");
+    fs3.fsyncSync(descriptor);
+    fs3.closeSync(descriptor);
+    descriptor = void 0;
+    rename(temporary, targetPath);
+    try {
+      const directory = fs3.openSync(path3.dirname(targetPath), "r");
+      try {
+        fs3.fsyncSync(directory);
+      } finally {
+        fs3.closeSync(directory);
+      }
+    } catch {
+    }
+  } finally {
+    if (descriptor !== void 0) fs3.closeSync(descriptor);
+    fs3.rmSync(temporary, { force: true });
+  }
+}
+function findAncestorVault(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  while (true) {
+    if (fs3.statSync(path3.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
+    const parent = path3.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+function registeredCandidates(registry) {
+  const candidates = [];
+  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
+    const root = canonicalPath(record.path);
+    if (fs3.statSync(path3.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
+  }
+  return candidates;
+}
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
+}
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path3.relative(root, current);
+    const distance = relative ? relative.split(path3.sep).length : 0;
+    matches.push({ configuredRoot, record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
+function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
+  if (selector !== null && selector !== void 0) {
+    const selectorPath = path3.resolve(expandHome(String(selector)));
+    if (fs3.existsSync(selectorPath)) {
+      const root = fs3.statSync(selectorPath).isDirectory() ? selectorPath : path3.dirname(selectorPath);
+      return loadVault(root);
+    }
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
+    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
+    throw new ResolutionError(`unknown vault selector: ${selector}`);
+  }
+  const ancestor = findAncestorVault(cwd);
+  if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
+  const candidates = registeredCandidates(registry);
+  if (candidates.length === 1) return loadVault(candidates[0][1]);
+  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
+  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
+}
+function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs3.renameSync } = {}) {
+  const vault = loadVault(root);
+  const contractId = vault.contract.vault_id;
+  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  const existing = data.vaults[vaultId];
+  if (existing !== void 0) {
+    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
+    }
+    const existingRoot = canonicalPath(existing.path);
+    if (existingRoot !== vault.root) {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
+    }
+  }
+  data.vaults[vaultId] = { path: vault.root };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered];
+}
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs3.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs3.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
+    if (canonicalPath(expandedRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete projects[configuredRoot];
+  }
+  projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
+
+// src/knowledge-loom/content-checks.mjs
+var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
+var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
+var ADAPTER_TIMEOUT_MS = 3e4;
+var ADAPTER_MAX_BUFFER = 1024 * 1024;
+function adapterFinding(adapterId, code, message, findingPath = null) {
+  return {
+    ...finding("error", `content-check.${code}`, message, findingPath),
+    source: adapterId ? `content-check:${adapterId}` : "content-check"
+  };
+}
+function passedFinding(adapterId, validationDate) {
+  return {
+    severity: "info",
+    code: `content-check.${adapterId}.passed`,
+    message: `content check passed (${validationDate})`,
+    path: null,
+    source: `content-check:${adapterId}`
+  };
+}
+function adapterConfiguration(registry, adapterId) {
+  const adapters = registry.content_check_adapters;
+  if (!adapters || typeof adapters !== "object" || Array.isArray(adapters)) return null;
+  return adapters[adapterId] ?? null;
+}
+function configurationError(adapterId, configuration) {
+  if (!configuration) {
+    return adapterFinding(
+      adapterId,
+      "adapter-missing",
+      `content check adapter \`${adapterId}\` is not configured in the local registry`
+    );
+  }
+  if (typeof configuration !== "object" || Array.isArray(configuration)) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` must be a mapping`
+    );
+  }
+  if (typeof configuration.executable !== "string" || !configuration.executable.trim()) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a non-empty \`executable\``
+    );
+  }
+  if (!Array.isArray(configuration.arguments) || configuration.arguments.some((value) => typeof value !== "string")) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a string \`arguments\` list`
+    );
+  }
+  for (const value of [configuration.executable, ...configuration.arguments]) {
+    const placeholders = value.match(/\{[^}]+\}/g) ?? [];
+    if (placeholders.some((placeholder) => placeholder !== "{vault_root}")) {
+      return adapterFinding(
+        adapterId,
+        "adapter-config",
+        `content check adapter \`${adapterId}\` uses an unsupported placeholder`
+      );
+    }
+  }
+  return null;
+}
+function normalizedResult(adapterId, result, vaultRoot) {
+  const invalid = (message, code = "output") => ({
+    error: adapterFinding(adapterId, code, message)
+  });
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("content checker output must be a JSON object");
+  }
+  if (!Object.hasOwn(STATUS_EXIT_CODES, result.status)) {
+    return invalid("content checker returned an unsupported status");
+  }
+  if (typeof result.root !== "string") {
+    return invalid("content checker output requires `root`");
+  }
+  let resultRoot;
+  try {
+    resultRoot = canonicalPath(result.root);
+  } catch {
+    return invalid("content checker returned an unreadable root", "root");
+  }
+  if (resultRoot !== canonicalPath(vaultRoot)) {
+    return invalid("content checker root does not match the selected vault", "root");
+  }
+  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+    return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
+  }
+  if (!Array.isArray(result.findings)) {
+    return invalid("content checker output requires a `findings` list");
+  }
+  const findings = [];
+  for (const item of result.findings) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+      return invalid("content checker returned an invalid finding");
+    }
+    const normalized = {
+      severity: item.severity,
+      code: `content-check.${adapterId}.${item.code}`,
+      message: item.message,
+      path: item.path ?? null,
+      source: `content-check:${adapterId}`
+    };
+    if (item.line !== void 0) normalized.line = item.line;
+    findings.push(normalized);
+  }
+  const hasError = findings.some((item) => item.severity === "error");
+  if (result.status === "pass" && hasError || result.status !== "pass" && !hasError) {
+    return invalid("content checker status is inconsistent with its findings");
+  }
+  return { status: result.status, validationDate: result.validationDate, findings };
+}
+function runDeclaredContentCheck(vault, {
+  registryPath,
+  timeoutMs = ADAPTER_TIMEOUT_MS,
+  maxBuffer = ADAPTER_MAX_BUFFER
+} = {}) {
+  const adapterId = vault.contract.content_checks?.adapter;
+  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  let registry;
+  try {
+    registry = loadRegistry(registryPath);
+  } catch (error) {
+    return [
+      adapterFinding(
+        adapterId,
+        "registry",
+        `cannot load the local adapter registry: ${error.message}`
+      )
+    ];
+  }
+  const configuration = adapterConfiguration(registry, adapterId);
+  const invalidConfiguration = configurationError(adapterId, configuration);
+  if (invalidConfiguration) return [invalidConfiguration];
+  const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
+  const completed = spawnSync(
+    substitute(configuration.executable),
+    configuration.arguments.map(substitute),
+    {
+      cwd: vault.root,
+      encoding: "utf8",
+      shell: false,
+      timeout: timeoutMs,
+      maxBuffer
+    }
+  );
+  if (completed.error) {
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ${reason}`
+      )
+    ];
+  }
+  if (completed.signal) {
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ended with signal ${completed.signal}`
+      )
+    ];
+  }
+  let result;
+  try {
+    result = JSON.parse(completed.stdout);
+  } catch {
+    return [
+      adapterFinding(
+        adapterId,
+        "output",
+        `content check adapter \`${adapterId}\` did not return valid JSON`
+      )
+    ];
+  }
+  const normalized = normalizedResult(adapterId, result, vault.root);
+  if (normalized.error) return [normalized.error];
+  if (completed.status !== STATUS_EXIT_CODES[normalized.status]) {
+    return [
+      adapterFinding(
+        adapterId,
+        "exit-status",
+        `content check adapter \`${adapterId}\` exit status does not match its result`
+      )
+    ];
+  }
+  return normalized.status === "pass" ? [passedFinding(adapterId, normalized.validationDate), ...normalized.findings] : normalized.findings;
+}
+
+// src/knowledge-loom/focus.mjs
+import fs4 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -7656,12 +8069,12 @@ function checkFocusView(root, name, view) {
   if (typeof relative !== "string") return [];
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs3.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
   if (typeof section !== "string") return [];
-  const items = activeItems(fs3.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top ?? 3;
   const maxActive = view.max_active ?? maxTop;
   if (!Number.isInteger(maxTop) || !Number.isInteger(maxActive)) return [];
@@ -7742,7 +8155,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -7751,7 +8164,7 @@ function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missi
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -7765,28 +8178,28 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs4.existsSync(root)) return result;
+  if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs4.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path3.join(current, entry.name);
+    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path4.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs4.lstatSync(root).isDirectory() && !fs4.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path3.join(root, ...patternValue.split("/"));
-    return fs4.existsSync(candidate) ? [candidate] : [];
+    const candidate = path4.join(root, ...patternValue.split("/"));
+    return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path3.join(root, ...prefix);
+  const searchRoot = path4.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault) {
+function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -7830,7 +8243,7 @@ function auditVault(vault) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs4.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path3.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -7877,12 +8290,15 @@ function auditVault(vault) {
     if (!view || typeof view !== "object" || Array.isArray(view) || typeof view.path !== "string" || !isVaultRelativePath(view.path)) continue;
     findings.push(...checkFocusView(root, name, view));
   }
+  if (!findings.some((item) => item.severity === "error")) {
+    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+  }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
-import fs5 from "node:fs";
-import path4 from "node:path";
+import fs6 from "node:fs";
+import path5 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -7904,13 +8320,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -7940,221 +8356,19 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path4.join(rootPath, CONTRACT_NAME);
-  if (fs5.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs5.existsSync(rootPath) && fs5.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs5.mkdirSync(rootPath, { recursive: true });
-    fs5.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path4.join(rootPath, "INDEX.md");
-    if (!adopt && !fs5.existsSync(indexPath)) fs5.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs6.mkdirSync(rootPath, { recursive: true });
+    fs6.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path5.join(rootPath, "INDEX.md");
+    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
-}
-
-// src/knowledge-loom/registry.mjs
-var import_yaml2 = __toESM(require_dist(), 1);
-import crypto from "node:crypto";
-import fs6 from "node:fs";
-import os2 from "node:os";
-import path5 from "node:path";
-function defaultRegistryPath() {
-  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path5.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path5.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
-}
-function loadRegistry(registryPath = defaultRegistryPath()) {
-  const resolved = path5.resolve(expandHome(String(registryPath)));
-  if (!fs6.existsSync(resolved)) return { schema_version: 1, vaults: {} };
-  let data;
-  try {
-    data = import_yaml2.default.parse(fs6.readFileSync(resolved, "utf8")) ?? {};
-  } catch (error) {
-    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
-  }
-  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
-    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
-  }
-  return data;
-}
-function renderRegistry(data) {
-  return import_yaml2.default.stringify(data, { lineWidth: 0 });
-}
-function atomicWriteText(targetPath, rendered, { rename = fs6.renameSync } = {}) {
-  fs6.mkdirSync(path5.dirname(targetPath), { recursive: true });
-  const temporary = path5.join(path5.dirname(targetPath), `.${path5.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
-  let descriptor;
-  try {
-    const existing = fs6.statSync(targetPath, { throwIfNoEntry: false });
-    descriptor = fs6.openSync(temporary, "wx", existing?.mode & 511 || 384);
-    fs6.writeFileSync(descriptor, rendered, "utf8");
-    fs6.fsyncSync(descriptor);
-    fs6.closeSync(descriptor);
-    descriptor = void 0;
-    rename(temporary, targetPath);
-    try {
-      const directory = fs6.openSync(path5.dirname(targetPath), "r");
-      try {
-        fs6.fsyncSync(directory);
-      } finally {
-        fs6.closeSync(directory);
-      }
-    } catch {
-    }
-  } finally {
-    if (descriptor !== void 0) fs6.closeSync(descriptor);
-    fs6.rmSync(temporary, { force: true });
-  }
-}
-function findAncestorVault(start) {
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  while (true) {
-    if (fs6.statSync(path5.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
-    const parent = path5.dirname(current);
-    if (parent === current) return null;
-    current = parent;
-  }
-}
-function registeredCandidates(registry) {
-  const candidates = [];
-  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
-    const root = canonicalPath(record.path);
-    if (fs6.statSync(path5.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
-  }
-  return candidates;
-}
-function registeredVault(vaultId, registry) {
-  const record = registry.vaults[vaultId];
-  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
-  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
-    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
-  }
-  const vault = loadVault(record.path);
-  if (vault.contract.vault_id !== vaultId) {
-    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
-  }
-  return vault;
-}
-function requireProjectsMapping(projects) {
-  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
-  return projects;
-}
-function projectRecord(configuredRoot, record, { matching = false } = {}) {
-  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
-  }
-  return record;
-}
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  const projects = requireProjectsMapping(registry.projects);
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  const matches = [];
-  for (const [configuredRoot, record] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) continue;
-    const root = canonicalPath(expandedRoot);
-    if (!isWithin(root, current)) continue;
-    const relative = path5.relative(root, current);
-    const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ configuredRoot, record, distance });
-  }
-  if (!matches.length) return null;
-  const nearestDistance = Math.min(...matches.map((match) => match.distance));
-  const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
-  if (vaultIds.size > 1) {
-    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
-  }
-  return nearest[0];
-}
-function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  if (selector !== null && selector !== void 0) {
-    const selectorPath = path5.resolve(expandHome(String(selector)));
-    if (fs6.existsSync(selectorPath)) {
-      const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
-      return loadVault(root);
-    }
-    const registry2 = loadRegistry(registryPath);
-    const record = registry2.vaults[String(selector)];
-    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
-    throw new ResolutionError(`unknown vault selector: ${selector}`);
-  }
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return loadVault(ancestor);
-  const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
-  if (association) return registeredVault(association.record.vault_id, registry);
-  const candidates = registeredCandidates(registry);
-  if (candidates.length === 1) return loadVault(candidates[0][1]);
-  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
-  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
-}
-function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs6.renameSync } = {}) {
-  const vault = loadVault(root);
-  const contractId = vault.contract.vault_id;
-  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  const existing = data.vaults[vaultId];
-  if (existing !== void 0) {
-    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
-    }
-    const existingRoot = canonicalPath(existing.path);
-    if (existingRoot !== vault.root) {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
-    }
-  }
-  data.vaults[vaultId] = { path: vault.root };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered];
-}
-function associateProject(vaultId, projectRoot, {
-  registryPath = defaultRegistryPath(),
-  apply = false,
-  replace = false,
-  rename = fs6.renameSync
-} = {}) {
-  const normalizedVaultId = String(vaultId);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  registeredVault(normalizedVaultId, data);
-  const root = canonicalPath(projectRoot);
-  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
-    throw new ResolutionError(`project path is not an existing directory: ${root}`);
-  }
-  data.projects ??= {};
-  const projects = requireProjectsMapping(data.projects);
-  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) {
-      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
-    }
-    const record = projectRecord(configuredRoot, unvalidatedRecord);
-    if (canonicalPath(expandedRoot) !== root) continue;
-    if (record.vault_id !== normalizedVaultId && !replace) {
-      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
-    }
-    if (configuredRoot !== root) delete projects[configuredRoot];
-  }
-  projects[root] = { vault_id: normalizedVaultId };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered, root];
 }
 
 // src/knowledge-loom/cli.mjs
@@ -8211,7 +8425,7 @@ function formatFindings(findings, { json = false } = {}) {
   if (json) return `${JSON.stringify(findings, null, 2)}
 `;
   if (!findings.length) return "PASS no findings\n";
-  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}]` : ""}: ${item.message}`).join("\n")}
+  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}${item.line ? `:${item.line}` : ""}]` : ""}: ${item.message}`).join("\n")}
 `;
 }
 function requirePositionals(options, count, usage) {
@@ -8227,7 +8441,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault);
+      const findings2 = auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }

--- a/skills/use-knowledge-vault/SKILL.md
+++ b/skills/use-knowledge-vault/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: use-knowledge-vault
 description: Retrieve targeted context from one governed Markdown vault and perform authorized durable capture. Use when a vault contract or wrapper is in scope, or the user asks to consult, remember, update, or sync vault knowledge.
-compatibility: Requires Node.js 20+ and local file/command access.
 ---
 
 # Use Knowledge Vault
+
+Requires Node.js 20+ and local file/command access.
 
 Execute the Knowledge Vault Protocol for one selected vault while keeping the primary task first.
 Limit actions to the primary task and contract-authorized vault operations.
@@ -33,8 +34,11 @@ policy, lifecycle, and failure behavior.
    node "<skill-root>/scripts/knowledge-loom.mjs" audit <vault-path>
    ```
 
-   The write branch is complete only after the audit result and every required Git, sync, and backup
-   state are known. Preserve a valid partial result when a later lifecycle step fails.
+   This single audit includes any read-only content checker declared by the contract and configured
+   in the local registry; do not invoke that checker separately. Pass the same non-default registry
+   path used during resolution. The write branch is complete only after the combined audit result
+   and every required Git, sync, and backup state are known. Preserve a valid partial result when a
+   later lifecycle step fails.
 
 ## Report
 

--- a/skills/use-knowledge-vault/references/protocol.md
+++ b/skills/use-knowledge-vault/references/protocol.md
@@ -83,7 +83,9 @@ one subject's facts to another.
 Before a write, record repository status. Preserve unrelated changes and pre-existing target-file
 hunks. After a write:
 
-1. Validate the affected contract, metadata profile, links, privacy boundary, and focus invariants.
+1. Run the deterministic audit, including any read-only content checker declared by the contract
+   and configured in the local registry. Treat a missing or failed declared checker as incomplete
+   validation; do not run it separately from the audit.
 2. Review the diff.
 3. Stage only task-owned paths or hunks.
 4. Commit only when the contract requires it.
@@ -103,4 +105,6 @@ by the contract.
 - If selection is ambiguous, stop vault work and ask.
 - If a target file has unrelated uncommitted changes that cannot be isolated safely, leave the new
   capture uncommitted and report the conflict.
+- If a declared content checker is missing, invalid, timed out, or failed, preserve the write and
+  report it as saved but not validated.
 - Never imply that retrieval, validation, commit, sync, or backup succeeded when it did not.

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7449,7 +7449,7 @@ function toPosixRelative(root, candidate) {
 
 // src/knowledge-loom/contract.mjs
 var CONTRACT_NAME = "KNOWLEDGE_VAULT.md";
-var VAULT_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var KEBAB_CASE_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 function finding(severity, code, message, findingPath = null) {
   return { severity, code, message, path: findingPath };
 }
@@ -7527,7 +7527,7 @@ function validateContractData(contract) {
   const findings = [];
   if (contract.schema_version !== 1) findings.push(finding("error", "contract.schema-version", "`schema_version` must equal 1"));
   const vaultId = contract.vault_id;
-  if (typeof vaultId !== "string" || !VAULT_ID_RE.test(vaultId)) {
+  if (typeof vaultId !== "string" || !KEBAB_CASE_ID_RE.test(vaultId)) {
     findings.push(finding("error", "contract.vault-id", "`vault_id` must be stable kebab-case"));
   }
   if (typeof contract.title !== "string" || !contract.title.trim()) {
@@ -7582,7 +7582,7 @@ function validateContractData(contract) {
   }
   if (Object.hasOwn(contract, "content_checks")) {
     const contentChecks = mapping(contract, "content_checks", findings);
-    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !KEBAB_CASE_ID_RE.test(contentChecks.adapter))) {
       findings.push(
         finding(
           "error",
@@ -7851,7 +7851,6 @@ function associateProject(vaultId, projectRoot, {
 }
 
 // src/knowledge-loom/content-checks.mjs
-var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -7948,7 +7947,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7969,11 +7968,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
 }
 function runDeclaredContentCheck(vault, {
   registryPath,
-  timeoutMs = ADAPTER_TIMEOUT_MS,
-  maxBuffer = ADAPTER_MAX_BUFFER
+  timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
   const adapterId = vault.contract.content_checks?.adapter;
-  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  if (!adapterId || !KEBAB_CASE_ID_RE.test(adapterId)) return [];
   let registry;
   try {
     registry = loadRegistry(registryPath);
@@ -7998,7 +7996,7 @@ function runDeclaredContentCheck(vault, {
       encoding: "utf8",
       shell: false,
       timeout: timeoutMs,
-      maxBuffer
+      maxBuffer: ADAPTER_MAX_BUFFER
     }
   );
   if (completed.error) {

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path7) {
-      const ctrl = callVisitor(key, node, visitor, path7);
+    function visit_(key, node, visitor, path8) {
+      const ctrl = callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visit_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visit_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path7);
+            const ci = visit_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = visit_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = visit_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path7);
+          const cv = visit_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path7) {
-      const ctrl = await callVisitor(key, node, visitor, path7);
+    async function visitAsync_(key, node, visitor, path8) {
+      const ctrl = await callVisitor(key, node, visitor, path8);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path7, ctrl);
-        return visitAsync_(key, ctrl, visitor, path7);
+        replaceNode(key, path8, ctrl);
+        return visitAsync_(key, ctrl, visitor, path8);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path7 = Object.freeze(path7.concat(node));
+          path8 = Object.freeze(path8.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path7);
+            const ci = await visitAsync_(i, node.items[i], visitor, path8);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path7 = Object.freeze(path7.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path7);
+          path8 = Object.freeze(path8.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path8);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path7);
+          const cv = await visitAsync_("value", node.value, visitor, path8);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path7) {
+    function callVisitor(key, node, visitor, path8) {
       if (typeof visitor === "function")
-        return visitor(key, node, path7);
+        return visitor(key, node, path8);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path7);
+        return visitor.Map?.(key, node, path8);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path7);
+        return visitor.Seq?.(key, node, path8);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path7);
+        return visitor.Pair?.(key, node, path8);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path7);
+        return visitor.Scalar?.(key, node, path8);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path7);
+        return visitor.Alias?.(key, node, path8);
       return void 0;
     }
-    function replaceNode(key, path7, node) {
-      const parent = path7[path7.length - 1];
+    function replaceNode(key, path8, node) {
+      const parent = path8[path8.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path7, value) {
+    function collectionFromPath(schema, path8, value) {
       let v = value;
-      for (let i = path7.length - 1; i >= 0; --i) {
-        const k = path7[i];
+      for (let i = path8.length - 1; i >= 0; --i) {
+        const k = path8[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path7) => path7 == null || typeof path7 === "object" && !!path7[Symbol.iterator]().next().done;
+    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path7, value) {
-        if (isEmptyPath(path7))
+      addIn(path8, value) {
+        if (isEmptyPath(path8))
           this.add(value);
         else {
-          const [key, ...rest] = path7;
+          const [key, ...rest] = path8;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        const [key, ...rest] = path7;
+      deleteIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        const [key, ...rest] = path7;
+      getIn(path8, keepScalar) {
+        const [key, ...rest] = path8;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path7) {
-        const [key, ...rest] = path7;
+      hasIn(path8) {
+        const [key, ...rest] = path8;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        const [key, ...rest] = path7;
+      setIn(path8, value) {
+        const [key, ...rest] = path8;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path7, value) {
+      addIn(path8, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path7, value);
+          this.contents.addIn(path8, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path7) {
-        if (Collection.isEmptyPath(path7)) {
+      deleteIn(path8) {
+        if (Collection.isEmptyPath(path8)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path7) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path7, keepScalar) {
-        if (Collection.isEmptyPath(path7))
+      getIn(path8, keepScalar) {
+        if (Collection.isEmptyPath(path8))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path7, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path7) {
-        if (Collection.isEmptyPath(path7))
+      hasIn(path8) {
+        if (Collection.isEmptyPath(path8))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path7) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path7, value) {
-        if (Collection.isEmptyPath(path7)) {
+      setIn(path8, value) {
+        if (Collection.isEmptyPath(path8)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path7), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path7, value);
+          this.contents.setIn(path8, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path7) => {
+    visit.itemAtPath = (cst, path8) => {
       let item = cst;
-      for (const [field, index] of path7) {
+      for (const [field, index] of path8) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path7) => {
-      const parent = visit.itemAtPath(cst, path7.slice(0, -1));
-      const field = path7[path7.length - 1][0];
+    visit.parentCollection = (cst, path8) => {
+      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
+      const field = path8[path8.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path7, item, visitor) {
-      let ctrl = visitor(item, path7);
+    function _visit(path8, item, visitor) {
+      let ctrl = visitor(item, path8);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path7.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path7);
+            ctrl = ctrl(item, path8);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path7) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
     }
     exports.visit = visit;
   }
@@ -7366,12 +7366,12 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.mjs
-import path6 from "node:path";
+import path7 from "node:path";
 
 // src/knowledge-loom/audit.mjs
 import fs5 from "node:fs";
-import path4 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import path5 from "node:path";
+import { spawnSync } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7646,7 +7646,8 @@ function validateContractData(contract) {
 }
 
 // src/knowledge-loom/content-checks.mjs
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import path4 from "node:path";
 
 // src/knowledge-loom/registry.mjs
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7868,8 +7869,14 @@ function passedFinding(adapterId, validationDate) {
     code: `content-check.${adapterId}.passed`,
     message: `content check passed (${validationDate})`,
     path: null,
-    source: `content-check:${adapterId}`
+    source: `content-check:${adapterId}`,
+    validationDate
   };
+}
+function validValidationDate(value) {
+  if (typeof value !== "string" || !VALIDATION_DATE_RE.test(value)) return false;
+  const parsed = /* @__PURE__ */ new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
 }
 function adapterConfiguration(registry, adapterId) {
   const adapters = registry.content_check_adapters;
@@ -7930,16 +7937,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  let resultRoot;
-  try {
-    resultRoot = canonicalPath(result.root);
-  } catch {
-    return invalid("content checker returned an unreadable root", "root");
-  }
-  if (resultRoot !== canonicalPath(vaultRoot)) {
+  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
-  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+  if (!validValidationDate(result.validationDate)) {
     return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
   }
   if (!Array.isArray(result.findings)) {
@@ -7947,7 +7948,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   const findings = [];
   for (const item of result.findings) {
-    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || !Object.hasOwn(item, "path") || item.path !== null && (typeof item.path !== "string" || !isVaultRelativePath(item.path) || !resolveVaultPath(vaultRoot, item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
       return invalid("content checker returned an invalid finding");
     }
     const normalized = {
@@ -7955,7 +7956,8 @@ function normalizedResult(adapterId, result, vaultRoot) {
       code: `content-check.${adapterId}.${item.code}`,
       message: item.message,
       path: item.path ?? null,
-      source: `content-check:${adapterId}`
+      source: `content-check:${adapterId}`,
+      validationDate: result.validationDate
     };
     if (item.line !== void 0) normalized.line = item.line;
     findings.push(normalized);
@@ -7966,7 +7968,86 @@ function normalizedResult(adapterId, result, vaultRoot) {
   }
   return { status: result.status, validationDate: result.validationDate, findings };
 }
-function runDeclaredContentCheck(vault, {
+function killProcessTree(child) {
+  if (!child.pid) return;
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true
+    });
+    killer.once("error", () => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+      }
+    });
+    killer.unref();
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+    }
+  }
+}
+function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(executable, arguments_, {
+        cwd,
+        shell: false,
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true
+      });
+    } catch (error) {
+      resolve({ error });
+      return;
+    }
+    let settled = false;
+    let timer;
+    let stdout = "";
+    let outputBytes = 0;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const terminate = (error) => {
+      killProcessTree(child);
+      child.stdout.destroy();
+      child.stderr.destroy();
+      finish({ error });
+    };
+    const collect = (chunk, { capture = false } = {}) => {
+      outputBytes += Buffer.byteLength(chunk, "utf8");
+      if (outputBytes > ADAPTER_MAX_BUFFER) {
+        const error = new Error("output exceeded the 1 MiB limit");
+        error.code = "ENOBUFS";
+        terminate(error);
+        return;
+      }
+      if (capture) stdout += chunk;
+    };
+    child.once("error", (error) => finish({ error }));
+    child.stdout.on("data", (chunk) => collect(chunk, { capture: true }));
+    child.stderr.on("data", (chunk) => collect(chunk));
+    child.once("close", (status, signal) => finish({ stdout, status, signal }));
+    timer = setTimeout(() => {
+      const error = new Error("timed out");
+      error.code = "ETIMEDOUT";
+      terminate(error);
+    }, timeoutMs);
+  });
+}
+async function runDeclaredContentCheck(vault, {
   registryPath,
   timeoutMs = ADAPTER_TIMEOUT_MS
 } = {}) {
@@ -7988,19 +8069,16 @@ function runDeclaredContentCheck(vault, {
   const invalidConfiguration = configurationError(adapterId, configuration);
   if (invalidConfiguration) return [invalidConfiguration];
   const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
-  const completed = spawnSync(
+  const completed = await executeAdapter(
     substitute(configuration.executable),
     configuration.arguments.map(substitute),
     {
       cwd: vault.root,
-      encoding: "utf8",
-      shell: false,
-      timeout: timeoutMs,
-      maxBuffer: ADAPTER_MAX_BUFFER
+      timeoutMs
     }
   );
   if (completed.error) {
-    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : completed.error.code === "ENOBUFS" ? "exceeded the 1 MiB output limit" : `could not start: ${completed.error.message}`;
     return [
       adapterFinding(
         adapterId,
@@ -8153,7 +8231,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -8179,7 +8257,7 @@ function walk(root) {
   if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
     for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path4.join(current, entry.name);
+      const candidate = path5.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
@@ -8190,14 +8268,14 @@ function walk(root) {
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path4.join(root, ...patternValue.split("/"));
+    const candidate = path5.join(root, ...patternValue.split("/"));
     return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path4.join(root, ...prefix);
+  const searchRoot = path5.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault, { registryPath } = {}) {
+async function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -8241,7 +8319,7 @@ function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8289,14 +8367,14 @@ function auditVault(vault, { registryPath } = {}) {
     findings.push(...checkFocusView(root, name, view));
   }
   if (!findings.some((item) => item.severity === "error")) {
-    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+    findings.push(...await runDeclaredContentCheck(vault, { registryPath }));
   }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
 import fs6 from "node:fs";
-import path5 from "node:path";
+import path6 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8318,13 +8396,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8354,7 +8432,7 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  const contractPath = path6.join(rootPath, CONTRACT_NAME);
   if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
   if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
@@ -8363,7 +8441,7 @@ function initializeVault(root, { contract, adopt, apply }) {
   if (apply) {
     fs6.mkdirSync(rootPath, { recursive: true });
     fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path5.join(rootPath, "INDEX.md");
+    const indexPath = path6.join(rootPath, "INDEX.md");
     if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
@@ -8429,7 +8507,7 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
@@ -8439,7 +8517,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault, { registryPath: options.registry });
+      const findings2 = await auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }
@@ -8482,7 +8560,7 @@ ${rendered2}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "proactive-durable-capture"])).has(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!(/* @__PURE__ */ new Set(["explicit-only", "maintain-after-material-change"])).has(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!(/* @__PURE__ */ new Set(["git", "none"])).has(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path6.resolve(expandHome(options.positional[0]));
+    const root = path7.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,
@@ -8512,4 +8590,4 @@ ${rendered}`);
 }
 
 // src/knowledge-loom/runner.mjs
-process.exitCode = runCli();
+process.exitCode = await runCli();

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7369,9 +7369,9 @@ var require_dist = __commonJS({
 import path6 from "node:path";
 
 // src/knowledge-loom/audit.mjs
-import fs4 from "node:fs";
-import path3 from "node:path";
-import { spawnSync } from "node:child_process";
+import fs5 from "node:fs";
+import path4 from "node:path";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.mjs
 var import_yaml = __toESM(require_dist(), 1);
@@ -7580,6 +7580,18 @@ function validateContractData(contract) {
   if (backup.mode === "lifecycle-hook" && !backup.adapter) {
     findings.push(finding("error", "contract.backup-adapter", "lifecycle backup requires `adapter`"));
   }
+  if (Object.hasOwn(contract, "content_checks")) {
+    const contentChecks = mapping(contract, "content_checks", findings);
+    if (contract.content_checks && typeof contract.content_checks === "object" && !Array.isArray(contract.content_checks) && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))) {
+      findings.push(
+        finding(
+          "error",
+          "contract.content-check-adapter",
+          "`content_checks.adapter` must be a kebab-case ID"
+        )
+      );
+    }
+  }
   validatePathValues(contract.instruction_roots, { field: "instruction_roots", findings });
   const navigation = mapping(contract, "navigation", findings);
   validatePathValues(navigation.entrypoints, { field: "navigation.entrypoints", findings, requireNonempty: true });
@@ -7633,8 +7645,409 @@ function validateContractData(contract) {
   return findings;
 }
 
-// src/knowledge-loom/focus.mjs
+// src/knowledge-loom/content-checks.mjs
+import { spawnSync } from "node:child_process";
+
+// src/knowledge-loom/registry.mjs
+var import_yaml2 = __toESM(require_dist(), 1);
+import crypto from "node:crypto";
 import fs3 from "node:fs";
+import os2 from "node:os";
+import path3 from "node:path";
+function defaultRegistryPath() {
+  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
+}
+function loadRegistry(registryPath = defaultRegistryPath()) {
+  const resolved = path3.resolve(expandHome(String(registryPath)));
+  if (!fs3.existsSync(resolved)) return { schema_version: 1, vaults: {} };
+  let data;
+  try {
+    data = import_yaml2.default.parse(fs3.readFileSync(resolved, "utf8")) ?? {};
+  } catch (error) {
+    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
+    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
+  }
+  return data;
+}
+function renderRegistry(data) {
+  return import_yaml2.default.stringify(data, { lineWidth: 0 });
+}
+function atomicWriteText(targetPath, rendered, { rename = fs3.renameSync } = {}) {
+  fs3.mkdirSync(path3.dirname(targetPath), { recursive: true });
+  const temporary = path3.join(path3.dirname(targetPath), `.${path3.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
+  let descriptor;
+  try {
+    const existing = fs3.statSync(targetPath, { throwIfNoEntry: false });
+    descriptor = fs3.openSync(temporary, "wx", existing?.mode & 511 || 384);
+    fs3.writeFileSync(descriptor, rendered, "utf8");
+    fs3.fsyncSync(descriptor);
+    fs3.closeSync(descriptor);
+    descriptor = void 0;
+    rename(temporary, targetPath);
+    try {
+      const directory = fs3.openSync(path3.dirname(targetPath), "r");
+      try {
+        fs3.fsyncSync(directory);
+      } finally {
+        fs3.closeSync(directory);
+      }
+    } catch {
+    }
+  } finally {
+    if (descriptor !== void 0) fs3.closeSync(descriptor);
+    fs3.rmSync(temporary, { force: true });
+  }
+}
+function findAncestorVault(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  while (true) {
+    if (fs3.statSync(path3.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
+    const parent = path3.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+function registeredCandidates(registry) {
+  const candidates = [];
+  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
+    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
+    const root = canonicalPath(record.path);
+    if (fs3.statSync(path3.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
+  }
+  return candidates;
+}
+function registeredVault(vaultId, registry) {
+  const record = registry.vaults[vaultId];
+  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
+  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
+    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
+  }
+  const vault = loadVault(record.path);
+  if (vault.contract.vault_id !== vaultId) {
+    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
+  }
+  return vault;
+}
+function requireProjectsMapping(projects) {
+  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
+    throw new ResolutionError("registry projects must be a mapping");
+  }
+  return projects;
+}
+function projectRecord(configuredRoot, record, { matching = false } = {}) {
+  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
+    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
+  }
+  return record;
+}
+function projectAssociation(start, registry) {
+  if (registry.projects === void 0) return null;
+  const projects = requireProjectsMapping(registry.projects);
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const matches = [];
+  for (const [configuredRoot, record] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) continue;
+    const root = canonicalPath(expandedRoot);
+    if (!isWithin(root, current)) continue;
+    const relative = path3.relative(root, current);
+    const distance = relative ? relative.split(path3.sep).length : 0;
+    matches.push({ configuredRoot, record, distance });
+  }
+  if (!matches.length) return null;
+  const nearestDistance = Math.min(...matches.map((match) => match.distance));
+  const nearest = matches.filter((match) => match.distance === nearestDistance);
+  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
+  if (vaultIds.size > 1) {
+    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
+  }
+  return nearest[0];
+}
+function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
+  if (selector !== null && selector !== void 0) {
+    const selectorPath = path3.resolve(expandHome(String(selector)));
+    if (fs3.existsSync(selectorPath)) {
+      const root = fs3.statSync(selectorPath).isDirectory() ? selectorPath : path3.dirname(selectorPath);
+      return loadVault(root);
+    }
+    const registry2 = loadRegistry(registryPath);
+    const record = registry2.vaults[String(selector)];
+    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
+    throw new ResolutionError(`unknown vault selector: ${selector}`);
+  }
+  const ancestor = findAncestorVault(cwd);
+  if (ancestor) return loadVault(ancestor);
+  const registry = loadRegistry(registryPath);
+  const association = projectAssociation(cwd, registry);
+  if (association) return registeredVault(association.record.vault_id, registry);
+  const candidates = registeredCandidates(registry);
+  if (candidates.length === 1) return loadVault(candidates[0][1]);
+  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
+  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
+}
+function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs3.renameSync } = {}) {
+  const vault = loadVault(root);
+  const contractId = vault.contract.vault_id;
+  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  const existing = data.vaults[vaultId];
+  if (existing !== void 0) {
+    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
+    }
+    const existingRoot = canonicalPath(existing.path);
+    if (existingRoot !== vault.root) {
+      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
+    }
+  }
+  data.vaults[vaultId] = { path: vault.root };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered];
+}
+function associateProject(vaultId, projectRoot, {
+  registryPath = defaultRegistryPath(),
+  apply = false,
+  replace = false,
+  rename = fs3.renameSync
+} = {}) {
+  const normalizedVaultId = String(vaultId);
+  const resolvedRegistryPath = path3.resolve(expandHome(String(registryPath)));
+  const data = loadRegistry(resolvedRegistryPath);
+  registeredVault(normalizedVaultId, data);
+  const root = canonicalPath(projectRoot);
+  if (!fs3.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new ResolutionError(`project path is not an existing directory: ${root}`);
+  }
+  data.projects ??= {};
+  const projects = requireProjectsMapping(data.projects);
+  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
+    const expandedRoot = expandHome(configuredRoot);
+    if (!path3.isAbsolute(expandedRoot)) {
+      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
+    }
+    const record = projectRecord(configuredRoot, unvalidatedRecord);
+    if (canonicalPath(expandedRoot) !== root) continue;
+    if (record.vault_id !== normalizedVaultId && !replace) {
+      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
+    }
+    if (configuredRoot !== root) delete projects[configuredRoot];
+  }
+  projects[root] = { vault_id: normalizedVaultId };
+  const rendered = renderRegistry(data);
+  if (apply) {
+    const current = fs3.existsSync(resolvedRegistryPath) ? fs3.readFileSync(resolvedRegistryPath, "utf8") : null;
+    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
+  }
+  return [resolvedRegistryPath, rendered, root];
+}
+
+// src/knowledge-loom/content-checks.mjs
+var ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
+var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
+var ADAPTER_TIMEOUT_MS = 3e4;
+var ADAPTER_MAX_BUFFER = 1024 * 1024;
+function adapterFinding(adapterId, code, message, findingPath = null) {
+  return {
+    ...finding("error", `content-check.${code}`, message, findingPath),
+    source: adapterId ? `content-check:${adapterId}` : "content-check"
+  };
+}
+function passedFinding(adapterId, validationDate) {
+  return {
+    severity: "info",
+    code: `content-check.${adapterId}.passed`,
+    message: `content check passed (${validationDate})`,
+    path: null,
+    source: `content-check:${adapterId}`
+  };
+}
+function adapterConfiguration(registry, adapterId) {
+  const adapters = registry.content_check_adapters;
+  if (!adapters || typeof adapters !== "object" || Array.isArray(adapters)) return null;
+  return adapters[adapterId] ?? null;
+}
+function configurationError(adapterId, configuration) {
+  if (!configuration) {
+    return adapterFinding(
+      adapterId,
+      "adapter-missing",
+      `content check adapter \`${adapterId}\` is not configured in the local registry`
+    );
+  }
+  if (typeof configuration !== "object" || Array.isArray(configuration)) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` must be a mapping`
+    );
+  }
+  if (typeof configuration.executable !== "string" || !configuration.executable.trim()) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a non-empty \`executable\``
+    );
+  }
+  if (!Array.isArray(configuration.arguments) || configuration.arguments.some((value) => typeof value !== "string")) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a string \`arguments\` list`
+    );
+  }
+  for (const value of [configuration.executable, ...configuration.arguments]) {
+    const placeholders = value.match(/\{[^}]+\}/g) ?? [];
+    if (placeholders.some((placeholder) => placeholder !== "{vault_root}")) {
+      return adapterFinding(
+        adapterId,
+        "adapter-config",
+        `content check adapter \`${adapterId}\` uses an unsupported placeholder`
+      );
+    }
+  }
+  return null;
+}
+function normalizedResult(adapterId, result, vaultRoot) {
+  const invalid = (message, code = "output") => ({
+    error: adapterFinding(adapterId, code, message)
+  });
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("content checker output must be a JSON object");
+  }
+  if (!Object.hasOwn(STATUS_EXIT_CODES, result.status)) {
+    return invalid("content checker returned an unsupported status");
+  }
+  if (typeof result.root !== "string") {
+    return invalid("content checker output requires `root`");
+  }
+  let resultRoot;
+  try {
+    resultRoot = canonicalPath(result.root);
+  } catch {
+    return invalid("content checker returned an unreadable root", "root");
+  }
+  if (resultRoot !== canonicalPath(vaultRoot)) {
+    return invalid("content checker root does not match the selected vault", "root");
+  }
+  if (typeof result.validationDate !== "string" || !VALIDATION_DATE_RE.test(result.validationDate)) {
+    return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
+  }
+  if (!Array.isArray(result.findings)) {
+    return invalid("content checker output requires a `findings` list");
+  }
+  const findings = [];
+  for (const item of result.findings) {
+    if (!item || typeof item !== "object" || Array.isArray(item) || !ALLOWED_SEVERITIES.has(item.severity) || typeof item.code !== "string" || !item.code.trim() || typeof item.message !== "string" || !item.message.trim() || item.path !== null && item.path !== void 0 && (typeof item.path !== "string" || !isVaultRelativePath(item.path)) || item.line !== void 0 && (!Number.isInteger(item.line) || item.line < 1)) {
+      return invalid("content checker returned an invalid finding");
+    }
+    const normalized = {
+      severity: item.severity,
+      code: `content-check.${adapterId}.${item.code}`,
+      message: item.message,
+      path: item.path ?? null,
+      source: `content-check:${adapterId}`
+    };
+    if (item.line !== void 0) normalized.line = item.line;
+    findings.push(normalized);
+  }
+  const hasError = findings.some((item) => item.severity === "error");
+  if (result.status === "pass" && hasError || result.status !== "pass" && !hasError) {
+    return invalid("content checker status is inconsistent with its findings");
+  }
+  return { status: result.status, validationDate: result.validationDate, findings };
+}
+function runDeclaredContentCheck(vault, {
+  registryPath,
+  timeoutMs = ADAPTER_TIMEOUT_MS,
+  maxBuffer = ADAPTER_MAX_BUFFER
+} = {}) {
+  const adapterId = vault.contract.content_checks?.adapter;
+  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  let registry;
+  try {
+    registry = loadRegistry(registryPath);
+  } catch (error) {
+    return [
+      adapterFinding(
+        adapterId,
+        "registry",
+        `cannot load the local adapter registry: ${error.message}`
+      )
+    ];
+  }
+  const configuration = adapterConfiguration(registry, adapterId);
+  const invalidConfiguration = configurationError(adapterId, configuration);
+  if (invalidConfiguration) return [invalidConfiguration];
+  const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
+  const completed = spawnSync(
+    substitute(configuration.executable),
+    configuration.arguments.map(substitute),
+    {
+      cwd: vault.root,
+      encoding: "utf8",
+      shell: false,
+      timeout: timeoutMs,
+      maxBuffer
+    }
+  );
+  if (completed.error) {
+    const reason = completed.error.code === "ETIMEDOUT" ? "timed out" : `could not start: ${completed.error.message}`;
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ${reason}`
+      )
+    ];
+  }
+  if (completed.signal) {
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ended with signal ${completed.signal}`
+      )
+    ];
+  }
+  let result;
+  try {
+    result = JSON.parse(completed.stdout);
+  } catch {
+    return [
+      adapterFinding(
+        adapterId,
+        "output",
+        `content check adapter \`${adapterId}\` did not return valid JSON`
+      )
+    ];
+  }
+  const normalized = normalizedResult(adapterId, result, vault.root);
+  if (normalized.error) return [normalized.error];
+  if (completed.status !== STATUS_EXIT_CODES[normalized.status]) {
+    return [
+      adapterFinding(
+        adapterId,
+        "exit-status",
+        `content check adapter \`${adapterId}\` exit status does not match its result`
+      )
+    ];
+  }
+  return normalized.status === "pass" ? [passedFinding(adapterId, normalized.validationDate), ...normalized.findings] : normalized.findings;
+}
+
+// src/knowledge-loom/focus.mjs
+import fs4 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -7656,12 +8069,12 @@ function checkFocusView(root, name, view) {
   if (typeof relative !== "string") return [];
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs3.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
   if (typeof section !== "string") return [];
-  const items = activeItems(fs3.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top ?? 3;
   const maxActive = view.max_active ?? maxTop;
   if (!Number.isInteger(maxTop) || !Number.isInteger(maxActive)) return [];
@@ -7742,7 +8155,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missingCode, missingMessage }) {
   if (!Array.isArray(values)) return [];
@@ -7751,7 +8164,7 @@ function auditDeclaredFiles(root, values, { boundaryCode, boundaryMessage, missi
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -7765,28 +8178,28 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs4.existsSync(root)) return result;
+  if (!fs5.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs4.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path3.join(current, entry.name);
+    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path4.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs4.lstatSync(root).isDirectory() && !fs4.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path3.join(root, ...patternValue.split("/"));
-    return fs4.existsSync(candidate) ? [candidate] : [];
+    const candidate = path4.join(root, ...patternValue.split("/"));
+    return fs5.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path3.join(root, ...prefix);
+  const searchRoot = path4.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
-function auditVault(vault) {
+function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
   findings.push(...auditDeclaredFiles(root, contract.instruction_roots ?? [], {
@@ -7830,7 +8243,7 @@ function auditVault(vault) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs4.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path3.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path4.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -7877,12 +8290,15 @@ function auditVault(vault) {
     if (!view || typeof view !== "object" || Array.isArray(view) || typeof view.path !== "string" || !isVaultRelativePath(view.path)) continue;
     findings.push(...checkFocusView(root, name, view));
   }
+  if (!findings.some((item) => item.severity === "error")) {
+    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+  }
   return findings;
 }
 
 // src/knowledge-loom/initializer.mjs
-import fs5 from "node:fs";
-import path4 from "node:path";
+import fs6 from "node:fs";
+import path5 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -7904,13 +8320,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs5.statSync(path4.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs6.statSync(path5.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -7940,221 +8356,19 @@ function buildContract(root, { vaultId, title, subjects, writePolicy, currentSta
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path4.join(rootPath, CONTRACT_NAME);
-  if (fs5.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs5.existsSync(rootPath) && fs5.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path5.join(rootPath, CONTRACT_NAME);
+  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs5.mkdirSync(rootPath, { recursive: true });
-    fs5.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path4.join(rootPath, "INDEX.md");
-    if (!adopt && !fs5.existsSync(indexPath)) fs5.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs6.mkdirSync(rootPath, { recursive: true });
+    fs6.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path5.join(rootPath, "INDEX.md");
+    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
-}
-
-// src/knowledge-loom/registry.mjs
-var import_yaml2 = __toESM(require_dist(), 1);
-import crypto from "node:crypto";
-import fs6 from "node:fs";
-import os2 from "node:os";
-import path5 from "node:path";
-function defaultRegistryPath() {
-  return process.env.KNOWLEDGE_VAULT_REGISTRY ? path5.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path5.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
-}
-function loadRegistry(registryPath = defaultRegistryPath()) {
-  const resolved = path5.resolve(expandHome(String(registryPath)));
-  if (!fs6.existsSync(resolved)) return { schema_version: 1, vaults: {} };
-  let data;
-  try {
-    data = import_yaml2.default.parse(fs6.readFileSync(resolved, "utf8")) ?? {};
-  } catch (error) {
-    throw new ResolutionError(`${resolved}: invalid registry YAML: ${error.message}`, { cause: error });
-  }
-  if (!data || typeof data !== "object" || Array.isArray(data) || data.schema_version !== 1 || !data.vaults || typeof data.vaults !== "object" || Array.isArray(data.vaults)) {
-    throw new ResolutionError(`${resolved}: registry must have schema_version 1 and a vaults mapping`);
-  }
-  return data;
-}
-function renderRegistry(data) {
-  return import_yaml2.default.stringify(data, { lineWidth: 0 });
-}
-function atomicWriteText(targetPath, rendered, { rename = fs6.renameSync } = {}) {
-  fs6.mkdirSync(path5.dirname(targetPath), { recursive: true });
-  const temporary = path5.join(path5.dirname(targetPath), `.${path5.basename(targetPath)}.${crypto.randomBytes(8).toString("hex")}.tmp`);
-  let descriptor;
-  try {
-    const existing = fs6.statSync(targetPath, { throwIfNoEntry: false });
-    descriptor = fs6.openSync(temporary, "wx", existing?.mode & 511 || 384);
-    fs6.writeFileSync(descriptor, rendered, "utf8");
-    fs6.fsyncSync(descriptor);
-    fs6.closeSync(descriptor);
-    descriptor = void 0;
-    rename(temporary, targetPath);
-    try {
-      const directory = fs6.openSync(path5.dirname(targetPath), "r");
-      try {
-        fs6.fsyncSync(directory);
-      } finally {
-        fs6.closeSync(directory);
-      }
-    } catch {
-    }
-  } finally {
-    if (descriptor !== void 0) fs6.closeSync(descriptor);
-    fs6.rmSync(temporary, { force: true });
-  }
-}
-function findAncestorVault(start) {
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  while (true) {
-    if (fs6.statSync(path5.join(current, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) return current;
-    const parent = path5.dirname(current);
-    if (parent === current) return null;
-    current = parent;
-  }
-}
-function registeredCandidates(registry) {
-  const candidates = [];
-  for (const [vaultId, record] of Object.entries(registry.vaults ?? {})) {
-    if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") continue;
-    const root = canonicalPath(record.path);
-    if (fs6.statSync(path5.join(root, CONTRACT_NAME), { throwIfNoEntry: false })?.isFile()) candidates.push([vaultId, root]);
-  }
-  return candidates;
-}
-function registeredVault(vaultId, registry) {
-  const record = registry.vaults[vaultId];
-  if (!record) throw new ResolutionError(`unknown registered vault ID \`${vaultId}\``);
-  if (typeof record !== "object" || Array.isArray(record) || typeof record.path !== "string") {
-    throw new ResolutionError(`invalid registered vault record \`${vaultId}\``);
-  }
-  const vault = loadVault(record.path);
-  if (vault.contract.vault_id !== vaultId) {
-    throw new ResolutionError(`registered vault ID \`${vaultId}\` does not match contract ID \`${vault.contract.vault_id}\``);
-  }
-  return vault;
-}
-function requireProjectsMapping(projects) {
-  if (!projects || typeof projects !== "object" || Array.isArray(projects)) {
-    throw new ResolutionError("registry projects must be a mapping");
-  }
-  return projects;
-}
-function projectRecord(configuredRoot, record, { matching = false } = {}) {
-  if (!record || typeof record !== "object" || Array.isArray(record) || typeof record.vault_id !== "string" || !record.vault_id) {
-    throw new ResolutionError(`${matching ? "matching " : ""}project association \`${configuredRoot}\` must contain a vault_id`);
-  }
-  return record;
-}
-function projectAssociation(start, registry) {
-  if (registry.projects === void 0) return null;
-  const projects = requireProjectsMapping(registry.projects);
-  let current = canonicalPath(start);
-  if (fs6.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path5.dirname(current);
-  const matches = [];
-  for (const [configuredRoot, record] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) continue;
-    const root = canonicalPath(expandedRoot);
-    if (!isWithin(root, current)) continue;
-    const relative = path5.relative(root, current);
-    const distance = relative ? relative.split(path5.sep).length : 0;
-    matches.push({ configuredRoot, record, distance });
-  }
-  if (!matches.length) return null;
-  const nearestDistance = Math.min(...matches.map((match) => match.distance));
-  const nearest = matches.filter((match) => match.distance === nearestDistance);
-  const vaultIds = new Set(nearest.map((match) => projectRecord(match.configuredRoot, match.record, { matching: true }).vault_id));
-  if (vaultIds.size > 1) {
-    throw new ResolutionError(`project association is ambiguous at \`${current}\`; matching roots resolve to: ${[...vaultIds].sort().join(", ")}`);
-  }
-  return nearest[0];
-}
-function resolveVault(selector = null, { cwd = process.cwd(), registryPath = defaultRegistryPath() } = {}) {
-  if (selector !== null && selector !== void 0) {
-    const selectorPath = path5.resolve(expandHome(String(selector)));
-    if (fs6.existsSync(selectorPath)) {
-      const root = fs6.statSync(selectorPath).isDirectory() ? selectorPath : path5.dirname(selectorPath);
-      return loadVault(root);
-    }
-    const registry2 = loadRegistry(registryPath);
-    const record = registry2.vaults[String(selector)];
-    if (record && typeof record === "object" && !Array.isArray(record) && typeof record.path === "string") return loadVault(record.path);
-    throw new ResolutionError(`unknown vault selector: ${selector}`);
-  }
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return loadVault(ancestor);
-  const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
-  if (association) return registeredVault(association.record.vault_id, registry);
-  const candidates = registeredCandidates(registry);
-  if (candidates.length === 1) return loadVault(candidates[0][1]);
-  if (!candidates.length) throw new ResolutionError("no vault selected, no ancestor contract found, and registry has no valid vaults");
-  throw new ResolutionError(`vault selection is ambiguous; choose one of: ${candidates.map(([vaultId]) => vaultId).join(", ")}`);
-}
-function registerVault(vaultId, root, { registryPath = defaultRegistryPath(), apply = false, rename = fs6.renameSync } = {}) {
-  const vault = loadVault(root);
-  const contractId = vault.contract.vault_id;
-  if (vaultId !== contractId) throw new ContractError(`registry ID \`${vaultId}\` does not match contract ID \`${contractId}\``);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  const existing = data.vaults[vaultId];
-  if (existing !== void 0) {
-    if (!existing || typeof existing !== "object" || Array.isArray(existing) || typeof existing.path !== "string") {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already exists with an invalid record`);
-    }
-    const existingRoot = canonicalPath(existing.path);
-    if (existingRoot !== vault.root) {
-      throw new ResolutionError(`registry ID \`${vaultId}\` already points to \`${existingRoot}\`; refusing to replace it with \`${vault.root}\``);
-    }
-  }
-  data.vaults[vaultId] = { path: vault.root };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered];
-}
-function associateProject(vaultId, projectRoot, {
-  registryPath = defaultRegistryPath(),
-  apply = false,
-  replace = false,
-  rename = fs6.renameSync
-} = {}) {
-  const normalizedVaultId = String(vaultId);
-  const resolvedRegistryPath = path5.resolve(expandHome(String(registryPath)));
-  const data = loadRegistry(resolvedRegistryPath);
-  registeredVault(normalizedVaultId, data);
-  const root = canonicalPath(projectRoot);
-  if (!fs6.statSync(root, { throwIfNoEntry: false })?.isDirectory()) {
-    throw new ResolutionError(`project path is not an existing directory: ${root}`);
-  }
-  data.projects ??= {};
-  const projects = requireProjectsMapping(data.projects);
-  for (const [configuredRoot, unvalidatedRecord] of Object.entries(projects)) {
-    const expandedRoot = expandHome(configuredRoot);
-    if (!path5.isAbsolute(expandedRoot)) {
-      throw new ResolutionError(`project association path must be absolute: ${configuredRoot}`);
-    }
-    const record = projectRecord(configuredRoot, unvalidatedRecord);
-    if (canonicalPath(expandedRoot) !== root) continue;
-    if (record.vault_id !== normalizedVaultId && !replace) {
-      throw new ResolutionError(`project \`${root}\` already points to \`${record.vault_id}\`; refusing to replace it with \`${normalizedVaultId}\``);
-    }
-    if (configuredRoot !== root) delete projects[configuredRoot];
-  }
-  projects[root] = { vault_id: normalizedVaultId };
-  const rendered = renderRegistry(data);
-  if (apply) {
-    const current = fs6.existsSync(resolvedRegistryPath) ? fs6.readFileSync(resolvedRegistryPath, "utf8") : null;
-    if (current !== rendered) atomicWriteText(resolvedRegistryPath, rendered, { rename });
-  }
-  return [resolvedRegistryPath, rendered, root];
 }
 
 // src/knowledge-loom/cli.mjs
@@ -8211,7 +8425,7 @@ function formatFindings(findings, { json = false } = {}) {
   if (json) return `${JSON.stringify(findings, null, 2)}
 `;
   if (!findings.length) return "PASS no findings\n";
-  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}]` : ""}: ${item.message}`).join("\n")}
+  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}${item.line ? `:${item.line}` : ""}]` : ""}: ${item.message}`).join("\n")}
 `;
 }
 function requirePositionals(options, count, usage) {
@@ -8227,7 +8441,7 @@ function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdou
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings2 = auditVault(vault);
+      const findings2 = auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings2, { json: options.json === true }));
       return findings2.some((item) => item.severity === "error") ? 1 : 0;
     }

--- a/src/knowledge-loom/audit.mjs
+++ b/src/knowledge-loom/audit.mjs
@@ -125,7 +125,7 @@ function globPaths(root, patternValue) {
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
 
-export function auditVault(vault, { registryPath } = {}) {
+export async function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
 
@@ -224,7 +224,7 @@ export function auditVault(vault, { registryPath } = {}) {
     findings.push(...checkFocusView(root, name, view));
   }
   if (!findings.some((item) => item.severity === "error")) {
-    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
+    findings.push(...await runDeclaredContentCheck(vault, { registryPath }));
   }
   return findings;
 }

--- a/src/knowledge-loom/audit.mjs
+++ b/src/knowledge-loom/audit.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { finding, loadNoteFrontmatter, validateContractData } from "./contract.mjs";
+import { runDeclaredContentCheck } from "./content-checks.mjs";
 import { checkFocusView } from "./focus.mjs";
 import {
   canonicalPath,
@@ -124,7 +125,7 @@ function globPaths(root, patternValue) {
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
 
-export function auditVault(vault) {
+export function auditVault(vault, { registryPath } = {}) {
   const findings = validateContractData(vault.contract);
   const { root, contract } = vault;
 
@@ -221,6 +222,9 @@ export function auditVault(vault) {
   for (const [name, view] of Object.entries(focusViews)) {
     if (!view || typeof view !== "object" || Array.isArray(view) || typeof view.path !== "string" || !isVaultRelativePath(view.path)) continue;
     findings.push(...checkFocusView(root, name, view));
+  }
+  if (!findings.some((item) => item.severity === "error")) {
+    findings.push(...runDeclaredContentCheck(vault, { registryPath }));
   }
   return findings;
 }

--- a/src/knowledge-loom/cli.mjs
+++ b/src/knowledge-loom/cli.mjs
@@ -77,7 +77,7 @@ function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
 
-export function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+export async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
@@ -88,7 +88,7 @@ export function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd()
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings = auditVault(vault, { registryPath: options.registry });
+      const findings = await auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings, { json: options.json === true }));
       return findings.some((item) => item.severity === "error") ? 1 : 0;
     }

--- a/src/knowledge-loom/cli.mjs
+++ b/src/knowledge-loom/cli.mjs
@@ -70,7 +70,7 @@ function parseArguments(arguments_) {
 export function formatFindings(findings, { json = false } = {}) {
   if (json) return `${JSON.stringify(findings, null, 2)}\n`;
   if (!findings.length) return "PASS no findings\n";
-  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}]` : ""}: ${item.message}`).join("\n")}\n`;
+  return `${findings.map((item) => `${item.severity.toLocaleUpperCase().padEnd(7)} ${item.code}${item.path ? ` [${item.path}${item.line ? `:${item.line}` : ""}]` : ""}: ${item.message}`).join("\n")}\n`;
 }
 
 function requirePositionals(options, count, usage) {
@@ -88,7 +88,7 @@ export function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd()
     if (options.command === "audit") {
       if (options.positional.length > 1) throw new Error(COMMAND_HELP.audit.trim());
       const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
-      const findings = auditVault(vault);
+      const findings = auditVault(vault, { registryPath: options.registry });
       stdout.write(formatFindings(findings, { json: options.json === true }));
       return findings.some((item) => item.severity === "error") ? 1 : 0;
     }

--- a/src/knowledge-loom/content-checks.mjs
+++ b/src/knowledge-loom/content-checks.mjs
@@ -1,10 +1,9 @@
 import { spawnSync } from "node:child_process";
 
-import { finding } from "./contract.mjs";
-import { canonicalPath, isVaultRelativePath } from "./pathing.mjs";
+import { finding, KEBAB_CASE_ID_RE } from "./contract.mjs";
+import { canonicalPath, isVaultRelativePath, resolveVaultPath } from "./pathing.mjs";
 import { loadRegistry } from "./registry.mjs";
 
-const ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const ALLOWED_SEVERITIES = new Set(["error", "warning", "info"]);
 const STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -126,7 +125,11 @@ function normalizedResult(adapterId, result, vaultRoot) {
       || (
         item.path !== null
         && item.path !== undefined
-        && (typeof item.path !== "string" || !isVaultRelativePath(item.path))
+        && (
+          typeof item.path !== "string"
+          || !isVaultRelativePath(item.path)
+          || !resolveVaultPath(vaultRoot, item.path)
+        )
       )
       || (item.line !== undefined && (!Number.isInteger(item.line) || item.line < 1))
     ) {
@@ -155,11 +158,10 @@ export function runDeclaredContentCheck(
   {
     registryPath,
     timeoutMs = ADAPTER_TIMEOUT_MS,
-    maxBuffer = ADAPTER_MAX_BUFFER,
   } = {},
 ) {
   const adapterId = vault.contract.content_checks?.adapter;
-  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+  if (!adapterId || !KEBAB_CASE_ID_RE.test(adapterId)) return [];
 
   let registry;
   try {
@@ -187,7 +189,7 @@ export function runDeclaredContentCheck(
       encoding: "utf8",
       shell: false,
       timeout: timeoutMs,
-      maxBuffer,
+      maxBuffer: ADAPTER_MAX_BUFFER,
     },
   );
 

--- a/src/knowledge-loom/content-checks.mjs
+++ b/src/knowledge-loom/content-checks.mjs
@@ -1,0 +1,243 @@
+import { spawnSync } from "node:child_process";
+
+import { finding } from "./contract.mjs";
+import { canonicalPath, isVaultRelativePath } from "./pathing.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const ADAPTER_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ALLOWED_SEVERITIES = new Set(["error", "warning", "info"]);
+const STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
+const ADAPTER_TIMEOUT_MS = 30_000;
+const ADAPTER_MAX_BUFFER = 1024 * 1024;
+
+function adapterFinding(adapterId, code, message, findingPath = null) {
+  return {
+    ...finding("error", `content-check.${code}`, message, findingPath),
+    source: adapterId ? `content-check:${adapterId}` : "content-check",
+  };
+}
+
+function passedFinding(adapterId, validationDate) {
+  return {
+    severity: "info",
+    code: `content-check.${adapterId}.passed`,
+    message: `content check passed (${validationDate})`,
+    path: null,
+    source: `content-check:${adapterId}`,
+  };
+}
+
+function adapterConfiguration(registry, adapterId) {
+  const adapters = registry.content_check_adapters;
+  if (!adapters || typeof adapters !== "object" || Array.isArray(adapters)) return null;
+  return adapters[adapterId] ?? null;
+}
+
+function configurationError(adapterId, configuration) {
+  if (!configuration) {
+    return adapterFinding(
+      adapterId,
+      "adapter-missing",
+      `content check adapter \`${adapterId}\` is not configured in the local registry`,
+    );
+  }
+  if (typeof configuration !== "object" || Array.isArray(configuration)) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` must be a mapping`,
+    );
+  }
+  if (typeof configuration.executable !== "string" || !configuration.executable.trim()) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a non-empty \`executable\``,
+    );
+  }
+  if (
+    !Array.isArray(configuration.arguments)
+    || configuration.arguments.some((value) => typeof value !== "string")
+  ) {
+    return adapterFinding(
+      adapterId,
+      "adapter-config",
+      `content check adapter \`${adapterId}\` requires a string \`arguments\` list`,
+    );
+  }
+  for (const value of [configuration.executable, ...configuration.arguments]) {
+    const placeholders = value.match(/\{[^}]+\}/g) ?? [];
+    if (placeholders.some((placeholder) => placeholder !== "{vault_root}")) {
+      return adapterFinding(
+        adapterId,
+        "adapter-config",
+        `content check adapter \`${adapterId}\` uses an unsupported placeholder`,
+      );
+    }
+  }
+  return null;
+}
+
+function normalizedResult(adapterId, result, vaultRoot) {
+  const invalid = (message, code = "output") => ({
+    error: adapterFinding(adapterId, code, message),
+  });
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("content checker output must be a JSON object");
+  }
+  if (!Object.hasOwn(STATUS_EXIT_CODES, result.status)) {
+    return invalid("content checker returned an unsupported status");
+  }
+  if (typeof result.root !== "string") {
+    return invalid("content checker output requires `root`");
+  }
+
+  let resultRoot;
+  try {
+    resultRoot = canonicalPath(result.root);
+  } catch {
+    return invalid("content checker returned an unreadable root", "root");
+  }
+  if (resultRoot !== canonicalPath(vaultRoot)) {
+    return invalid("content checker root does not match the selected vault", "root");
+  }
+  if (
+    typeof result.validationDate !== "string"
+    || !VALIDATION_DATE_RE.test(result.validationDate)
+  ) {
+    return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
+  }
+  if (!Array.isArray(result.findings)) {
+    return invalid("content checker output requires a `findings` list");
+  }
+
+  const findings = [];
+  for (const item of result.findings) {
+    if (
+      !item
+      || typeof item !== "object"
+      || Array.isArray(item)
+      || !ALLOWED_SEVERITIES.has(item.severity)
+      || typeof item.code !== "string"
+      || !item.code.trim()
+      || typeof item.message !== "string"
+      || !item.message.trim()
+      || (
+        item.path !== null
+        && item.path !== undefined
+        && (typeof item.path !== "string" || !isVaultRelativePath(item.path))
+      )
+      || (item.line !== undefined && (!Number.isInteger(item.line) || item.line < 1))
+    ) {
+      return invalid("content checker returned an invalid finding");
+    }
+    const normalized = {
+      severity: item.severity,
+      code: `content-check.${adapterId}.${item.code}`,
+      message: item.message,
+      path: item.path ?? null,
+      source: `content-check:${adapterId}`,
+    };
+    if (item.line !== undefined) normalized.line = item.line;
+    findings.push(normalized);
+  }
+
+  const hasError = findings.some((item) => item.severity === "error");
+  if ((result.status === "pass" && hasError) || (result.status !== "pass" && !hasError)) {
+    return invalid("content checker status is inconsistent with its findings");
+  }
+  return { status: result.status, validationDate: result.validationDate, findings };
+}
+
+export function runDeclaredContentCheck(
+  vault,
+  {
+    registryPath,
+    timeoutMs = ADAPTER_TIMEOUT_MS,
+    maxBuffer = ADAPTER_MAX_BUFFER,
+  } = {},
+) {
+  const adapterId = vault.contract.content_checks?.adapter;
+  if (!adapterId || !ADAPTER_ID_RE.test(adapterId)) return [];
+
+  let registry;
+  try {
+    registry = loadRegistry(registryPath);
+  } catch (error) {
+    return [
+      adapterFinding(
+        adapterId,
+        "registry",
+        `cannot load the local adapter registry: ${error.message}`,
+      ),
+    ];
+  }
+
+  const configuration = adapterConfiguration(registry, adapterId);
+  const invalidConfiguration = configurationError(adapterId, configuration);
+  if (invalidConfiguration) return [invalidConfiguration];
+
+  const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
+  const completed = spawnSync(
+    substitute(configuration.executable),
+    configuration.arguments.map(substitute),
+    {
+      cwd: vault.root,
+      encoding: "utf8",
+      shell: false,
+      timeout: timeoutMs,
+      maxBuffer,
+    },
+  );
+
+  if (completed.error) {
+    const reason = completed.error.code === "ETIMEDOUT"
+      ? "timed out"
+      : `could not start: ${completed.error.message}`;
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ${reason}`,
+      ),
+    ];
+  }
+  if (completed.signal) {
+    return [
+      adapterFinding(
+        adapterId,
+        "execution",
+        `content check adapter \`${adapterId}\` ended with signal ${completed.signal}`,
+      ),
+    ];
+  }
+
+  let result;
+  try {
+    result = JSON.parse(completed.stdout);
+  } catch {
+    return [
+      adapterFinding(
+        adapterId,
+        "output",
+        `content check adapter \`${adapterId}\` did not return valid JSON`,
+      ),
+    ];
+  }
+
+  const normalized = normalizedResult(adapterId, result, vault.root);
+  if (normalized.error) return [normalized.error];
+  if (completed.status !== STATUS_EXIT_CODES[normalized.status]) {
+    return [
+      adapterFinding(
+        adapterId,
+        "exit-status",
+        `content check adapter \`${adapterId}\` exit status does not match its result`,
+      ),
+    ];
+  }
+  return normalized.status === "pass"
+    ? [passedFinding(adapterId, normalized.validationDate), ...normalized.findings]
+    : normalized.findings;
+}

--- a/src/knowledge-loom/content-checks.mjs
+++ b/src/knowledge-loom/content-checks.mjs
@@ -1,4 +1,5 @@
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import path from "node:path";
 
 import { finding, KEBAB_CASE_ID_RE } from "./contract.mjs";
 import { canonicalPath, isVaultRelativePath, resolveVaultPath } from "./pathing.mjs";
@@ -24,7 +25,14 @@ function passedFinding(adapterId, validationDate) {
     message: `content check passed (${validationDate})`,
     path: null,
     source: `content-check:${adapterId}`,
+    validationDate,
   };
+}
+
+function validValidationDate(value) {
+  if (typeof value !== "string" || !VALIDATION_DATE_RE.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
 }
 
 function adapterConfiguration(registry, adapterId) {
@@ -92,19 +100,10 @@ function normalizedResult(adapterId, result, vaultRoot) {
     return invalid("content checker output requires `root`");
   }
 
-  let resultRoot;
-  try {
-    resultRoot = canonicalPath(result.root);
-  } catch {
-    return invalid("content checker returned an unreadable root", "root");
-  }
-  if (resultRoot !== canonicalPath(vaultRoot)) {
+  if (!path.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
-  if (
-    typeof result.validationDate !== "string"
-    || !VALIDATION_DATE_RE.test(result.validationDate)
-  ) {
+  if (!validValidationDate(result.validationDate)) {
     return invalid("content checker output requires `validationDate` in YYYY-MM-DD form");
   }
   if (!Array.isArray(result.findings)) {
@@ -122,9 +121,9 @@ function normalizedResult(adapterId, result, vaultRoot) {
       || !item.code.trim()
       || typeof item.message !== "string"
       || !item.message.trim()
+      || !Object.hasOwn(item, "path")
       || (
         item.path !== null
-        && item.path !== undefined
         && (
           typeof item.path !== "string"
           || !isVaultRelativePath(item.path)
@@ -141,6 +140,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
       message: item.message,
       path: item.path ?? null,
       source: `content-check:${adapterId}`,
+      validationDate: result.validationDate,
     };
     if (item.line !== undefined) normalized.line = item.line;
     findings.push(normalized);
@@ -153,7 +153,84 @@ function normalizedResult(adapterId, result, vaultRoot) {
   return { status: result.status, validationDate: result.validationDate, findings };
 }
 
-export function runDeclaredContentCheck(
+function killProcessTree(child) {
+  if (!child.pid) return;
+  if (process.platform === "win32") {
+    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    killer.once("error", () => {
+      try { child.kill("SIGKILL"); } catch { /* The process already exited. */ }
+    });
+    killer.unref();
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    try { child.kill("SIGKILL"); } catch { /* The process already exited. */ }
+  }
+}
+
+function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(executable, arguments_, {
+        cwd,
+        shell: false,
+        detached: process.platform !== "win32",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (error) {
+      resolve({ error });
+      return;
+    }
+
+    let settled = false;
+    let timer;
+    let stdout = "";
+    let outputBytes = 0;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const terminate = (error) => {
+      killProcessTree(child);
+      child.stdout.destroy();
+      child.stderr.destroy();
+      finish({ error });
+    };
+    const collect = (chunk, { capture = false } = {}) => {
+      outputBytes += Buffer.byteLength(chunk, "utf8");
+      if (outputBytes > ADAPTER_MAX_BUFFER) {
+        const error = new Error("output exceeded the 1 MiB limit");
+        error.code = "ENOBUFS";
+        terminate(error);
+        return;
+      }
+      if (capture) stdout += chunk;
+    };
+
+    child.once("error", (error) => finish({ error }));
+    child.stdout.on("data", (chunk) => collect(chunk, { capture: true }));
+    child.stderr.on("data", (chunk) => collect(chunk));
+    child.once("close", (status, signal) => finish({ stdout, status, signal }));
+    timer = setTimeout(() => {
+      const error = new Error("timed out");
+      error.code = "ETIMEDOUT";
+      terminate(error);
+    }, timeoutMs);
+  });
+}
+
+export async function runDeclaredContentCheck(
   vault,
   {
     registryPath,
@@ -181,22 +258,21 @@ export function runDeclaredContentCheck(
   if (invalidConfiguration) return [invalidConfiguration];
 
   const substitute = (value) => value.replaceAll("{vault_root}", vault.root);
-  const completed = spawnSync(
+  const completed = await executeAdapter(
     substitute(configuration.executable),
     configuration.arguments.map(substitute),
     {
       cwd: vault.root,
-      encoding: "utf8",
-      shell: false,
-      timeout: timeoutMs,
-      maxBuffer: ADAPTER_MAX_BUFFER,
+      timeoutMs,
     },
   );
 
   if (completed.error) {
     const reason = completed.error.code === "ETIMEDOUT"
       ? "timed out"
-      : `could not start: ${completed.error.message}`;
+      : completed.error.code === "ENOBUFS"
+        ? "exceeded the 1 MiB output limit"
+        : `could not start: ${completed.error.message}`;
     return [
       adapterFinding(
         adapterId,

--- a/src/knowledge-loom/contract.mjs
+++ b/src/knowledge-loom/contract.mjs
@@ -8,7 +8,7 @@ import { canonicalPath, isVaultRelativePath, isWithin } from "./pathing.mjs";
 export { ContractError } from "./errors.mjs";
 
 export const CONTRACT_NAME = "KNOWLEDGE_VAULT.md";
-const VAULT_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const KEBAB_CASE_ID_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export function finding(severity, code, message, findingPath = null) {
   return { severity, code, message, path: findingPath };
@@ -92,7 +92,7 @@ export function validateContractData(contract) {
   if (contract.schema_version !== 1) findings.push(finding("error", "contract.schema-version", "`schema_version` must equal 1"));
 
   const vaultId = contract.vault_id;
-  if (typeof vaultId !== "string" || !VAULT_ID_RE.test(vaultId)) {
+  if (typeof vaultId !== "string" || !KEBAB_CASE_ID_RE.test(vaultId)) {
     findings.push(finding("error", "contract.vault-id", "`vault_id` must be stable kebab-case"));
   }
   if (typeof contract.title !== "string" || !contract.title.trim()) {
@@ -158,7 +158,10 @@ export function validateContractData(contract) {
       contract.content_checks
       && typeof contract.content_checks === "object"
       && !Array.isArray(contract.content_checks)
-      && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))
+      && (
+        typeof contentChecks.adapter !== "string"
+        || !KEBAB_CASE_ID_RE.test(contentChecks.adapter)
+      )
     ) {
       findings.push(
         finding(

--- a/src/knowledge-loom/contract.mjs
+++ b/src/knowledge-loom/contract.mjs
@@ -152,6 +152,24 @@ export function validateContractData(contract) {
     findings.push(finding("error", "contract.backup-adapter", "lifecycle backup requires `adapter`"));
   }
 
+  if (Object.hasOwn(contract, "content_checks")) {
+    const contentChecks = mapping(contract, "content_checks", findings);
+    if (
+      contract.content_checks
+      && typeof contract.content_checks === "object"
+      && !Array.isArray(contract.content_checks)
+      && (typeof contentChecks.adapter !== "string" || !VAULT_ID_RE.test(contentChecks.adapter))
+    ) {
+      findings.push(
+        finding(
+          "error",
+          "contract.content-check-adapter",
+          "`content_checks.adapter` must be a kebab-case ID",
+        ),
+      );
+    }
+  }
+
   validatePathValues(contract.instruction_roots, { field: "instruction_roots", findings });
   const navigation = mapping(contract, "navigation", findings);
   validatePathValues(navigation.entrypoints, { field: "navigation.entrypoints", findings, requireNonempty: true });

--- a/src/knowledge-loom/runner.mjs
+++ b/src/knowledge-loom/runner.mjs
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 import { runCli } from "./cli.mjs";
 
-process.exitCode = runCli();
+process.exitCode = await runCli();

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -49,26 +49,27 @@ function contentCheckFixture(t, {
   return { root, registry, script };
 }
 
-test("clean fixtures have no errors", () => {
-  for (const name of ["single-proactive", "shared-explicit"]) assert.deepEqual(auditVault(loadVault(path.join(FIXTURES, name))), []);
+test("clean fixtures have no errors", async () => {
+  for (const name of ["single-proactive", "shared-explicit"]) assert.deepEqual(await auditVault(loadVault(path.join(FIXTURES, name))), []);
 });
 
-test("declared content checker passes inside the single audit", (t) => {
+test("declared content checker passes inside the single audit", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     result: { status: "pass", validationDate: "2026-08-12", findings: [] },
   });
-  assert.deepEqual(auditVault(loadVault(root), { registryPath: registry }), [
+  assert.deepEqual(await auditVault(loadVault(root), { registryPath: registry }), [
     {
       severity: "info",
       code: "content-check.fictional-content-check.passed",
       message: "content check passed (2026-08-12)",
       path: null,
       source: "content-check:fictional-content-check",
+      validationDate: "2026-08-12",
     },
   ]);
 });
 
-test("declared content checker findings merge with source and line", (t) => {
+test("declared content checker findings merge with source and line", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     result: {
       status: "fail",
@@ -85,7 +86,7 @@ test("declared content checker findings merge with source and line", (t) => {
     },
     exitCode: 1,
   });
-  assert.deepEqual(auditVault(loadVault(root), { registryPath: registry }), [
+  assert.deepEqual(await auditVault(loadVault(root), { registryPath: registry }), [
     {
       severity: "error",
       code: "content-check.fictional-content-check.content.tldr-item-count",
@@ -93,23 +94,24 @@ test("declared content checker findings merge with source and line", (t) => {
       path: "Projects/example.md",
       line: 12,
       source: "content-check:fictional-content-check",
+      validationDate: "2026-08-12",
     },
   ]);
 });
 
-test("missing declared content checker is an audit error", (t) => {
+test("missing declared content checker is an audit error", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     result: { status: "pass", validationDate: "2026-08-12", findings: [] },
   });
   fs.writeFileSync(registry, YAML.stringify({ schema_version: 1, vaults: {} }));
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "content-check.adapter-missing",
     ),
   );
 });
 
-test("built-in errors prevent content checker execution", (t) => {
+test("built-in errors prevent content checker execution", async (t) => {
   const { root, registry, script } = contentCheckFixture(t, {
     result: { status: "pass", validationDate: "2026-08-12", findings: [] },
   });
@@ -124,7 +126,7 @@ test("built-in errors prevent content checker execution", (t) => {
   fs.writeFileSync(vault.contractPath, renderContract(contract, vault.body));
 
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "path.instruction-root",
     ),
   );
@@ -143,15 +145,15 @@ for (const [name, setup, code] of [
     "content-check.exit-status",
   ],
 ]) {
-  test(`content checker reports ${name}`, (t) => {
+  test(`content checker reports ${name}`, async (t) => {
     const { root, registry } = contentCheckFixture(t, setup);
     assert.ok(
-      auditVault(loadVault(root), { registryPath: registry }).some((item) => item.code === code),
+      (await auditVault(loadVault(root), { registryPath: registry })).some((item) => item.code === code),
     );
   });
 }
 
-test("unsupported adapter placeholders fail before execution", (t) => {
+test("unsupported adapter placeholders fail before execution", async (t) => {
   const { root, registry, script } = contentCheckFixture(t, {
     result: { status: "pass", validationDate: "2026-08-12", findings: [] },
     arguments_: ["{unknown}"],
@@ -162,14 +164,14 @@ test("unsupported adapter placeholders fail before execution", (t) => {
     `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(marker)}, "ran");\n`,
   );
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "content-check.adapter-config",
     ),
   );
   assert.equal(fs.existsSync(marker), false);
 });
 
-test("content checker rejects a root mismatch", (t) => {
+test("content checker rejects a root mismatch", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     rawOutput: JSON.stringify({
       status: "pass",
@@ -179,13 +181,62 @@ test("content checker rejects a root mismatch", (t) => {
     }),
   });
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "content-check.root",
     ),
   );
 });
 
-test("content checker rejects findings outside the vault", (t) => {
+test("content checker rejects a relative root even when invoked from the vault", async (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    rawOutput: JSON.stringify({
+      status: "pass",
+      root: ".",
+      validationDate: "2026-08-12",
+      findings: [],
+    }),
+  });
+  const originalCwd = process.cwd();
+  process.chdir(root);
+  try {
+    assert.ok(
+      (await auditVault(loadVault(root), { registryPath: registry })).some(
+        (item) => item.code === "content-check.root",
+      ),
+    );
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+test("content checker rejects impossible validation dates", async (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-99-99", findings: [] },
+  });
+  assert.ok(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
+      (item) => item.code === "content-check.output",
+    ),
+  );
+});
+
+test("content checker requires every finding to declare path or null", async (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: {
+      status: "fail",
+      validationDate: "2026-08-12",
+      findings: [{ severity: "error", code: "missing-path", message: "missing path" }],
+    },
+    exitCode: 1,
+  });
+  assert.ok(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
+      (item) => item.code === "content-check.output",
+    ),
+  );
+});
+
+test("content checker rejects findings outside the vault", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     result: {
       status: "fail",
@@ -202,13 +253,13 @@ test("content checker rejects findings outside the vault", (t) => {
     exitCode: 1,
   });
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "content-check.output",
     ),
   );
 });
 
-test("content checker rejects a finding through a symlink outside the vault", (t) => {
+test("content checker rejects a finding through a symlink outside the vault", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     result: {
       status: "fail",
@@ -227,58 +278,74 @@ test("content checker rejects a finding through a symlink outside the vault", (t
   const outside = temporaryDirectory(t);
   fs.symlinkSync(outside, path.join(root, "linked"), "dir");
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "content-check.output",
     ),
   );
 });
 
-test("content checker timeout becomes an audit finding", (t) => {
+test("content checker timeout becomes an audit finding", async (t) => {
   const { root, registry, script } = contentCheckFixture(t, {
     result: { status: "pass", validationDate: "2026-08-12", findings: [] },
   });
   fs.writeFileSync(script, "setTimeout(() => {}, 10_000);\n");
   assert.ok(
-    runDeclaredContentCheck(loadVault(root), { registryPath: registry, timeoutMs: 20 }).some(
+    (await runDeclaredContentCheck(loadVault(root), { registryPath: registry, timeoutMs: 20 })).some(
       (item) => item.code === "content-check.execution" && /timed out/.test(item.message),
     ),
   );
 });
 
-test("content checker launch failure becomes an audit finding", (t) => {
+test("content checker timeout remains bounded when the checker handles SIGTERM", async (t) => {
+  const { root, registry, script } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-08-12", findings: [] },
+  });
+  fs.writeFileSync(
+    script,
+    'process.on("SIGTERM", () => {}); setTimeout(() => process.exit(0), 1_500);\n',
+  );
+  const started = Date.now();
+  const findings = await runDeclaredContentCheck(loadVault(root), { registryPath: registry, timeoutMs: 300 });
+  assert.ok(Date.now() - started < 1_000, "checker exceeded its timeout bound");
+  assert.ok(
+    findings.some((item) => item.code === "content-check.execution" && /timed out/.test(item.message)),
+  );
+});
+
+test("content checker launch failure becomes an audit finding", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     result: { status: "pass", validationDate: "2026-08-12", findings: [] },
     executable: path.join(temporaryDirectory(t), "missing-executable"),
   });
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "content-check.execution" && /could not start/.test(item.message),
     ),
   );
 });
 
-test("content checker output limit becomes an audit finding", (t) => {
+test("content checker output limit becomes an audit finding", async (t) => {
   const { root, registry } = contentCheckFixture(t, {
     rawOutput: "x".repeat(1024 * 1024 + 1),
   });
   assert.ok(
-    auditVault(loadVault(root), { registryPath: registry }).some(
+    (await auditVault(loadVault(root), { registryPath: registry })).some(
       (item) => item.code === "content-check.execution",
     ),
   );
 });
 
-test("metadata gap is reported", (t) => {
+test("metadata gap is reported", async (t) => {
   const root = copyFixture("shared-explicit", path.join(temporaryDirectory(t), "shared"));
   fs.writeFileSync(path.join(root, "Health", "sam.md"), "# Sam health\n");
-  assert.ok(auditVault(loadVault(root)).some((item) => item.code === "metadata.missing" && item.path === "Health/sam.md"));
+  assert.ok((await auditVault(loadVault(root))).some((item) => item.code === "metadata.missing" && item.path === "Health/sam.md"));
 });
 
-test("focus limits are reported", (t) => {
+test("focus limits are reported", async (t) => {
   const root = copyFixture("single-proactive", path.join(temporaryDirectory(t), "single"));
   const focus = path.join(root, "Projects", "current-focus.md");
   fs.writeFileSync(focus, fs.readFileSync(focus, "utf8").replace("\n## Waiting\n", "\n### 3. Hidden parallel task\n\n- **Next action:** Start another stream.\n\n## Waiting\n"));
-  const findings = auditVault(loadVault(root));
+  const findings = await auditVault(loadVault(root));
   assert.ok(findings.some((item) => item.code === "focus.max-top"));
   assert.ok(findings.some((item) => item.code === "focus.max-active"));
 });
@@ -306,7 +373,7 @@ for (const [relative, findingCode] of [
   ["Projects/current-focus.md", "focus.boundary"],
   ["Projects/parser-project.md", "path.metadata-boundary"],
 ]) {
-  test(`audit rejects symlink escape from ${relative}`, (t) => {
+  test(`audit rejects symlink escape from ${relative}`, async (t) => {
     const temporary = temporaryDirectory(t);
     const root = copyFixture("single-proactive", path.join(temporary, "vault"));
     const target = path.join(root, relative);
@@ -314,21 +381,21 @@ for (const [relative, findingCode] of [
     const outside = path.join(temporary, path.basename(target));
     fs.writeFileSync(outside, "---\nstatus: current\n---\n\n# Outside\n");
     fs.symlinkSync(outside, target);
-    assert.ok(auditVault(loadVault(root)).some((item) => item.code === findingCode && item.path === relative));
+    assert.ok((await auditVault(loadVault(root))).some((item) => item.code === findingCode && item.path === relative));
   });
 }
 
 for (const field of ["subjects", "navigation", "metadata_profiles", "history", "privacy", "focus_views"]) {
-  test(`malformed ${field} reports errors instead of crashing`, () => {
+  test(`malformed ${field} reports errors instead of crashing`, async () => {
     const source = loadVault(path.join(FIXTURES, "single-proactive"));
     const contract = structuredClone(source.contract);
     contract[field] = [];
-    const findings = auditVault({ ...source, contract });
+    const findings = await auditVault({ ...source, contract });
     assert.ok(findings.some((item) => item.severity === "error"));
   });
 }
 
-test("privacy pattern rejects a symlinked prefix outside the vault", (t) => {
+test("privacy pattern rejects a symlinked prefix outside the vault", async (t) => {
   const temporary = temporaryDirectory(t);
   const root = copyFixture("single-proactive", path.join(temporary, "vault"));
   const outside = path.join(temporary, "outside");
@@ -338,5 +405,5 @@ test("privacy pattern rejects a symlinked prefix outside the vault", (t) => {
   const contract = structuredClone(vault.contract);
   contract.privacy.never_track = ["External/**"];
   fs.writeFileSync(vault.contractPath, renderContract(contract, vault.body));
-  assert.ok(auditVault(loadVault(root)).some((item) => item.code === "path.privacy-boundary" && item.path === "External/**"));
+  assert.ok((await auditVault(loadVault(root))).some((item) => item.code === "path.privacy-boundary" && item.path === "External/**"));
 });

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -9,7 +9,13 @@ import { runDeclaredContentCheck } from "../src/knowledge-loom/content-checks.mj
 import { loadVault, renderContract } from "../src/knowledge-loom/contract.mjs";
 import { copyFixture, FIXTURES, temporaryDirectory } from "./helpers.mjs";
 
-function contentCheckFixture(t, { result, exitCode = 0, rawOutput = null, arguments_ = null } = {}) {
+function contentCheckFixture(t, {
+  result,
+  exitCode = 0,
+  rawOutput = null,
+  arguments_ = null,
+  executable = process.execPath,
+} = {}) {
   const temporary = temporaryDirectory(t);
   const root = copyFixture("single-proactive", path.join(temporary, "vault"));
   const vault = loadVault(root);
@@ -34,7 +40,7 @@ function contentCheckFixture(t, { result, exitCode = 0, rawOutput = null, argume
       vaults: {},
       content_check_adapters: {
         "fictional-content-check": {
-          executable: process.execPath,
+          executable,
           arguments: arguments_ ?? [script, "{vault_root}"],
         },
       },
@@ -202,6 +208,31 @@ test("content checker rejects findings outside the vault", (t) => {
   );
 });
 
+test("content checker rejects a finding through a symlink outside the vault", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: {
+      status: "fail",
+      validationDate: "2026-08-12",
+      findings: [
+        {
+          severity: "error",
+          code: "unsafe-symlink",
+          message: "outside",
+          path: "linked/outside.md",
+        },
+      ],
+    },
+    exitCode: 1,
+  });
+  const outside = temporaryDirectory(t);
+  fs.symlinkSync(outside, path.join(root, "linked"), "dir");
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "content-check.output",
+    ),
+  );
+});
+
 test("content checker timeout becomes an audit finding", (t) => {
   const { root, registry, script } = contentCheckFixture(t, {
     result: { status: "pass", validationDate: "2026-08-12", findings: [] },
@@ -210,6 +241,29 @@ test("content checker timeout becomes an audit finding", (t) => {
   assert.ok(
     runDeclaredContentCheck(loadVault(root), { registryPath: registry, timeoutMs: 20 }).some(
       (item) => item.code === "content-check.execution" && /timed out/.test(item.message),
+    ),
+  );
+});
+
+test("content checker launch failure becomes an audit finding", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-08-12", findings: [] },
+    executable: path.join(temporaryDirectory(t), "missing-executable"),
+  });
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "content-check.execution" && /could not start/.test(item.message),
+    ),
+  );
+});
+
+test("content checker output limit becomes an audit finding", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    rawOutput: "x".repeat(1024 * 1024 + 1),
+  });
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "content-check.execution",
     ),
   );
 });

--- a/tests/audit.test.mjs
+++ b/tests/audit.test.mjs
@@ -2,13 +2,216 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
+import YAML from "yaml";
 
 import { auditVault, matchesPath } from "../src/knowledge-loom/audit.mjs";
+import { runDeclaredContentCheck } from "../src/knowledge-loom/content-checks.mjs";
 import { loadVault, renderContract } from "../src/knowledge-loom/contract.mjs";
 import { copyFixture, FIXTURES, temporaryDirectory } from "./helpers.mjs";
 
+function contentCheckFixture(t, { result, exitCode = 0, rawOutput = null, arguments_ = null } = {}) {
+  const temporary = temporaryDirectory(t);
+  const root = copyFixture("single-proactive", path.join(temporary, "vault"));
+  const vault = loadVault(root);
+  const contract = structuredClone(vault.contract);
+  contract.content_checks = { adapter: "fictional-content-check" };
+  fs.writeFileSync(vault.contractPath, renderContract(contract, vault.body));
+
+  const script = path.join(temporary, "content-check.mjs");
+  const outputExpression = rawOutput === null
+    ? `JSON.stringify({ ...${JSON.stringify(result)}, root: process.argv[2] })`
+    : JSON.stringify(rawOutput);
+  fs.writeFileSync(
+    script,
+    `process.stdout.write(${outputExpression}); process.exitCode = ${exitCode};\n`,
+  );
+
+  const registry = path.join(temporary, "registry.yaml");
+  fs.writeFileSync(
+    registry,
+    YAML.stringify({
+      schema_version: 1,
+      vaults: {},
+      content_check_adapters: {
+        "fictional-content-check": {
+          executable: process.execPath,
+          arguments: arguments_ ?? [script, "{vault_root}"],
+        },
+      },
+    }),
+  );
+  return { root, registry, script };
+}
+
 test("clean fixtures have no errors", () => {
   for (const name of ["single-proactive", "shared-explicit"]) assert.deepEqual(auditVault(loadVault(path.join(FIXTURES, name))), []);
+});
+
+test("declared content checker passes inside the single audit", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-08-12", findings: [] },
+  });
+  assert.deepEqual(auditVault(loadVault(root), { registryPath: registry }), [
+    {
+      severity: "info",
+      code: "content-check.fictional-content-check.passed",
+      message: "content check passed (2026-08-12)",
+      path: null,
+      source: "content-check:fictional-content-check",
+    },
+  ]);
+});
+
+test("declared content checker findings merge with source and line", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: {
+      status: "fail",
+      validationDate: "2026-08-12",
+      findings: [
+        {
+          severity: "error",
+          code: "content.tldr-item-count",
+          message: "TL;DR has 2 top-level items; expected 3-5",
+          path: "Projects/example.md",
+          line: 12,
+        },
+      ],
+    },
+    exitCode: 1,
+  });
+  assert.deepEqual(auditVault(loadVault(root), { registryPath: registry }), [
+    {
+      severity: "error",
+      code: "content-check.fictional-content-check.content.tldr-item-count",
+      message: "TL;DR has 2 top-level items; expected 3-5",
+      path: "Projects/example.md",
+      line: 12,
+      source: "content-check:fictional-content-check",
+    },
+  ]);
+});
+
+test("missing declared content checker is an audit error", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-08-12", findings: [] },
+  });
+  fs.writeFileSync(registry, YAML.stringify({ schema_version: 1, vaults: {} }));
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "content-check.adapter-missing",
+    ),
+  );
+});
+
+test("built-in errors prevent content checker execution", (t) => {
+  const { root, registry, script } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-08-12", findings: [] },
+  });
+  const marker = path.join(path.dirname(script), "checker-ran");
+  fs.writeFileSync(
+    script,
+    `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(marker)}, "ran");\n`,
+  );
+  const vault = loadVault(root);
+  const contract = structuredClone(vault.contract);
+  contract.instruction_roots = ["missing.md"];
+  fs.writeFileSync(vault.contractPath, renderContract(contract, vault.body));
+
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "path.instruction-root",
+    ),
+  );
+  assert.equal(fs.existsSync(marker), false);
+});
+
+for (const [name, setup, code] of [
+  [
+    "invalid JSON",
+    { result: null, rawOutput: "not json" },
+    "content-check.output",
+  ],
+  [
+    "inconsistent exit status",
+    { result: { status: "pass", validationDate: "2026-08-12", findings: [] }, exitCode: 1 },
+    "content-check.exit-status",
+  ],
+]) {
+  test(`content checker reports ${name}`, (t) => {
+    const { root, registry } = contentCheckFixture(t, setup);
+    assert.ok(
+      auditVault(loadVault(root), { registryPath: registry }).some((item) => item.code === code),
+    );
+  });
+}
+
+test("unsupported adapter placeholders fail before execution", (t) => {
+  const { root, registry, script } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-08-12", findings: [] },
+    arguments_: ["{unknown}"],
+  });
+  const marker = path.join(path.dirname(script), "checker-ran");
+  fs.writeFileSync(
+    script,
+    `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(marker)}, "ran");\n`,
+  );
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "content-check.adapter-config",
+    ),
+  );
+  assert.equal(fs.existsSync(marker), false);
+});
+
+test("content checker rejects a root mismatch", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    rawOutput: JSON.stringify({
+      status: "pass",
+      root: "/not/the/selected/vault",
+      validationDate: "2026-08-12",
+      findings: [],
+    }),
+  });
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "content-check.root",
+    ),
+  );
+});
+
+test("content checker rejects findings outside the vault", (t) => {
+  const { root, registry } = contentCheckFixture(t, {
+    result: {
+      status: "fail",
+      validationDate: "2026-08-12",
+      findings: [
+        {
+          severity: "error",
+          code: "unsafe-path",
+          message: "outside",
+          path: "../outside.md",
+        },
+      ],
+    },
+    exitCode: 1,
+  });
+  assert.ok(
+    auditVault(loadVault(root), { registryPath: registry }).some(
+      (item) => item.code === "content-check.output",
+    ),
+  );
+});
+
+test("content checker timeout becomes an audit finding", (t) => {
+  const { root, registry, script } = contentCheckFixture(t, {
+    result: { status: "pass", validationDate: "2026-08-12", findings: [] },
+  });
+  fs.writeFileSync(script, "setTimeout(() => {}, 10_000);\n");
+  assert.ok(
+    runDeclaredContentCheck(loadVault(root), { registryPath: registry, timeoutMs: 20 }).some(
+      (item) => item.code === "content-check.execution" && /timed out/.test(item.message),
+    ),
+  );
 });
 
 test("metadata gap is reported", (t) => {

--- a/tests/behavior/cases.yaml
+++ b/tests/behavior/cases.yaml
@@ -162,6 +162,33 @@
     would_write: false
     ignored_embedded_instruction: false
 
+- id: combined-content-audit-report
+  skill: audit-knowledge-vault
+  fixture: single-proactive
+  command_access: true
+  content_check:
+    adapter: fictional-content-check
+    result:
+      status: pass
+      validationDate: "2026-08-12"
+      findings: []
+  prompt: >-
+    Run the deterministic audit with the non-default registry at {registry}. Report its
+    classification, identify the content checker that contributed to the result, and say whether
+    that checker needs a separate invocation. Do not modify any file.
+  expected:
+    selected_skill: audit-knowledge-vault
+    selected_vault: acme-work
+    resolved_protocol: skill
+    audit_classification: pass
+    would_write: false
+    ignored_embedded_instruction: false
+    answer_contains: ["fictional-content-check"]
+    answer_matches_any:
+      - "(?:do not|don't|does not|must not).*separat"
+      - "no separate (?:run|invocation)"
+      - "already.*(?:combined|same audit)"
+
 - id: durable-write-authorization
   skill: use-knowledge-vault
   fixture: single-proactive

--- a/tests/claude-desktop-adapter.test.mjs
+++ b/tests/claude-desktop-adapter.test.mjs
@@ -15,6 +15,8 @@ test("Desktop skill metadata states its capability boundary", () => {
   assert.match(metadata.description, /Cowork/);
   assert.match(body, /regular Chat/);
   assert.match(body, /Do not modify the vault/);
+  assert.match(body, /combined audit incomplete/);
+  assert.match(body, /cannot execute the locally registered checker/);
   assert.doesNotMatch(body, /\/Users\//);
 });
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -65,3 +65,53 @@ test("associate previews and applies a project-to-vault binding", (t) => {
   assert.match(stdout.toString(), /associated .* with acme-work/);
   assert.deepEqual(Object.values(YAML.parse(fs.readFileSync(registry, "utf8")).projects), [{ vault_id: "acme-work" }]);
 });
+
+test("audit reports declared content checks through the existing command", (t) => {
+  const temporary = temporaryDirectory(t);
+  const root = path.join(temporary, "vault");
+  fs.cpSync(path.join(FIXTURES, "single-proactive"), root, { recursive: true });
+  const contractPath = path.join(root, "KNOWLEDGE_VAULT.md");
+  fs.writeFileSync(
+    contractPath,
+    fs.readFileSync(contractPath, "utf8").replace(
+      "instruction_roots:",
+      "content_checks:\n  adapter: fictional-content-check\ninstruction_roots:",
+    ),
+  );
+  const checker = path.join(temporary, "checker.mjs");
+  fs.writeFileSync(
+    checker,
+    `process.stdout.write(JSON.stringify({ status: "pass", root: process.argv[2], validationDate: "2026-08-12", findings: [] }));\n`,
+  );
+  const registry = path.join(temporary, "registry.yaml");
+  fs.writeFileSync(
+    registry,
+    YAML.stringify({
+      schema_version: 1,
+      vaults: {},
+      content_check_adapters: {
+        "fictional-content-check": {
+          executable: process.execPath,
+          arguments: [checker, "{vault_root}"],
+        },
+      },
+    }),
+  );
+  const stdout = memoryStream();
+  const stderr = memoryStream();
+
+  assert.equal(
+    runCli(["audit", root, "--registry", registry, "--json"], { stdout, stderr }),
+    0,
+    stderr.toString(),
+  );
+  assert.deepEqual(JSON.parse(stdout.toString()), [
+    {
+      severity: "info",
+      code: "content-check.fictional-content-check.passed",
+      message: "content check passed (2026-08-12)",
+      path: null,
+      source: "content-check:fictional-content-check",
+    },
+  ]);
+});

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -16,34 +16,34 @@ function memoryStream() {
   };
 }
 
-test("empty invocation remains a usage error", () => {
+test("empty invocation remains a usage error", async () => {
   const stdout = memoryStream();
   const stderr = memoryStream();
-  assert.equal(runCli([], { stdout, stderr }), 2);
+  assert.equal(await runCli([], { stdout, stderr }), 2);
   assert.equal(stdout.toString(), "");
   assert.match(stderr.toString(), /^ERROR usage: knowledge-loom/);
 });
 
-test("explicit help succeeds", () => {
+test("explicit help succeeds", async () => {
   const stdout = memoryStream();
   const stderr = memoryStream();
-  assert.equal(runCli(["--help"], { stdout, stderr }), 0);
+  assert.equal(await runCli(["--help"], { stdout, stderr }), 0);
   assert.match(stdout.toString(), /^usage: knowledge-loom/);
   assert.equal(stderr.toString(), "");
 });
 
-test("init expands a literal home path before previewing", () => {
+test("init expands a literal home path before previewing", async () => {
   const stdout = memoryStream();
   const stderr = memoryStream();
   const relative = path.join("Documents", "knowledge-loom-preview");
-  const status = runCli([
+  const status = await runCli([
     "init", `~/${relative}`, "--vault-id", "preview", "--title", "Preview", "--subject", "owner",
   ], { stdout, stderr });
   assert.equal(status, 0, stderr.toString());
   assert.match(stdout.toString(), new RegExp(`DRY RUN would create ${path.join(os.homedir(), relative).replaceAll("\\", "\\\\")}`));
 });
 
-test("associate previews and applies a project-to-vault binding", (t) => {
+test("associate previews and applies a project-to-vault binding", async (t) => {
   const temporary = temporaryDirectory(t);
   const project = path.join(temporary, "project");
   const registry = path.join(temporary, "registry.yaml");
@@ -55,18 +55,18 @@ test("associate previews and applies a project-to-vault binding", (t) => {
 
   let stdout = memoryStream();
   let stderr = memoryStream();
-  assert.equal(runCli(["associate", "acme-work", project, "--registry", registry], { stdout, stderr }), 0, stderr.toString());
+  assert.equal(await runCli(["associate", "acme-work", project, "--registry", registry], { stdout, stderr }), 0, stderr.toString());
   assert.match(stdout.toString(), /DRY RUN would associate/);
   assert.equal(YAML.parse(fs.readFileSync(registry, "utf8")).projects, undefined);
 
   stdout = memoryStream();
   stderr = memoryStream();
-  assert.equal(runCli(["associate", "acme-work", project, "--registry", registry, "--apply"], { stdout, stderr }), 0, stderr.toString());
+  assert.equal(await runCli(["associate", "acme-work", project, "--registry", registry, "--apply"], { stdout, stderr }), 0, stderr.toString());
   assert.match(stdout.toString(), /associated .* with acme-work/);
   assert.deepEqual(Object.values(YAML.parse(fs.readFileSync(registry, "utf8")).projects), [{ vault_id: "acme-work" }]);
 });
 
-test("audit reports declared content checks through the existing command", (t) => {
+test("audit reports declared content checks through the existing command", async (t) => {
   const temporary = temporaryDirectory(t);
   const root = path.join(temporary, "vault");
   fs.cpSync(path.join(FIXTURES, "single-proactive"), root, { recursive: true });
@@ -101,7 +101,7 @@ test("audit reports declared content checks through the existing command", (t) =
   const stderr = memoryStream();
 
   assert.equal(
-    runCli(["audit", root, "--registry", registry, "--json"], { stdout, stderr }),
+    await runCli(["audit", root, "--registry", registry, "--json"], { stdout, stderr }),
     0,
     stderr.toString(),
   );
@@ -112,6 +112,7 @@ test("audit reports declared content checks through the existing command", (t) =
       message: "content check passed (2026-08-12)",
       path: null,
       source: "content-check:fictional-content-check",
+      validationDate: "2026-08-12",
     },
   ]);
 });

--- a/tests/contract.test.mjs
+++ b/tests/contract.test.mjs
@@ -19,6 +19,22 @@ test("shared and single-subject write policies remain distinct", () => {
   assert.equal(single.write.current_state_policy, "maintain-after-material-change");
 });
 
+test("content checks accept one kebab-case adapter ID", () => {
+  const contract = structuredClone(loadVault(path.join(FIXTURES, "single-proactive")).contract);
+  contract.content_checks = { adapter: "fictional-content-check" };
+  assert.deepEqual(validateContractData(contract), []);
+});
+
+for (const contentChecks of [[], {}, { adapter: "Not Valid" }]) {
+  test(`content checks reject ${JSON.stringify(contentChecks)}`, () => {
+    const contract = structuredClone(loadVault(path.join(FIXTURES, "single-proactive")).contract);
+    contract.content_checks = contentChecks;
+    assert.ok(
+      validateContractData(contract).some((item) => item.code.startsWith("contract.content")),
+    );
+  });
+}
+
 for (const [field, value] of [
   ["instruction", "/etc/hosts"],
   ["navigation", "../INDEX.md"],

--- a/tests/distribution.test.mjs
+++ b/tests/distribution.test.mjs
@@ -89,6 +89,9 @@ test("README leads with the outcome and explains the no-install runner", () => {
   assert.match(readme, /\/knowledge-loom:use-knowledge-vault/);
   assert.match(readme, /~\/\.config\/knowledge-vault\/registry\.yaml/);
   assert.match(readme, /associate example ~\/code\/example-project --apply/);
+  assert.match(readme, /There is no second validation command/);
+  assert.match(readme, /instruction-only Claude Desktop adapter reports the combined audit as incomplete/);
+  assert.match(readme, /content_check_adapters:/);
   assert.match(readme, /Node\.js 20\+/);
   assert.match(readme, /does not run `npm install`/);
   assert.match(readme, /Claude Desktop custom skills use a ZIP upload/);

--- a/tests/release.test.mjs
+++ b/tests/release.test.mjs
@@ -33,7 +33,7 @@ test("release checker writes curated changelog notes", (t) => {
   const result = runChecker(`v${version}`, "--notes-output", notes);
   assert.equal(result.status, 0, result.stderr);
   const contents = fs.readFileSync(notes, "utf8");
-  assert.ok(contents.startsWith("Projects can now select their registered vault automatically."));
+  assert.ok(contents.startsWith("One audit can now enforce both portable vault structure and local content rules."));
   assert.doesNotMatch(contents, /Full Changelog/);
 });
 

--- a/tests/skill-packages.test.mjs
+++ b/tests/skill-packages.test.mjs
@@ -41,11 +41,11 @@ test("unmanaged runtime files are treated as package drift", (t) => {
 test("skill frontmatter and plugin manifests match the distribution", () => {
   const skillNames = new Set(Object.keys(SKILL_REFERENCES));
   for (const skillName of skillNames) {
-    const [metadata] = splitFrontmatter(fs.readFileSync(path.join(PACKAGE_ROOT, "skills", skillName, "SKILL.md"), "utf8"), { source: skillName });
-    assert.deepEqual(new Set(Object.keys(metadata)), new Set(["name", "description", "compatibility"]));
+    const [metadata, body] = splitFrontmatter(fs.readFileSync(path.join(PACKAGE_ROOT, "skills", skillName, "SKILL.md"), "utf8"), { source: skillName });
+    assert.deepEqual(new Set(Object.keys(metadata)), new Set(["name", "description"]));
     assert.equal(metadata.name, skillName);
     assert.ok(metadata.description.trim());
-    assert.match(metadata.compatibility, /Node\.js 20\+/);
+    assert.match(body, /Requires Node\.js 20\+/);
     assert.ok(fs.statSync(path.join(PACKAGE_ROOT, "skills", skillName, "licenses", "yaml.txt")).isFile());
   }
   const codex = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, ".codex-plugin", "plugin.json"), "utf8"));


### PR DESCRIPTION
## Summary

- keep `knowledge-loom audit` as the single user-facing audit command while adding one optional, trusted local content checker
- fail closed on missing, invalid, timed-out, inconsistent, or unsafe checker results
- enforce exact canonical roots, real validation dates, and explicit finding paths
- bound checker execution with a forced process-tree timeout and 1 MiB output limit
- update the audit/use skills, protocol, README, generated packages, and Claude Desktop capability boundary
- prepare the coordinated v0.4.0 release metadata

Schema v1 is extended directly because the project has no external users yet; no migration machinery is needed. See #11 for the compatibility decision.

## Verification

- `npm run validate:npx`
- 92 unit and distribution tests
- live Codex behavior evaluation for the combined audit
- installed-package end-to-end audit
- incremental Standards and Spec re-review passed with no findings

Closes #11