### PR TITLE
Release v0.7.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "knowledge-loom",
       "source": "./",
       "description": "Keep Codex and Claude inside clear boundaries when they read or update local Markdown notes.",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "Mike Xiao",
         "url": "https://github.com/magickaichen"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.7.1
+
+Linked Git worktrees now reuse the vault association registered for their main checkout.
+
+### Fixed
+
+- Added a `git rev-parse --git-common-dir` fallback when no project association matches the
+  current worktree path directly.
+- Preserved direct worktree associations as the higher-priority match.
+- Added a regression test through the public `probe` command with a real linked worktree.
+
+### Compatibility
+
+- Preserved registry schema version 1 and all existing project associations.
+- Required no registry migration or per-worktree entries for temporary checkouts.
+
 ## v0.7.0
 
 Durable vault notes and navigation pointers now have an agent-readable writing gate with optional

--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ projects:
 The registry stays outside both repositories. An explicit ID or path still wins. Inside a vault,
 the nearest `KNOWLEDGE_VAULT.md` wins. Otherwise, the nearest project association wins; nested
 projects can deliberately override a parent association. A broken association stops resolution
-instead of silently choosing another vault.
+instead of silently choosing another vault. Linked Git worktrees inherit the main checkout's
+association through their Git common directory, so temporary worktrees do not need separate
+registry entries. A direct worktree association still takes precedence when one exists.
 
 ### Optional vault-specific content checks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-loom",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-loom",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "yaml": "2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Agent-neutral governance and skills for local Markdown knowledge vaults",
   "type": "module",

--- a/references/protocol.md
+++ b/references/protocol.md
@@ -47,7 +47,9 @@ Resolve a vault deterministically:
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority.
+or backup authority. When the current directory is inside a linked Git worktree and no association
+matches that path directly, use the repository's Git common directory to match the equivalent path
+in the main checkout. Do not require a separate registry entry for each temporary worktree.
 
 ## Retrieve
 

--- a/references/protocol.md
+++ b/references/protocol.md
@@ -40,16 +40,17 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise use the nearest project association in the registry.
+3. Otherwise use the nearest project association in the registry. Match the current path first.
+   For a linked Git worktree with no direct match, use its Git common directory to match the
+   equivalent path in the main checkout.
 4. Otherwise, if the registry contains exactly one valid vault, use it.
 5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
    and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority. When the current directory is inside a linked Git worktree and no association
-matches that path directly, use the repository's Git common directory to match the equivalent path
-in the main checkout. Do not require a separate registry entry for each temporary worktree.
+or backup authority. One main-checkout association covers its linked worktrees; a direct worktree
+association remains the nearest match.
 
 ## Retrieve
 

--- a/skills/audit-knowledge-vault/references/protocol.md
+++ b/skills/audit-knowledge-vault/references/protocol.md
@@ -47,7 +47,9 @@ Resolve a vault deterministically:
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority.
+or backup authority. When the current directory is inside a linked Git worktree and no association
+matches that path directly, use the repository's Git common directory to match the equivalent path
+in the main checkout. Do not require a separate registry entry for each temporary worktree.
 
 ## Retrieve
 

--- a/skills/audit-knowledge-vault/references/protocol.md
+++ b/skills/audit-knowledge-vault/references/protocol.md
@@ -40,16 +40,17 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise use the nearest project association in the registry.
+3. Otherwise use the nearest project association in the registry. Match the current path first.
+   For a linked Git worktree with no direct match, use its Git common directory to match the
+   equivalent path in the main checkout.
 4. Otherwise, if the registry contains exactly one valid vault, use it.
 5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
    and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority. When the current directory is inside a linked Git worktree and no association
-matches that path directly, use the repository's Git common directory to match the equivalent path
-in the main checkout. Do not require a separate registry entry for each temporary worktree.
+or backup authority. One main-checkout association covers its linked worktrees; a direct worktree
+association remains the nearest match.
 
 ## Retrieve
 

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,6 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7768,6 +7769,22 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
   }
   return { ...record, vault_id: record.vault_id };
 }
