### PR TITLE
Avoid false-positive command injection findings in plugin scans

### DIFF
--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8321,10 +8321,6 @@ function globRegex(pattern, { characterClasses = true } = {}) {
 function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
-function git(root, ...arguments_) {
-  const stdout = gitOutput(root, arguments_);
-  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
-}
 function auditDeclaredFiles(root, values, {
   boundaryCode,
   boundaryMessage,
@@ -8445,16 +8441,15 @@ async function auditVault(vault, { registryPath } = {}) {
     validNeverTrack.push(patternValue);
   }
   const history = isUnknownRecord(contract.history) ? contract.history : {};
-  const gitCheck = git(root, "rev-parse", "--show-toplevel");
-  const gitRoot = gitCheck.status === 0 ? gitCheck.stdout.trim() : "";
+  const gitRoot = gitOutput(root, ["rev-parse", "--show-toplevel"])?.trim() ?? "";
   const isGit = Boolean(gitRoot) && canonicalPath(gitRoot) === canonicalPath(root);
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = git(root, "status", "--short");
-    if (status.stdout.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = git(root, "ls-files");
-    for (const relative of tracked.stdout.split(/\r?\n/).filter(Boolean)) {
+    const status = gitOutput(root, ["status", "--short"]);
+    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const tracked = gitOutput(root, ["ls-files"]);
+    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,7 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7772,11 +7772,16 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-    encoding: "utf8"
-  });
-  if (completed.status !== 0) return null;
-  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  let output;
+  try {
+    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+  const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
   const commonDirectory = path3.resolve(current, commonDirectoryOutput);
@@ -8311,7 +8316,17 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  try {
+    return {
+      status: 0,
+      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"]
+      })
+    };
+  } catch {
+    return { status: 1, stdout: "" };
+  }
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,6 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,10 +7675,24 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
+
+// src/knowledge-loom/git.ts
+import { execFileSync } from "node:child_process";
+function gitOutput(root, arguments_) {
+  try {
+    return execFileSync("git", ["-C", root, ...arguments_], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+}
+
+// src/knowledge-loom/registry.ts
 function defaultRegistryPath() {
   return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
 }
@@ -7772,15 +7785,8 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  let output;
-  try {
-    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-  } catch {
-    return null;
-  }
+  const output = gitOutput(current, ["rev-parse", "--show-toplevel", "--git-common-dir"]);
+  if (output === null) return null;
   const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
@@ -8316,17 +8322,8 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  try {
-    return {
-      status: 0,
-      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"]
-      })
-    };
-  } catch {
-    return { status: 1, stdout: "" };
-  }
+  const stdout = gitOutput(root, arguments_);
+  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8446,10 +8446,10 @@ async function auditVault(vault, { registryPath } = {}) {
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = gitOutput(root, ["status", "--short"]);
-    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = gitOutput(root, ["ls-files"]);
-    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
+    const statusOutput = gitOutput(root, ["status", "--short"]);
+    if (statusOutput?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const trackedFilesOutput = gitOutput(root, ["ls-files"]);
+    for (const relative of (trackedFilesOutput ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8321,10 +8321,6 @@ function globRegex(pattern, { characterClasses = true } = {}) {
 function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
-function git(root, ...arguments_) {
-  const stdout = gitOutput(root, arguments_);
-  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
-}
 function auditDeclaredFiles(root, values, {
   boundaryCode,
   boundaryMessage,
@@ -8445,16 +8441,15 @@ async function auditVault(vault, { registryPath } = {}) {
     validNeverTrack.push(patternValue);
   }
   const history = isUnknownRecord(contract.history) ? contract.history : {};
-  const gitCheck = git(root, "rev-parse", "--show-toplevel");
-  const gitRoot = gitCheck.status === 0 ? gitCheck.stdout.trim() : "";
+  const gitRoot = gitOutput(root, ["rev-parse", "--show-toplevel"])?.trim() ?? "";
   const isGit = Boolean(gitRoot) && canonicalPath(gitRoot) === canonicalPath(root);
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = git(root, "status", "--short");
-    if (status.stdout.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = git(root, "ls-files");
-    for (const relative of tracked.stdout.split(/\r?\n/).filter(Boolean)) {
+    const status = gitOutput(root, ["status", "--short"]);
+    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const tracked = gitOutput(root, ["ls-files"]);
+    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,7 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7772,11 +7772,16 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-    encoding: "utf8"
-  });
-  if (completed.status !== 0) return null;
-  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  let output;
+  try {
+    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+  const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
   const commonDirectory = path3.resolve(current, commonDirectoryOutput);
@@ -8311,7 +8316,17 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  try {
+    return {
+      status: 0,
+      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"]
+      })
+    };
+  } catch {
+    return { status: 1, stdout: "" };
+  }
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,6 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,10 +7675,24 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
+
+// src/knowledge-loom/git.ts
+import { execFileSync } from "node:child_process";
+function gitOutput(root, arguments_) {
+  try {
+    return execFileSync("git", ["-C", root, ...arguments_], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+}
+
+// src/knowledge-loom/registry.ts
 function defaultRegistryPath() {
   return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
 }
@@ -7772,15 +7785,8 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  let output;
-  try {
-    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-  } catch {
-    return null;
-  }
+  const output = gitOutput(current, ["rev-parse", "--show-toplevel", "--git-common-dir"]);
+  if (output === null) return null;
   const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
@@ -8316,17 +8322,8 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  try {
-    return {
-      status: 0,
-      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"]
-      })
-    };
-  } catch {
-    return { status: 1, stdout: "" };
-  }
+  const stdout = gitOutput(root, arguments_);
+  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8446,10 +8446,10 @@ async function auditVault(vault, { registryPath } = {}) {
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = gitOutput(root, ["status", "--short"]);
-    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = gitOutput(root, ["ls-files"]);
-    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
+    const statusOutput = gitOutput(root, ["status", "--short"]);
+    if (statusOutput?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const trackedFilesOutput = gitOutput(root, ["ls-files"]);
+    for (const relative of (trackedFilesOutput ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -8321,10 +8321,6 @@ function globRegex(pattern, { characterClasses = true } = {}) {
 function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
-function git(root, ...arguments_) {
-  const stdout = gitOutput(root, arguments_);
-  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
-}
 function auditDeclaredFiles(root, values, {
   boundaryCode,
   boundaryMessage,
@@ -8445,16 +8441,15 @@ async function auditVault(vault, { registryPath } = {}) {
     validNeverTrack.push(patternValue);
   }
   const history = isUnknownRecord(contract.history) ? contract.history : {};
-  const gitCheck = git(root, "rev-parse", "--show-toplevel");
-  const gitRoot = gitCheck.status === 0 ? gitCheck.stdout.trim() : "";
+  const gitRoot = gitOutput(root, ["rev-parse", "--show-toplevel"])?.trim() ?? "";
   const isGit = Boolean(gitRoot) && canonicalPath(gitRoot) === canonicalPath(root);
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = git(root, "status", "--short");
-    if (status.stdout.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = git(root, "ls-files");
-    for (const relative of tracked.stdout.split(/\r?\n/).filter(Boolean)) {
+    const status = gitOutput(root, ["status", "--short"]);
+    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const tracked = gitOutput(root, ["ls-files"]);
+    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,7 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7772,11 +7772,16 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-    encoding: "utf8"
-  });
-  if (completed.status !== 0) return null;
-  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  let output;
+  try {
+    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+  const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
   const commonDirectory = path3.resolve(current, commonDirectoryOutput);
@@ -8311,7 +8316,17 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  try {
+    return {
+      status: 0,
+      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"]
+      })
+    };
+  } catch {
+    return { status: 1, stdout: "" };
+  }
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,6 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,10 +7675,24 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
+
+// src/knowledge-loom/git.ts
+import { execFileSync } from "node:child_process";
+function gitOutput(root, arguments_) {
+  try {
+    return execFileSync("git", ["-C", root, ...arguments_], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+}
+
+// src/knowledge-loom/registry.ts
 function defaultRegistryPath() {
   return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
 }
@@ -7772,15 +7785,8 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  let output;
-  try {
-    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-  } catch {
-    return null;
-  }
+  const output = gitOutput(current, ["rev-parse", "--show-toplevel", "--git-common-dir"]);
+  if (output === null) return null;
   const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
@@ -8316,17 +8322,8 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  try {
-    return {
-      status: 0,
-      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"]
-      })
-    };
-  } catch {
-    return { status: 1, stdout: "" };
-  }
+  const stdout = gitOutput(root, arguments_);
+  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -8446,10 +8446,10 @@ async function auditVault(vault, { registryPath } = {}) {
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = gitOutput(root, ["status", "--short"]);
-    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = gitOutput(root, ["ls-files"]);
-    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
+    const statusOutput = gitOutput(root, ["status", "--short"]);
+    if (statusOutput?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const trackedFilesOutput = gitOutput(root, ["ls-files"]);
+    for (const relative of (trackedFilesOutput ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8321,10 +8321,6 @@ function globRegex(pattern, { characterClasses = true } = {}) {
 function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
-function git(root, ...arguments_) {
-  const stdout = gitOutput(root, arguments_);
-  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
-}
 function auditDeclaredFiles(root, values, {
   boundaryCode,
   boundaryMessage,
@@ -8445,16 +8441,15 @@ async function auditVault(vault, { registryPath } = {}) {
     validNeverTrack.push(patternValue);
   }
   const history = isUnknownRecord(contract.history) ? contract.history : {};
-  const gitCheck = git(root, "rev-parse", "--show-toplevel");
-  const gitRoot = gitCheck.status === 0 ? gitCheck.stdout.trim() : "";
+  const gitRoot = gitOutput(root, ["rev-parse", "--show-toplevel"])?.trim() ?? "";
   const isGit = Boolean(gitRoot) && canonicalPath(gitRoot) === canonicalPath(root);
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = git(root, "status", "--short");
-    if (status.stdout.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = git(root, "ls-files");
-    for (const relative of tracked.stdout.split(/\r?\n/).filter(Boolean)) {
+    const status = gitOutput(root, ["status", "--short"]);
+    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const tracked = gitOutput(root, ["ls-files"]);
+    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,7 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { spawnSync as spawnSync2 } from "node:child_process";
+import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,7 +7676,7 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
@@ -7772,11 +7772,16 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-    encoding: "utf8"
-  });
-  if (completed.status !== 0) return null;
-  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  let output;
+  try {
+    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+  const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
   const commonDirectory = path3.resolve(current, commonDirectoryOutput);
@@ -8311,7 +8316,17 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  return spawnSync2("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+  try {
+    return {
+      status: 0,
+      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"]
+      })
+    };
+  } catch {
+    return { status: 1, stdout: "" };
+  }
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7371,7 +7371,6 @@ import path7 from "node:path";
 // src/knowledge-loom/audit.ts
 import fs5 from "node:fs";
 import path5 from "node:path";
-import { execFileSync as execFileSync2 } from "node:child_process";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7676,10 +7675,24 @@ import path4 from "node:path";
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
 import crypto from "node:crypto";
-import { execFileSync } from "node:child_process";
 import fs3 from "node:fs";
 import os2 from "node:os";
 import path3 from "node:path";
+
+// src/knowledge-loom/git.ts
+import { execFileSync } from "node:child_process";
+function gitOutput(root, arguments_) {
+  try {
+    return execFileSync("git", ["-C", root, ...arguments_], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+}
+
+// src/knowledge-loom/registry.ts
 function defaultRegistryPath() {
   return process.env.KNOWLEDGE_VAULT_REGISTRY ? path3.resolve(expandHome(process.env.KNOWLEDGE_VAULT_REGISTRY)) : path3.join(os2.homedir(), ".config", "knowledge-vault", "registry.yaml");
 }
@@ -7772,15 +7785,8 @@ function projectRecord(configuredRoot, record, { matching = false } = {}) {
 function mainCheckoutEquivalent(start) {
   let current = canonicalPath(start);
   if (fs3.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path3.dirname(current);
-  let output;
-  try {
-    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"]
-    });
-  } catch {
-    return null;
-  }
+  const output = gitOutput(current, ["rev-parse", "--show-toplevel", "--git-common-dir"]);
+  if (output === null) return null;
   const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
   const worktreeRoot = canonicalPath(worktreeOutput);
@@ -8316,17 +8322,8 @@ function matchesPath(pattern, candidate) {
   return globRegex(pattern).test(candidate);
 }
 function git(root, ...arguments_) {
-  try {
-    return {
-      status: 0,
-      stdout: execFileSync2("git", ["-C", root, ...arguments_], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"]
-      })
-    };
-  } catch {
-    return { status: 1, stdout: "" };
-  }
+  const stdout = gitOutput(root, arguments_);
+  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
 }
 function auditDeclaredFiles(root, values, {
   boundaryCode,

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -8446,10 +8446,10 @@ async function auditVault(vault, { registryPath } = {}) {
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
   if (isGit) {
-    const status = gitOutput(root, ["status", "--short"]);
-    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = gitOutput(root, ["ls-files"]);
-    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
+    const statusOutput = gitOutput(root, ["status", "--short"]);
+    if (statusOutput?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const trackedFilesOutput = gitOutput(root, ["ls-files"]);
+    for (const relative of (trackedFilesOutput ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/src/knowledge-loom/audit.ts
+++ b/src/knowledge-loom/audit.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
 
 import { finding, isUnknownRecord, loadNoteFrontmatter, validateContractData } from "./contract.js";
 import { runDeclaredContentCheck } from "./content-checks.js";
 import { errorMessage } from "./errors.js";
 import { checkFocusView, parseFocusView } from "./focus.js";
+import { gitOutput } from "./git.js";
 import {
   canonicalPath,
   isVaultRelativePath,
@@ -78,17 +78,8 @@ export function matchesPath(pattern: string, candidate: string): boolean {
 }
 
 function git(root: string, ...arguments_: string[]): { status: number; stdout: string } {
-  try {
-    return {
-      status: 0,
-      stdout: execFileSync("git", ["-C", root, ...arguments_], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }),
-    };
-  } catch {
-    return { status: 1, stdout: "" };
-  }
+  const stdout = gitOutput(root, arguments_);
+  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
 }
 
 interface DeclaredFilesOptions {

--- a/src/knowledge-loom/audit.ts
+++ b/src/knowledge-loom/audit.ts
@@ -226,10 +226,10 @@ export async function auditVault(
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
 
   if (isGit) {
-    const status = gitOutput(root, ["status", "--short"]);
-    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = gitOutput(root, ["ls-files"]);
-    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
+    const statusOutput = gitOutput(root, ["status", "--short"]);
+    if (statusOutput?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const trackedFilesOutput = gitOutput(root, ["ls-files"]);
+    for (const relative of (trackedFilesOutput ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/src/knowledge-loom/audit.ts
+++ b/src/knowledge-loom/audit.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 import { finding, isUnknownRecord, loadNoteFrontmatter, validateContractData } from "./contract.js";
 import { runDeclaredContentCheck } from "./content-checks.js";
@@ -77,8 +77,18 @@ export function matchesPath(pattern: string, candidate: string): boolean {
   return globRegex(pattern).test(candidate);
 }
 
-function git(root: string, ...arguments_: string[]) {
-  return spawnSync("git", ["-C", root, ...arguments_], { encoding: "utf8" });
+function git(root: string, ...arguments_: string[]): { status: number; stdout: string } {
+  try {
+    return {
+      status: 0,
+      stdout: execFileSync("git", ["-C", root, ...arguments_], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }),
+    };
+  } catch {
+    return { status: 1, stdout: "" };
+  }
 }
 
 interface DeclaredFilesOptions {

--- a/src/knowledge-loom/audit.ts
+++ b/src/knowledge-loom/audit.ts
@@ -77,11 +77,6 @@ export function matchesPath(pattern: string, candidate: string): boolean {
   return globRegex(pattern).test(candidate);
 }
 
-function git(root: string, ...arguments_: string[]): { status: number; stdout: string } {
-  const stdout = gitOutput(root, arguments_);
-  return stdout === null ? { status: 1, stdout: "" } : { status: 0, stdout };
-}
-
 interface DeclaredFilesOptions {
   boundaryCode: string;
   boundaryMessage: string;
@@ -225,17 +220,16 @@ export async function auditVault(
   }
 
   const history = isUnknownRecord(contract.history) ? contract.history : {};
-  const gitCheck = git(root, "rev-parse", "--show-toplevel");
-  const gitRoot = gitCheck.status === 0 ? gitCheck.stdout.trim() : "";
+  const gitRoot = gitOutput(root, ["rev-parse", "--show-toplevel"])?.trim() ?? "";
   const isGit = Boolean(gitRoot) && canonicalPath(gitRoot) === canonicalPath(root);
   if (history.type === "git" && !isGit) findings.push(finding("error", "git.missing", "contract requires Git but root is not a Git repository"));
   if (history.type === "none" && isGit) findings.push(finding("warning", "git.unconfigured", "root is a Git repository but contract declares no history"));
 
   if (isGit) {
-    const status = git(root, "status", "--short");
-    if (status.stdout.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
-    const tracked = git(root, "ls-files");
-    for (const relative of tracked.stdout.split(/\r?\n/).filter(Boolean)) {
+    const status = gitOutput(root, ["status", "--short"]);
+    if (status?.trim()) findings.push(finding("info", "git.dirty", "working tree has uncommitted changes"));
+    const tracked = gitOutput(root, ["ls-files"]);
+    for (const relative of (tracked ?? "").split(/\r?\n/).filter(Boolean)) {
       for (const patternValue of validNeverTrack) {
         if (matchesPath(patternValue, relative)) findings.push(finding("error", "privacy.tracked", `tracked path matches privacy rule \`${patternValue}\``, relative));
       }

--- a/src/knowledge-loom/git.ts
+++ b/src/knowledge-loom/git.ts
@@ -1,0 +1,12 @@
+import { execFileSync } from "node:child_process";
+
+export function gitOutput(root: string, arguments_: string[]): string | null {
+  try {
+    return execFileSync("git", ["-C", root, ...arguments_], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/knowledge-loom/registry.ts
+++ b/src/knowledge-loom/registry.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +6,7 @@ import YAML from "yaml";
 
 import { CONTRACT_NAME, isUnknownRecord, loadVault } from "./contract.js";
 import { ContractError, errorMessage, ResolutionError } from "./errors.js";
+import { gitOutput } from "./git.js";
 import { canonicalPath, expandHome, isWithin } from "./pathing.js";
 import type { LoadedVault, Registry, UnknownRecord } from "./types.js";
 
@@ -128,15 +128,8 @@ interface ProjectMatch {
 function mainCheckoutEquivalent(start: string): string | null {
   let current = canonicalPath(start);
   if (fs.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path.dirname(current);
-  let output: string;
-  try {
-    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-  } catch {
-    return null;
-  }
+  const output = gitOutput(current, ["rev-parse", "--show-toplevel", "--git-common-dir"]);
+  if (output === null) return null;
   const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
 

--- a/src/knowledge-loom/registry.ts
+++ b/src/knowledge-loom/registry.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -128,11 +128,16 @@ interface ProjectMatch {
 function mainCheckoutEquivalent(start: string): string | null {
   let current = canonicalPath(start);
   if (fs.statSync(current, { throwIfNoEntry: false })?.isFile()) current = path.dirname(current);
-  const completed = spawnSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
-    encoding: "utf8",
-  });
-  if (completed.status !== 0) return null;
-  const [worktreeOutput, commonDirectoryOutput] = completed.stdout.trimEnd().split(/\r?\n/);
+  let output: string;
+  try {
+    output = execFileSync("git", ["-C", current, "rev-parse", "--show-toplevel", "--git-common-dir"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+  const [worktreeOutput, commonDirectoryOutput] = output.trimEnd().split(/\r?\n/);
   if (!worktreeOutput || !commonDirectoryOutput) return null;
 
   const worktreeRoot = canonicalPath(worktreeOutput);

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { gitOutput } from "../src/knowledge-loom/git.ts";
+import { temporaryDirectory } from "./helpers.ts";
+
+test("gitOutput keeps arguments separate and returns stdout", (t) => {
+  const root = path.join(temporaryDirectory(t), "repository;still-one-argument");
+  fs.mkdirSync(root);
+
+  assert.notEqual(gitOutput(root, ["init", "--initial-branch=main"]), null);
+  assert.equal(gitOutput(root, ["rev-parse", "--show-toplevel"])?.trim(), fs.realpathSync(root));
+});
+
+test("gitOutput returns null when Git exits non-zero", (t) => {
+  const root = temporaryDirectory(t);
+  assert.equal(gitOutput(root, ["rev-parse", "--show-toplevel"]), null);
+});


### PR DESCRIPTION
## Summary

- Replace runtime `spawnSync` Git calls with a shared `execFileSync` helper.
- Keep Git arguments separated and avoid shell execution while preserving graceful failure handling.
- Rebuild all four generated skill runners and add focused success/failure tests.

## Why

The HOL scan for [awesome-ai-plugins#207](https://github.com/hashgraph-online/awesome-ai-plugins/pull/207) reports `COMMAND_INJECTION_JS_CHILD_PROCESS` once per generated runner because it matches `spawnSync(`. The existing calls use a fixed `git` executable, an argument array, and no shell, so the report is a conservative API-pattern finding rather than evidence of command-string injection.

## Verification

- `npm run validate:npx` — passed, 100 tests
- plugin-scanner 2.0.1116 on Python 3.12 with the same HOL policy — 92/A, 0 critical, 0 high, exit 0
- The original public `main` input reproduces 4 critical findings and exits 1 under the same scanner command.