### PR TITLE
Release v0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "knowledge-loom",
       "source": "./",
       "description": "Keep Codex and Claude inside clear boundaries when they read or update local Markdown notes.",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "author": {
         "name": "Mike Xiao",
         "url": "https://github.com/magickaichen"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v0.7.0
+
+Durable vault notes and navigation pointers now have an agent-readable writing gate with optional
+support for Matt Pocock's unmodified `writing-for-agents` skill.
+
+### Added
+
+- Added protocol-owned checks for one source of truth, co-located rationale and provenance, stable
+  terminology, conditional navigation pointers, lifecycle state, and duplicate pruning.
+- Added optional `writing-for-agents` invocation after write authorization when Distill will create
+  or restructure an agent-consumed note or navigation pointer.
+- Added a self-contained built-in authoring fallback when the companion skill is unavailable.
+- Added hermetic Codex and Claude behavior coverage for companion availability, retrieval-only
+  work, and authority boundaries.
+
+### Compatibility and safety
+
+- Kept `writing-for-agents` optional rather than making it an installation prerequisite.
+- Kept authority, evidence, privacy, subject isolation, validation, Git, sync, backup, and lifecycle
+  behavior under the Knowledge Vault Protocol.
+- Preserved contract schema version 1 and all existing installation routes.
+
+### Maintenance
+
+- Added agent-neutral contributor guidance for issue tracking, triage labels, and domain docs.
+- Updated GitHub Actions to `actions/setup-node@v7`.
+
 ## v0.6.0
 
 All handwritten contributor code now uses strict TypeScript while every installation route

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-loom",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-loom",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Agent-neutral governance and skills for local Markdown knowledge vaults",
   "type": "module",

--- a/tests/release.test.ts
+++ b/tests/release.test.ts
@@ -37,8 +37,9 @@ test("release checker writes curated changelog notes", (t) => {
   const result = runChecker(`v${version}`, "--notes-output", notes);
   assert.equal(result.status, 0, result.stderr);
   const contents = fs.readFileSync(notes, "utf8");
-  assert.ok(contents.startsWith("All handwritten contributor code now uses strict TypeScript"));
-  assert.match(contents, /self-contained JavaScript runner/);
+  assert.ok(contents.startsWith("Durable vault notes and navigation pointers now have an agent-readable writing gate"));
+  assert.match(contents, /optional `writing-for-agents` invocation/);
+  assert.match(contents, /Preserved contract schema version 1/);
   assert.doesNotMatch(contents, /Full Changelog/);
 });
 


### PR DESCRIPTION
## Summary

- release the agent-readable Distill and optional writing-for-agents integration from #20 as v0.7.0
- synchronize package, lockfile, Codex, Claude, and marketplace version metadata
- publish curated v0.7.0 notes and update the release-note assertion

## Validation

- npm run validate:npx
- 97 tests passed
- isolated skills@1.5.22 installation passed for all supported agents
- Standards review: 0 findings
- Spec review: 0 findings

## After merge

- create and push the annotated v0.7.0 tag
- verify the release workflow publishes the versioned Claude Desktop ZIP and curated notes