+function mainCheckoutEquivalent(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+    encoding: "utf8"
+  });
+  if (completed.status !== 0) return null;
+  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  if (!worktreeOutput || !commonDirectoryOutput) return null;
+  const worktreeRoot = canonicalPath(worktreeOutput);
+  const commonDirectory = path3.resolve(current, commonDirectoryOutput);
+  if (path3.basename(commonDirectory) !== ".git") return null;
+  const mainCheckout = canonicalPath(path3.dirname(commonDirectory));
+  if (mainCheckout === worktreeRoot || !isWithin(worktreeRoot, current)) return null;
+  return path3.join(mainCheckout, path3.relative(worktreeRoot, current));
+}
 function projectAssociation(start, registry) {
   if (registry.projects === void 0) return null;
   const projects = requireProjectsMapping(registry.projects);
@@ -7796,7 +7813,10 @@ function applicableVaultContext(cwd, registryPath) {
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return { vault: loadVault(ancestor), registry: null };
   const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
+  const association = projectAssociation(cwd, registry) ?? (() => {
+    const mainCheckout = mainCheckoutEquivalent(cwd);
+    return mainCheckout ? projectAssociation(mainCheckout, registry) : null;
+  })();
   const vault = association ? registeredVault(projectRecord(association.configuredRoot, association.record).vault_id, registry) : null;
   return { vault, registry };
 }
@@ -8291,7 +8311,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/init-knowledge-vault/references/protocol.md
+++ b/skills/init-knowledge-vault/references/protocol.md
@@ -47,7 +47,9 @@ Resolve a vault deterministically:
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority.
+or backup authority. When the current directory is inside a linked Git worktree and no association
+matches that path directly, use the repository's Git common directory to match the equivalent path
+in the main checkout. Do not require a separate registry entry for each temporary worktree.
 
 ## Retrieve
 

--- a/skills/init-knowledge-vault/references/protocol.md
+++ b/skills/init-knowledge-vault/references/protocol.md
@@ -40,16 +40,17 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise use the nearest project association in the registry.
+3. Otherwise use the nearest project association in the registry. Match the current path first.
+   For a linked Git worktree with no direct match, use its Git common directory to match the
+   equivalent path in the main checkout.
 4. Otherwise, if the registry contains exactly one valid vault, use it.
 5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
    and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority. When the current directory is inside a linked Git worktree and no association
-matches that path directly, use the repository's Git common directory to match the equivalent path
-in the main checkout. Do not require a separate registry entry for each temporary worktree.
+or backup authority. One main-checkout association covers its linked worktrees; a direct worktree
+association remains the nearest match.
 
 ## Retrieve
 

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,6 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7768,6 +7769,22 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
   }
   return { ...record, vault_id: record.vault_id };
 }
+function mainCheckoutEquivalent(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+    encoding: "utf8"
+  });
+  if (completed.status !== 0) return null;
+  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  if (!worktreeOutput || !commonDirectoryOutput) return null;
+  const worktreeRoot = canonicalPath(worktreeOutput);
+  const commonDirectory = path3.resolve(current, commonDirectoryOutput);
+  if (path3.basename(commonDirectory) !== ".git") return null;
+  const mainCheckout = canonicalPath(path3.dirname(commonDirectory));
+  if (mainCheckout === worktreeRoot || !isWithin(worktreeRoot, current)) return null;
+  return path3.join(mainCheckout, path3.relative(worktreeRoot, current));
+}
 function projectAssociation(start, registry) {
   if (registry.projects === void 0) return null;
   const projects = requireProjectsMapping(registry.projects);
@@ -7796,7 +7813,10 @@ function applicableVaultContext(cwd, registryPath) {
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return { vault: loadVault(ancestor), registry: null };
   const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
+  const association = projectAssociation(cwd, registry) ?? (() => {
+    const mainCheckout = mainCheckoutEquivalent(cwd);
+    return mainCheckout ? projectAssociation(mainCheckout, registry) : null;
+  })();
   const vault = association ? registeredVault(projectRecord(association.configuredRoot, association.record).vault_id, registry) : null;
   return { vault, registry };
 }
@@ -8291,7 +8311,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/manage-current-focus/references/protocol.md
+++ b/skills/manage-current-focus/references/protocol.md
@@ -47,7 +47,9 @@ Resolve a vault deterministically:
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority.
+or backup authority. When the current directory is inside a linked Git worktree and no association
+matches that path directly, use the repository's Git common directory to match the equivalent path
+in the main checkout. Do not require a separate registry entry for each temporary worktree.
 
 ## Retrieve
 

--- a/skills/manage-current-focus/references/protocol.md
+++ b/skills/manage-current-focus/references/protocol.md
@@ -40,16 +40,17 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise use the nearest project association in the registry.
+3. Otherwise use the nearest project association in the registry. Match the current path first.
+   For a linked Git worktree with no direct match, use its Git common directory to match the
+   equivalent path in the main checkout.
 4. Otherwise, if the registry contains exactly one valid vault, use it.
 5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
    and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority. When the current directory is inside a linked Git worktree and no association
-matches that path directly, use the repository's Git common directory to match the equivalent path
-in the main checkout. Do not require a separate registry entry for each temporary worktree.
+or backup authority. One main-checkout association covers its linked worktrees; a direct worktree
+association remains the nearest match.
 
 ## Retrieve
 

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,6 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7768,6 +7769,22 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
   }
   return { ...record, vault_id: record.vault_id };
 }
+function mainCheckoutEquivalent(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+    encoding: "utf8"
+  });
+  if (completed.status !== 0) return null;
+  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  if (!worktreeOutput || !commonDirectoryOutput) return null;
+  const worktreeRoot = canonicalPath(worktreeOutput);
+  const commonDirectory = path3.resolve(current, commonDirectoryOutput);
+  if (path3.basename(commonDirectory) !== ".git") return null;
+  const mainCheckout = canonicalPath(path3.dirname(commonDirectory));
+  if (mainCheckout === worktreeRoot || !isWithin(worktreeRoot, current)) return null;
+  return path3.join(mainCheckout, path3.relative(worktreeRoot, current));
+}
 function projectAssociation(start, registry) {
   if (registry.projects === void 0) return null;
   const projects = requireProjectsMapping(registry.projects);
@@ -7796,7 +7813,10 @@ function applicableVaultContext(cwd, registryPath) {
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return { vault: loadVault(ancestor), registry: null };
   const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
+  const association = projectAssociation(cwd, registry) ?? (() => {
+    const mainCheckout = mainCheckoutEquivalent(cwd);
+    return mainCheckout ? projectAssociation(mainCheckout, registry) : null;
+  })();
   const vault = association ? registeredVault(projectRecord(association.configuredRoot, association.record).vault_id, registry) : null;
   return { vault, registry };
 }
@@ -8291,7 +8311,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/use-knowledge-vault/references/protocol.md
+++ b/skills/use-knowledge-vault/references/protocol.md
@@ -47,7 +47,9 @@ Resolve a vault deterministically:
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority.
+or backup authority. When the current directory is inside a linked Git worktree and no association
+matches that path directly, use the repository's Git common directory to match the equivalent path
+in the main checkout. Do not require a separate registry entry for each temporary worktree.
 
 ## Retrieve
 

--- a/skills/use-knowledge-vault/references/protocol.md
+++ b/skills/use-knowledge-vault/references/protocol.md
@@ -40,16 +40,17 @@ Resolve a vault deterministically:
 
 1. Use an explicit path or registry ID supplied by the user or invoking wrapper.
 2. Otherwise use the nearest ancestor containing `KNOWLEDGE_VAULT.md`.
-3. Otherwise use the nearest project association in the registry.
+3. Otherwise use the nearest project association in the registry. Match the current path first.
+   For a linked Git worktree with no direct match, use its Git common directory to match the
+   equivalent path in the main checkout.
 4. Otherwise, if the registry contains exactly one valid vault, use it.
 5. If multiple candidates remain, ask for a selection. If a matching association is invalid, stop
    and report it instead of falling back.
 
 Never select a vault from topic similarity. Never combine vaults without explicit authorization.
 Project associations select a registered vault; they do not extend that vault's read, write, sync,
-or backup authority. When the current directory is inside a linked Git worktree and no association
-matches that path directly, use the repository's Git common directory to match the equivalent path
-in the main checkout. Do not require a separate registry entry for each temporary worktree.
+or backup authority. One main-checkout association covers its linked worktrees; a direct worktree
+association remains the nearest match.
 
 ## Retrieve
 

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync } from "node:child_process";
+import { spawnSync as spawnSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,6 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7768,6 +7769,22 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
   }
   return { ...record, vault_id: record.vault_id };
 }
+function mainCheckoutEquivalent(start) {
+  let current = canonicalPath(start);
+  if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
+  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+    encoding: "utf8"
+  });
+  if (completed.status !== 0) return null;
+  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  if (!worktreeOutput || !commonDirectoryOutput) return null;
+  const worktreeRoot = canonicalPath(worktreeOutput);
+  const commonDirectory = path3.resolve(current, commonDirectoryOutput);
+  if (path3.basename(commonDirectory) !== ".git") return null;
+  const mainCheckout = canonicalPath(path3.dirname(commonDirectory));
+  if (mainCheckout === worktreeRoot || !isWithin(worktreeRoot, current)) return null;
+  return path3.join(mainCheckout, path3.relative(worktreeRoot, current));
+}
 function projectAssociation(start, registry) {
   if (registry.projects === void 0) return null;
   const projects = requireProjectsMapping(registry.projects);
@@ -7796,7 +7813,10 @@ function applicableVaultContext(cwd, registryPath) {
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return { vault: loadVault(ancestor), registry: null };
   const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
+  const association = projectAssociation(cwd, registry) ?? (() => {
+    const mainCheckout = mainCheckoutEquivalent(cwd);
+    return mainCheckout ? projectAssociation(mainCheckout, registry) : null;
+  })();
   const vault = association ? registeredVault(projectRecord(association.configuredRoot, association.record).vault_id, registry) : null;
   return { vault, registry };
 }
@@ -8291,7 +8311,7 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/src/knowledge-loom/registry.ts
+++ b/src/knowledge-loom/registry.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -124,6 +125,24 @@ interface ProjectMatch {
   distance: number;
 }
 
+function mainCheckoutEquivalent(start: string): string | null {
+  let current = canonicalPath(start);
+  if (fs.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path.dirname(current);
+  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+    encoding: "utf8",
+  });
+  if (completed.status !== 0) return null;
+  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  if (!worktreeOutput || !commonDirectoryOutput) return null;
+
+  const worktreeRoot = canonicalPath(worktreeOutput);
+  const commonDirectory = path.resolve(current, commonDirectoryOutput);
+  if (path.basename(commonDirectory) !== ".git") return null;
+  const mainCheckout = canonicalPath(path.dirname(commonDirectory));
+  if (mainCheckout === worktreeRoot || !isWithin(worktreeRoot, current)) return null;
+  return path.join(mainCheckout, path.relative(worktreeRoot, current));
+}
+
 function projectAssociation(start: string, registry: Registry): ProjectMatch | null {
   if (registry.projects === undefined) return null;
   const projects = requireProjectsMapping(registry.projects);
@@ -153,7 +172,11 @@ function applicableVaultContext(cwd: string, registryPath: string | undefined): 
   const ancestor = findAncestorVault(cwd);
   if (ancestor) return { vault: loadVault(ancestor), registry: null };
   const registry = loadRegistry(registryPath);
-  const association = projectAssociation(cwd, registry);
+  const association = projectAssociation(cwd, registry)
+    ?? (() => {
+      const mainCheckout = mainCheckoutEquivalent(cwd);
+      return mainCheckout ? projectAssociation(mainCheckout, registry) : null;
+    })();
   const vault = association ? registeredVault(projectRecord(association.configuredRoot, association.record).vault_id, registry) : null;
   return { vault, registry };
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -14,6 +15,11 @@ function memoryStream() {
     write(value: string) { contents += value; },
     toString() { return contents; },
   };
+}
+
+function runGit(arguments_: string[]): void {
+  const completed = spawnSync("git", arguments_, { encoding: "utf8" });
+  assert.equal(completed.status, 0, completed.stderr);
 }
 
 test("empty invocation remains a usage error", async () => {
@@ -86,6 +92,31 @@ test("associate previews and applies a project-to-vault binding", async (t) => {
   stdout = memoryStream();
   stderr = memoryStream();
   assert.equal(await runCli(["probe", "--registry", registry], { cwd: project, stdout, stderr }), 0, stderr.toString());
+  assert.equal(stdout.toString(), `${fs.realpathSync(path.join(FIXTURES, "single-proactive"))}\n`);
+});
+
+test("probe follows a main checkout association from a linked worktree", async (t) => {
+  const temporary = temporaryDirectory(t);
+  const project = path.join(temporary, "project");
+  const worktree = path.join(temporary, "temporary-worktree");
+  const nested = path.join(worktree, "packages", "app");
+  const registry = path.join(temporary, "registry.yaml");
+  fs.mkdirSync(project);
+  runGit(["-C", project, "init", "--initial-branch=main"]);
+  fs.writeFileSync(path.join(project, "README.md"), "# Project\n");
+  runGit(["-C", project, "add", "README.md"]);
+  runGit(["-C", project, "-c", "user.name=Knowledge Loom", "-c", "user.email=tests@example.com", "commit", "-m", "initial"]);
+  runGit(["-C", project, "worktree", "add", "--detach", worktree, "HEAD"]);
+  fs.mkdirSync(nested, { recursive: true });
+  fs.writeFileSync(registry, YAML.stringify({
+    schema_version: 1,
+    vaults: { "acme-work": { path: path.join(FIXTURES, "single-proactive") } },
+    projects: { [project]: { vault_id: "acme-work" } },
+  }));
+  const stdout = memoryStream();
+  const stderr = memoryStream();
+
+  assert.equal(await runCli(["probe", "--registry", registry], { cwd: nested, stdout, stderr }), 0, stderr.toString());
   assert.equal(stdout.toString(), `${fs.realpathSync(path.join(FIXTURES, "single-proactive"))}\n`);
 });
 

--- a/tests/release.test.ts
+++ b/tests/release.test.ts
@@ -37,9 +37,9 @@ test("release checker writes curated changelog notes", (t) => {
   const result = runChecker(`v${version}`, "--notes-output", notes);
   assert.equal(result.status, 0, result.stderr);
   const contents = fs.readFileSync(notes, "utf8");
-  assert.ok(contents.startsWith("Durable vault notes and navigation pointers now have an agent-readable writing gate"));
-  assert.match(contents, /optional `writing-for-agents` invocation/);
-  assert.match(contents, /Preserved contract schema version 1/);
+  assert.ok(contents.startsWith("Linked Git worktrees now reuse the vault association registered for their main checkout"));
+  assert.match(contents, /`git rev-parse --git-common-dir` fallback/);
+  assert.match(contents, /Preserved registry schema version 1/);
   assert.doesNotMatch(contents, /Full Changelog/);
 });
 


### PR DESCRIPTION
## Summary

- Resolve registered vault associations from linked Git worktrees through `git rev-parse --git-common-dir`.
- Keep direct worktree associations higher priority and require no registry migration.
- Co-locate the worktree rule with vault selection, rebuild distributed skill packages, and release the fix as v0.7.1.

## Validation

- `npm run validate:npx` — 98 tests passed; audits and behavior dry-runs passed.
- Standards review — 0 findings.
- Spec review — 0 findings.

Closes #23