### PR TITLE
feat: check vault knowledge daily before retrieval

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,6 +6,21 @@ artifacts used to judge whether it is useful.
 
 ## Language
 
+**Vault observation**:
+A device's last successful check of a selected vault's configured remote revision. An observation
+does not establish that the local knowledge has incorporated that revision.
+_Avoid_: Latest knowledge, sync complete
+
+**Inbound access**:
+Contract-authorized preparation of local knowledge for retrieval, including a remote observation
+when due and safe integration when possible.
+_Avoid_: Background sync, automatic pull on every turn
+
+**Integration**:
+Incorporating an observed remote revision into the local knowledge while preserving authorized
+local work. A deferred integration leaves the local knowledge behind the observed revision.
+_Avoid_: Fetch, observation
+
 **Governance initialization**:
 Establishing a vault contract and minimal navigation for a new, empty Markdown vault.
 _Avoid_: Bootstrap, import

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ providers retain their own access and privacy rules.
 
 - [Advanced usage](docs/advanced-usage.md): project associations, CLI commands, content checks,
   Claude Desktop, and the optional writing companion.
+- [Daily inbound access](docs/inbound-access.md): opt-in remote observations, safe integration,
+  local state, and cooperative write locking.
 - [Protocol](references/protocol.md) and [contract schema](references/contract-schema.md): exact behavior and configuration.
 - [Contributing](CONTRIBUTING.md): development, validation, and releases.
 - [Changelog](CHANGELOG.md): version history.

--- a/docs/inbound-access.md
+++ b/docs/inbound-access.md
@@ -1,0 +1,92 @@
+# Daily inbound access
+
+`access` prepares an authorized Git vault for retrieval. It observes the configured remote when
+due and fast-forwards only when the checkout is safe to update. It does not install runtime hooks
+or upgrade skills.
+
+## Enable access
+
+Use a vault at its Git checkout root whose current branch tracks the intended remote and branch.
+Read its contract and resolve conflicting prose policies before enabling inbound access.
+Substitute the actual vault, remote, and branch:
+
+```sh
+npm run cli -- access /path/to/vault --enable-inbound --remote origin --branch main --json
+npm run cli -- access /path/to/vault --enable-inbound --remote origin --branch main --apply --json
+```
+
+The first invocation previews the complete contract. The second applies it under the shared lock.
+Review the diff, audit, and follow the existing commit/sync/backup lifecycle. Existing installations
+and contracts retain their behavior until explicitly updated and enabled.
+
+## Access and inspect
+
+```sh
+npm run cli -- access /path/to/vault --json
+npm run cli -- access /path/to/vault --status --json
+```
+
+Omitting the selector selects only an ancestor or project-associated vault. For an explicit vault
+request with no selector, use `resolve` first and pass its root. `probe`, `resolve`, and `audit`
+remain read-only. See [Prepare inbound access](../references/protocol.md#prepare-inbound-access)
+for the authoritative scheduling and failure rules.
+
+Results have `schema_version: 1`, a canonical `root`, and `status`. `check`, when present, is
+`performed`, `cached`, `failed`, `backoff`, or `read-only`. Observations separate `attempted_at`,
+`checked_at`, `remote_revision`, and the last recorded integration/local revision. Times are Unix
+milliseconds. `checked_at` records a successful fetch, not proof of integrated knowledge. A
+`state_file` identifies the local recovery record when available.
+
+| Status | Meaning and next action |
+| --- | --- |
+| `not-applicable` | No automatically applicable vault; continue the primary task. |
+| `not-enabled` | No inbound authorization; ordinary local retrieval remains available. |
+| `unverified` | Read-only status has no successful observation. |
+| `current` | HEAD equals the observed commit; respect the observation's age. |
+| `integrated` | A fast-forward completed; reload authority and relevant notes. |
+| `ahead` | Local commits extend the observed remote history; follow the declared sync lifecycle. |
+| `behind` | Integration is deferred; finish local work or the active Git operation. |
+| `diverged` | Both histories contain contributions; reconcile separately. |
+| `recovery-required` | Upstream was rewritten; inspect history and reconcile explicitly. |
+| `busy` | Another cooperating operation owns the lock; retry after it finishes. |
+| `unavailable` | Inspect the reason while retaining local work. |
+
+Degraded access returns exit 0 with a status so the caller can continue authorized local work.
+Invalid arguments, invalid contracts, and escaping governing/state paths return exit 2; resolve
+those errors before relying on retrieval. Plain text prints status/root; use JSON for detail.
+
+The default state directory is `~/.local/state/knowledge-loom`. `--state-dir` selects another local
+directory outside the vault and its Git directory. Each canonical checkout/local branch/remote
+identity gets an observation; aliases of the same checkout share it. There is no background
+schedule and no extra pre-write fetch.
+
+## Coordinate a writer
+
+```sh
+npm run cli -- with-vault-lock /path/to/vault -- node /path/to/trusted-edit-script.js
+```
+
+The supplied executable runs from the vault root without constructing a shell command. It must
+complete its writes before exiting; detached work is outside the lock contract. Use the wrapper
+only for already-authorized edits. Contention returns exit 1; a started child returns its exit
+code. Perform access before acquiring the writer lock; nested access contends with its own lock.
+
+The lock uses Git compare-and-swap on `refs/knowledge-loom/mutation-lock`, shared by linked
+worktrees. It records local owner/writer process IDs. Observation references under
+`refs/knowledge-loom/observations/` preserve observed commits. Ordinary branch push does not
+transfer these references; exclude them from mirror/all-reference transfers. Unrecognized or
+foreign-host ownership requires explicit inspection rather than automatic deletion.
+
+## Recover
+
+Read `access --status --json` to inspect observation and local revision. Fix a missing remote or
+mismatched upstream using the intended repository configuration, then retry. A dirty checkout can
+integrate an already observed revision on a later access after its writes finish, without fetching.
+
+After explicitly reconciling rewritten history, preserve the named observation file outside the
+active state directory, then retry to establish a new observation. Do the same for a corrupt
+record after checking why it was damaged. Never clear a live lock to bypass a writer. A killed
+owner whose writer has also terminated is recovered automatically.
+
+This access slice reports divergence and outbound work. Automatic semantic reconciliation,
+weekly release maintenance, and runtime setup are separate implementation tasks.

--- a/references/contract-schema.md
+++ b/references/contract-schema.md
@@ -29,6 +29,36 @@ available override.
 For `subjects.mode: single`, set `subjects.default` to the only subject. For multiple subjects,
 omit the default unless the vault truly has a safe global default.
 
+## Inbound access
+
+Git vaults can explicitly authorize daily inbound access independently of their outbound
+`sync.mode`. Existing contracts without `sync.inbound` authorize no automatic fetch or integration.
+An outbound `git-remote-push` declaration alone does not grant inbound authority.
+
+```yaml
+sync:
+  mode: git-remote-push
+  remote: origin
+  inbound:
+    mode: fast-forward
+    remote: origin
+    branch: main
+```
+
+`sync.inbound` requires `history.type: git`, `mode: fast-forward`, a configured remote name, and
+a valid remote branch name. The current branch must track that same remote/branch. The initial
+implementation supports vaults at their Git checkout root, including linked worktrees; nested
+vaults return an explicit unavailable state instead of updating unrelated repository files.
+
+Use the `access --enable-inbound --remote NAME --branch NAME` preview and apply the reviewed
+contract with `--apply`. The command preserves policy text and outbound settings. Review any
+incompatible prose policy as part of migration; enabling the field does not rewrite that policy.
+Validate, commit, and synchronize the contract change under its existing lifecycle before relying
+on clean-checkout integration. Removing `sync.inbound` disables future automatic inbound access.
+
+Operational observations are local state, not contract fields. See the protocol's **Prepare inbound
+access** section for observation intervals, deferred integration, and failure behavior.
+
 ## Metadata profiles
 
 Define profiles as a mapping:

--- a/references/protocol.md
+++ b/references/protocol.md
@@ -94,6 +94,9 @@ association remains the nearest match.
 
 ## Retrieve
 
+Before ordinary retrieval, complete **Prepare inbound access** for the selected vault. Explicit
+read-only audits and resolution probes retain their read-only behavior.
+
 1. Read `KNOWLEDGE_VAULT.md` completely.
 2. Resolve declared paths inside the vault boundary, then read its instruction roots and
    navigation entrypoints. Follow every instruction-root context pointer whose stated trigger
@@ -135,6 +138,44 @@ association remains the nearest match.
 11. Complete retrieval only when each decisive claim has supporting evidence, or the result states
     that the required evidence is missing, conflicting, stale, or unavailable. If mandatory route
     evidence is absent, say what is missing and abstain from the unsupported conclusion.
+
+## Prepare inbound access
+
+1. Resolve one vault using the applicable selection mode. Read its contract and instruction roots
+   before invoking inbound access; their policy governs whether the operation is authorized.
+2. Invoke `access` on the selected canonical root before reading knowledge. Without a selector it
+   uses automatic applicability only; explicit operations resolve first and pass the root. Missing
+   `sync.inbound` returns `not-enabled` without fetching. Offer a previewed migration when enabling
+   inbound behavior is within the user's request.
+3. Reuse a successful remote observation for 24 elapsed hours on the same device, checkout, local
+   branch, and configured remote/branch identity. Ordinary conversation causes no check. Writing
+   does not bypass this interval. An observation is not evidence of later remote changes.
+4. Integrate a clean, behind-only checkout by fast-forward. Revalidate governing paths afterward
+   and reload the contract, instruction roots, and relevant knowledge. Preserve staged, untracked,
+   unfinished, and unrelated edits. An active Git operation or cooperative writer defers integration.
+   A fetched remote revision with deferred integration remains `behind`.
+5. Report the actual result. `current` means the local commit equals the observed commit; `ahead`
+   means local commits remain; `diverged` requires reconciliation. Upstream rewrites require explicit
+   recovery. `unavailable` and `busy` preserve local work without prohibiting otherwise authorized
+   reading, editing, or committing. Disclose unverified remote state when it affects a judgment.
+   Invalid contracts or escaping governing paths still stop vault access.
+6. Separate last attempt, successful observation, and integration state. Failed remote checks use a
+   bounded five-minute retry backoff. `access --status` reports persisted observations and current
+   local revision without fetching, integrating, or rewriting state.
+
+Store operational records outside tracked vault contents. Cooperating writers use the same
+repository-wide mutation lock as access, including across linked worktrees. `with-vault-lock` runs
+an executable under that lock; its child must finish its writes before exiting. The wrapper adds
+no write authority. Do not claim that arbitrary external file edits bypassing these entry points
+are intercepted.
+
+Recover only confirmed terminated lock owners; elapsed time alone never authorizes stealing a
+live writer's lock. Git lock ownership is local operational metadata: keep these references out of
+explicit mirror/all-reference transfers.
+
+Access performs no outbound push, divergent merge, skill installation, or backup. Continue the
+declared lifecycle separately and report incomplete stages. Immediate reconciliation following a
+non-fast-forward push rejection belongs to the synchronization adapter, not this access operation.
 
 ## Write authorization
 

--- a/skills/audit-knowledge-vault/references/contract-schema.md
+++ b/skills/audit-knowledge-vault/references/contract-schema.md
@@ -29,6 +29,36 @@ available override.
 For `subjects.mode: single`, set `subjects.default` to the only subject. For multiple subjects,
 omit the default unless the vault truly has a safe global default.
 
+## Inbound access
+
+Git vaults can explicitly authorize daily inbound access independently of their outbound
+`sync.mode`. Existing contracts without `sync.inbound` authorize no automatic fetch or integration.
+An outbound `git-remote-push` declaration alone does not grant inbound authority.
+
+```yaml
+sync:
+  mode: git-remote-push
+  remote: origin
+  inbound:
+    mode: fast-forward
+    remote: origin
+    branch: main
+```
+
+`sync.inbound` requires `history.type: git`, `mode: fast-forward`, a configured remote name, and
+a valid remote branch name. The current branch must track that same remote/branch. The initial
+implementation supports vaults at their Git checkout root, including linked worktrees; nested
+vaults return an explicit unavailable state instead of updating unrelated repository files.
+
+Use the `access --enable-inbound --remote NAME --branch NAME` preview and apply the reviewed
+contract with `--apply`. The command preserves policy text and outbound settings. Review any
+incompatible prose policy as part of migration; enabling the field does not rewrite that policy.
+Validate, commit, and synchronize the contract change under its existing lifecycle before relying
+on clean-checkout integration. Removing `sync.inbound` disables future automatic inbound access.
+
+Operational observations are local state, not contract fields. See the protocol's **Prepare inbound
+access** section for observation intervals, deferred integration, and failure behavior.
+
 ## Metadata profiles
 
 Define profiles as a mapping:

--- a/skills/audit-knowledge-vault/references/protocol.md
+++ b/skills/audit-knowledge-vault/references/protocol.md
@@ -94,6 +94,9 @@ association remains the nearest match.
 
 ## Retrieve
 
+Before ordinary retrieval, complete **Prepare inbound access** for the selected vault. Explicit
+read-only audits and resolution probes retain their read-only behavior.
+
 1. Read `KNOWLEDGE_VAULT.md` completely.
 2. Resolve declared paths inside the vault boundary, then read its instruction roots and
    navigation entrypoints. Follow every instruction-root context pointer whose stated trigger
@@ -135,6 +138,44 @@ association remains the nearest match.
 11. Complete retrieval only when each decisive claim has supporting evidence, or the result states
     that the required evidence is missing, conflicting, stale, or unavailable. If mandatory route
     evidence is absent, say what is missing and abstain from the unsupported conclusion.
+
+## Prepare inbound access
+
+1. Resolve one vault using the applicable selection mode. Read its contract and instruction roots
+   before invoking inbound access; their policy governs whether the operation is authorized.
+2. Invoke `access` on the selected canonical root before reading knowledge. Without a selector it
+   uses automatic applicability only; explicit operations resolve first and pass the root. Missing
+   `sync.inbound` returns `not-enabled` without fetching. Offer a previewed migration when enabling
+   inbound behavior is within the user's request.
+3. Reuse a successful remote observation for 24 elapsed hours on the same device, checkout, local
+   branch, and configured remote/branch identity. Ordinary conversation causes no check. Writing
+   does not bypass this interval. An observation is not evidence of later remote changes.
+4. Integrate a clean, behind-only checkout by fast-forward. Revalidate governing paths afterward
+   and reload the contract, instruction roots, and relevant knowledge. Preserve staged, untracked,
+   unfinished, and unrelated edits. An active Git operation or cooperative writer defers integration.
+   A fetched remote revision with deferred integration remains `behind`.
+5. Report the actual result. `current` means the local commit equals the observed commit; `ahead`
+   means local commits remain; `diverged` requires reconciliation. Upstream rewrites require explicit
+   recovery. `unavailable` and `busy` preserve local work without prohibiting otherwise authorized
+   reading, editing, or committing. Disclose unverified remote state when it affects a judgment.
+   Invalid contracts or escaping governing paths still stop vault access.
+6. Separate last attempt, successful observation, and integration state. Failed remote checks use a
+   bounded five-minute retry backoff. `access --status` reports persisted observations and current
+   local revision without fetching, integrating, or rewriting state.
+
+Store operational records outside tracked vault contents. Cooperating writers use the same
+repository-wide mutation lock as access, including across linked worktrees. `with-vault-lock` runs
+an executable under that lock; its child must finish its writes before exiting. The wrapper adds
+no write authority. Do not claim that arbitrary external file edits bypassing these entry points
+are intercepted.
+
+Recover only confirmed terminated lock owners; elapsed time alone never authorizes stealing a
+live writer's lock. Git lock ownership is local operational metadata: keep these references out of
+explicit mirror/all-reference transfers.
+
+Access performs no outbound push, divergent merge, skill installation, or backup. Continue the
+declared lifecycle separately and report incomplete stages. Immediate reconciliation following a
+non-fast-forward push rejection belongs to the synchronization adapter, not this access operation.
 
 ## Write authorization
 

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path8) {
-      const ctrl = callVisitor(key, node, visitor, path8);
+    function visit_(key, node, visitor, path9) {
+      const ctrl = callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visit_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visit_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path8);
+            const ci = visit_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = visit_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = visit_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path8);
+          const cv = visit_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path8) {
-      const ctrl = await callVisitor(key, node, visitor, path8);
+    async function visitAsync_(key, node, visitor, path9) {
+      const ctrl = await callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visitAsync_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visitAsync_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path8);
+            const ci = await visitAsync_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path8);
+          const cv = await visitAsync_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path8) {
+    function callVisitor(key, node, visitor, path9) {
       if (typeof visitor === "function")
-        return visitor(key, node, path8);
+        return visitor(key, node, path9);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path8);
+        return visitor.Map?.(key, node, path9);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path8);
+        return visitor.Seq?.(key, node, path9);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path8);
+        return visitor.Pair?.(key, node, path9);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path8);
+        return visitor.Scalar?.(key, node, path9);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path8);
+        return visitor.Alias?.(key, node, path9);
       return void 0;
     }
-    function replaceNode(key, path8, node) {
-      const parent = path8[path8.length - 1];
+    function replaceNode(key, path9, node) {
+      const parent = path9[path9.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path8, value) {
+    function collectionFromPath(schema, path9, value) {
       let v = value;
-      for (let i = path8.length - 1; i >= 0; --i) {
-        const k = path8[i];
+      for (let i = path9.length - 1; i >= 0; --i) {
+        const k = path9[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
+    var isEmptyPath = (path9) => path9 == null || typeof path9 === "object" && !!path9[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path8, value) {
-        if (isEmptyPath(path8))
+      addIn(path9, value) {
+        if (isEmptyPath(path9))
           this.add(value);
         else {
-          const [key, ...rest] = path8;
+          const [key, ...rest] = path9;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        const [key, ...rest] = path8;
+      deleteIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        const [key, ...rest] = path8;
+      getIn(path9, keepScalar) {
+        const [key, ...rest] = path9;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path8) {
-        const [key, ...rest] = path8;
+      hasIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        const [key, ...rest] = path8;
+      setIn(path9, value) {
+        const [key, ...rest] = path9;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path8, value) {
+      addIn(path9, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path8, value);
+          this.contents.addIn(path9, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        if (Collection.isEmptyPath(path8)) {
+      deleteIn(path9) {
+        if (Collection.isEmptyPath(path9)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path9) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        if (Collection.isEmptyPath(path8))
+      getIn(path9, keepScalar) {
+        if (Collection.isEmptyPath(path9))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path9, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path8) {
-        if (Collection.isEmptyPath(path8))
+      hasIn(path9) {
+        if (Collection.isEmptyPath(path9))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path9) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        if (Collection.isEmptyPath(path8)) {
+      setIn(path9, value) {
+        if (Collection.isEmptyPath(path9)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path9), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path8, value);
+          this.contents.setIn(path9, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path8) => {
+    visit.itemAtPath = (cst, path9) => {
       let item = cst;
-      for (const [field, index] of path8) {
+      for (const [field, index] of path9) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path8) => {
-      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
-      const field = path8[path8.length - 1][0];
+    visit.parentCollection = (cst, path9) => {
+      const parent = visit.itemAtPath(cst, path9.slice(0, -1));
+      const field = path9[path9.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path8, item, visitor) {
-      let ctrl = visitor(item, path8);
+    function _visit(path9, item, visitor) {
+      let ctrl = visitor(item, path9);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path9.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path8);
+            ctrl = ctrl(item, path9);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path9) : ctrl;
     }
     exports.visit = visit;
   }
@@ -6916,14 +6916,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs7, sep: [] });
+                map.items.push({ start, key: fs8, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               } else {
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -7051,13 +7051,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs7, sep: [] });
+                fc.items.push({ start: [], key: fs8, sep: [] });
               else if (it.sep)
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               else
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -7366,11 +7366,14 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.ts
-import path7 from "node:path";
+import path8 from "node:path";
 
-// src/knowledge-loom/audit.ts
-import fs5 from "node:fs";
-import path5 from "node:path";
+// src/knowledge-loom/access.ts
+import { spawnSync as spawnSync2 } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs4 from "node:fs";
+import os4 from "node:os";
+import path4 from "node:path";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7595,6 +7598,13 @@ function validateContractData(contract) {
   if (sync.mode === "lifecycle-hook" && !sync.adapter) {
     findings.push(finding("error", "contract.sync-adapter", "lifecycle sync requires `adapter`"));
   }
+  if (sync.inbound !== void 0) {
+    const inbound = sync.inbound;
+    if (!isUnknownRecord(inbound) || inbound.mode !== "fast-forward" || typeof inbound.remote !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(inbound.remote) || typeof inbound.branch !== "string" || !inbound.branch || /[\s\0]/.test(inbound.branch)) {
+      findings.push(finding("error", "contract.inbound", "`sync.inbound` requires fast-forward mode, a remote name and a branch"));
+    }
+    if (history.type !== "git") findings.push(finding("error", "contract.inbound-history", "inbound access requires Git history"));
+  }
   const backup = mapping(contract, "backup", findings);
   if (Object.keys(backup).length && backup.mode !== "none" && backup.mode !== "lifecycle-hook") {
     findings.push(finding("error", "contract.backup", "unsupported `backup.mode`"));
@@ -7667,10 +7677,6 @@ function validateContractData(contract) {
   }
   return findings;
 }
-
-// src/knowledge-loom/content-checks.ts
-import { spawn } from "node:child_process";
-import path4 from "node:path";
 
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7821,8 +7827,8 @@ function projectAssociation(start, registry) {
   return nearest[0] ?? null;
 }
 function applicableVaultContext(cwd, registryPath) {
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return { vault: loadVault(ancestor), registry: null };
+  const ancestor2 = findAncestorVault(cwd);
+  if (ancestor2) return { vault: loadVault(ancestor2), registry: null };
   const registry = loadRegistry(registryPath);
   const association = projectAssociation(cwd, registry) ?? (() => {
     const mainCheckout = mainCheckoutEquivalent(cwd);
@@ -7915,7 +7921,296 @@ function associateProject(vaultId, projectRoot, {
   return [resolvedRegistryPath, rendered, root];
 }
 
+// src/knowledge-loom/vault-lock.ts
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import os3 from "node:os";
+import { setTimeout as setTimeout2 } from "node:timers/promises";
+var LOCK_REF = "refs/knowledge-loom/mutation-lock";
+function command(root, args, input) {
+  return spawnSync("git", ["-C", root, ...args], { encoding: "utf8", input, timeout: 1e4 });
+}
+function deadOwner(root, revision) {
+  try {
+    const result = command(root, ["cat-file", "blob", revision]);
+    const owner = JSON.parse(result.stdout);
+    if (!isUnknownRecord(owner) || owner.host !== os3.hostname() || typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid < 1) return false;
+    const pids = [owner.pid];
+    if (owner.writer_pid !== void 0) {
+      if (typeof owner.writer_pid !== "number" || !Number.isInteger(owner.writer_pid) || owner.writer_pid < 1) return false;
+      pids.push(owner.writer_group === true ? -owner.writer_pid : owner.writer_pid);
+    }
+    return pids.every((pid) => {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (error) {
+        return isUnknownRecord(error) && error.code === "ESRCH";
+      }
+    });
+  } catch {
+  }
+  return false;
+}
+async function withVaultLock(root, work, waitMs = 2e3) {
+  const owner = { schema_version: 1, host: os3.hostname(), pid: process.pid, token: randomUUID() };
+  const hashed = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify(owner));
+  if (hashed.status !== 0) throw new Error("cannot create vault mutation lock");
+  let revision = hashed.stdout.trim();
+  const deadline = performance.now() + waitMs;
+  do {
+    const existing = command(root, ["rev-parse", "--verify", "--quiet", LOCK_REF]);
+    const current = existing.status === 0 ? existing.stdout.trim() : "0".repeat(revision.length);
+    if (existing.status !== 0 || deadOwner(root, current)) {
+      const acquired = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, revision, current]);
+      if (acquired.status === 0) {
+        try {
+          return { acquired: true, value: await work((pid, group = false) => {
+            const updated = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify({ ...owner, writer_pid: pid, writer_group: group }));
+            const next = updated.stdout.trim();
+            if (updated.status !== 0 || command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, next, revision]).status !== 0) throw new Error("cannot track the active writer");
+            revision = next;
+          }) };
+        } finally {
+          const released = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", "-d", LOCK_REF, revision]);
+          if (released.status !== 0) throw new Error("vault mutation lock release failed; inspect lock ownership before retrying");
+        }
+      }
+    }
+    if (performance.now() >= deadline) break;
+    await setTimeout2(25);
+  } while (true);
+  return { acquired: false };
+}
+function runLockedProcess(root, executable, args, trackWriter, {
+  stdout,
+  stderr,
+  timeoutMs,
+  env = process.env
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const group = process.platform !== "win32";
+    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    let failure;
+    let timer;
+    const stop = () => {
+      try {
+        if (child.pid) process.kill(group ? -child.pid : child.pid, "SIGKILL");
+      } catch {
+      }
+    };
+    child.stdout.on("data", (data) => stdout?.write(data.toString()));
+    child.stderr.on("data", (data) => stderr?.write(data.toString()));
+    child.on("error", (error) => {
+      failure = error;
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (failure) reject(failure);
+      else resolve(code ?? 1);
+    });
+    try {
+      if (child.pid) trackWriter(child.pid, group);
+    } catch (error) {
+      failure = error;
+      stop();
+    }
+    if (timeoutMs !== void 0) timer = globalThis.setTimeout(() => {
+      failure = new Error("locked command timed out");
+      stop();
+    }, timeoutMs);
+  });
+}
+
+// src/knowledge-loom/access.ts
+var DAY = 864e5;
+var RETRY = 3e5;
+function ancestor(root, older, newer) {
+  const result = spawnSync2("git", ["-C", root, "merge-base", "--is-ancestor", older, newer], { timeout: 1e4 });
+  if (result.status !== 0 && result.status !== 1) throw new Error("could not compare Git history");
+  return result.status === 0;
+}
+function git(root, ...args) {
+  const result = spawnSync2("git", ["-C", root, ...args], { encoding: "utf8", timeout: 1e4 });
+  if (result.status !== 0) throw new Error(`Git ${args[0]} failed`);
+  return result.stdout.trim();
+}
+function validateAuthority(vault) {
+  const errors = validateContractData(vault.contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new ContractError(`invalid contract: ${errors.map((item) => item.message).join("; ")}`);
+  const contract = vault.contract;
+  const navigation = isUnknownRecord(contract.navigation) ? contract.navigation : {};
+  const files = [contract.instruction_roots, navigation.entrypoints].flatMap((value) => Array.isArray(value) ? value : []);
+  const views = isUnknownRecord(contract.focus_views) ? contract.focus_views : {};
+  for (const view of Object.values(views)) if (isUnknownRecord(view)) files.push(view.path);
+  for (const relative of files) {
+    const resolved = resolveVaultPath(vault.root, relative);
+    if (!resolved || !fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) throw new ContractError("contract file is missing or crosses the vault boundary");
+  }
+  const profiles = isUnknownRecord(contract.metadata_profiles) ? contract.metadata_profiles : {};
+  const privacy = isUnknownRecord(contract.privacy) ? contract.privacy : {};
+  const patterns = Array.isArray(privacy.never_track) ? [...privacy.never_track] : [];
+  for (const profile of Object.values(profiles)) if (isUnknownRecord(profile) && Array.isArray(profile.paths)) patterns.push(...profile.paths);
+  for (const pattern of patterns) if (!resolveVaultPatternPrefix(vault.root, pattern)) throw new ContractError("contract pattern crosses the vault boundary");
+}
+function upstreamProblem(root, remote, branch) {
+  try {
+    if (canonicalPath(git(root, "rev-parse", "--show-toplevel")) !== root) return "automatic access requires a vault at its Git checkout root";
+    git(root, "check-ref-format", `refs/heads/${branch}`);
+    const local = git(root, "symbolic-ref", "--quiet", "--short", "HEAD");
+    if (git(root, "config", "--get", `branch.${local}.remote`) !== remote || git(root, "config", "--get", `branch.${local}.merge`) !== `refs/heads/${branch}`) return "current branch upstream differs from authorized inbound remote/branch";
+    git(root, "remote", "get-url", "--", remote);
+    git(root, "rev-parse", "--verify", "HEAD");
+    return null;
+  } catch {
+    return "Git repository, remote, branch or upstream is unavailable; configure the authorized upstream before retrying";
+  }
+}
+function operationInProgress(root) {
+  return ["MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "rebase-merge", "rebase-apply", "sequencer", "index.lock"].some((name) => fs4.existsSync(path4.resolve(root, git(root, "rev-parse", "--git-path", name))));
+}
+async function accessVault(vault, { stateDir, now = Date.now, statusOnly = false } = {}) {
+  validateAuthority(vault);
+  const base = { schema_version: 1, root: vault.root };
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const inbound = isUnknownRecord(sync.inbound) ? sync.inbound : {};
+  if (inbound.mode !== "fast-forward") return { ...base, status: "not-enabled" };
+  if (typeof inbound.remote !== "string" || typeof inbound.branch !== "string") throw new Error("inbound requires remote and branch");
+  const { remote, branch } = inbound;
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  try {
+    if (statusOnly) return await refresh(vault, remote, branch, stateDir, now, true);
+    const locked = await withVaultLock(vault.root, (trackWriter) => refresh(vault, remote, branch, stateDir, now, false, trackWriter));
+    return locked.acquired ? locked.value : { ...base, status: "busy", reason: "another task owns the vault mutation lock; local work is preserved" };
+  } catch (error) {
+    if (error instanceof ContractError) throw error;
+    return { ...base, status: "unavailable", reason: "access could not complete; inspect repository and observation-state permissions before retrying" };
+  }
+}
+async function refresh(vault, remote, branch, stateDir, now, statusOnly, trackWriter) {
+  const base = { schema_version: 1, root: vault.root };
+  const currentVault = loadVault(vault.root);
+  validateAuthority(currentVault);
+  if (JSON.stringify(currentVault.contract.sync) !== JSON.stringify(vault.contract.sync)) return { ...base, status: "unavailable", reason: "inbound authority changed while waiting; reread the contract before retrying" };
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  const url = git(vault.root, "remote", "get-url", "--", remote);
+  const localBranch = git(vault.root, "symbolic-ref", "--short", "HEAD");
+  const key = createHash("sha256").update(JSON.stringify([vault.root, localBranch, remote, url, branch])).digest("hex");
+  const directory = canonicalPath(stateDir ?? path4.join(os4.homedir(), ".local", "state", "knowledge-loom"));
+  const common = canonicalPath(git(vault.root, "rev-parse", "--path-format=absolute", "--git-common-dir"));
+  if (isWithin(vault.root, directory) || isWithin(common, directory)) throw new ContractError("operational state must stay outside the vault and its Git directory");
+  const file = path4.join(directory, `${key}.json`);
+  const ref = `refs/knowledge-loom/observations/${key}`;
+  let previous = null;
+  try {
+    const stat = fs4.lstatSync(file, { throwIfNoEntry: false });
+    if (stat && (!stat.isFile() || stat.size > 16384)) throw new Error("invalid observation file");
+    if (stat) {
+      previous = JSON.parse(fs4.readFileSync(file, "utf8"));
+      if (!isUnknownRecord(previous) || previous.schema_version !== 1) throw new Error("invalid observation format");
+      for (const field of ["checked_at", "attempted_at", "retry_at"]) {
+        const value = previous[field];
+        if (value !== void 0 && (typeof value !== "number" || !Number.isFinite(value) || value < 0)) throw new Error("invalid observation time");
+      }
+      if (previous.remote_revision !== void 0 && (typeof previous.remote_revision !== "string" || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(previous.remote_revision))) throw new Error("invalid observation revision");
+    }
+  } catch {
+    return { ...base, status: "unavailable", reason: "observation file is unreadable or invalid; preserve it for inspection and retry with a repaired state directory", state_file: file };
+  }
+  const observed = isUnknownRecord(previous) ? previous : {};
+  const time = now();
+  if (statusOnly && typeof observed.retry_at === "number") return { ...base, status: "unavailable", check: "read-only", observed };
+  if (statusOnly && typeof observed.remote_revision !== "string") return { ...base, status: "unverified", check: "read-only", observed };
+  if (typeof observed.retry_at === "number" && time < observed.retry_at && typeof observed.attempted_at === "number" && time >= observed.attempted_at) {
+    return { ...base, status: "unavailable", check: statusOnly ? "read-only" : "backoff", observed };
+  }
+  const cached = typeof observed.checked_at === "number" && time >= observed.checked_at && time - observed.checked_at < DAY;
+  if (!cached && !statusOnly) {
+    try {
+      if (!trackWriter) throw new Error("remote observation requires a mutation lock");
+      const code = await runLockedProcess(vault.root, "git", ["fetch", "--no-tags", "--no-recurse-submodules", "--no-write-fetch-head", "--refmap=", "--", remote, `+refs/heads/${branch}:${ref}`], trackWriter, {
+        timeoutMs: 3e4,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" }
+      });
+      if (code !== 0) throw new Error("remote fetch failed");
+    } catch {
+      previous = { ...observed, schema_version: 1, attempted_at: time, retry_at: time + RETRY };
+      atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+      return { ...base, status: "unavailable", check: "failed", observed: previous, reason: "remote fetch failed; local work remains available" };
+    }
+    const revision2 = git(vault.root, "rev-parse", "--verify", ref);
+    const rewritten = typeof observed.remote_revision === "string" && !ancestor(vault.root, observed.remote_revision, revision2);
+    previous = { schema_version: 1, attempted_at: time, checked_at: now(), remote_revision: revision2, recovery_required: observed.recovery_required === true || rewritten };
+    atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+  }
+  if (isUnknownRecord(previous) && previous.recovery_required === true) return { ...base, status: "recovery-required", check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, reason: "upstream history changed; reconcile explicitly before resuming automatic integration" };
+  const latest = loadVault(vault.root);
+  validateAuthority(latest);
+  if (git(vault.root, "symbolic-ref", "--short", "HEAD") !== localBranch || git(vault.root, "remote", "get-url", "--", remote) !== url || upstreamProblem(vault.root, remote, branch) || JSON.stringify(latest.contract.sync) !== JSON.stringify(currentVault.contract.sync)) {
+    return { ...base, status: "unavailable", reason: "checkout or inbound authority changed during observation; retry access on the intended branch", observed: previous };
+  }
+  const head = git(vault.root, "rev-parse", "HEAD");
+  const revision = isUnknownRecord(previous) && typeof previous.remote_revision === "string" ? previous.remote_revision : "";
+  if (!revision) return { ...base, status: "unverified", check: statusOnly ? "read-only" : "cached", observed: previous };
+  let status = "current";
+  if (head !== revision) {
+    if (ancestor(vault.root, revision, head)) status = "ahead";
+    else if (!ancestor(vault.root, head, revision)) status = "diverged";
+    else if (statusOnly || operationInProgress(vault.root) || git(vault.root, "status", "--porcelain", "--untracked-files=all")) status = "behind";
+    else {
+      try {
+        git(vault.root, "-c", `core.hooksPath=${os4.devNull}`, "merge", "--ff-only", "--no-overwrite-ignore", revision);
+        status = "integrated";
+      } catch {
+        status = "behind";
+      }
+      if (status === "integrated") validateAuthority(loadVault(vault.root));
+    }
+  }
+  const localRevision = git(vault.root, "rev-parse", "HEAD");
+  if (!statusOnly && isUnknownRecord(previous)) {
+    const updated = { ...previous, integration_status: status, local_revision: localRevision };
+    if (JSON.stringify(updated) !== JSON.stringify(previous)) atomicWriteText(file, `${JSON.stringify(updated)}
+`);
+    previous = updated;
+  }
+  return { ...base, status, check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, head: localRevision, state_file: file };
+}
+async function configureInbound(vault, remote, branch, apply) {
+  validateAuthority(vault);
+  if (!remote || remote.startsWith("-") || /[\s\0]/.test(remote)) throw new Error("a configured remote name is required");
+  const check = spawnSync2("git", ["-C", vault.root, "check-ref-format", `refs/heads/${branch}`], { encoding: "utf8" });
+  if (!branch || check.status !== 0) throw new Error("a valid remote branch is required");
+  const configured = spawnSync2("git", ["-C", vault.root, "remote", "get-url", "--", remote], { encoding: "utf8" });
+  if (configured.status !== 0) throw new Error("remote is not configured; configure it before enabling inbound access");
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const contract = { ...vault.contract, sync: { ...sync, inbound: { mode: "fast-forward", remote, branch } } };
+  const errors = validateContractData(contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new Error(errors.map((item) => item.message).join("; "));
+  const rendered = renderContract(contract, vault.body);
+  if (apply) {
+    const before = fs4.readFileSync(vault.contractPath, "utf8");
+    const locked = await withVaultLock(vault.root, async () => {
+      validateAuthority(loadVault(vault.root));
+      if (fs4.readFileSync(vault.contractPath, "utf8") !== before) throw new Error("contract changed while waiting; preview again");
+      atomicWriteText(vault.contractPath, rendered);
+    });
+    if (!locked.acquired) throw new Error("another writer owns the vault; preview again after it finishes");
+  }
+  return { schema_version: 1, root: vault.root, status: apply ? "configured" : "preview", contract: rendered };
+}
+
+// src/knowledge-loom/audit.ts
+import fs6 from "node:fs";
+import path6 from "node:path";
+
 // src/knowledge-loom/content-checks.ts
+import { spawn as spawn2 } from "node:child_process";
+import path5 from "node:path";
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -8012,7 +8307,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
+  if (!path5.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
   if (!validValidationDate(result.validationDate)) {
@@ -8047,7 +8342,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
 function killProcessTree(child) {
   if (!child.pid) return;
   if (process.platform === "win32") {
-    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+    const killer = spawn2("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
       stdio: "ignore",
       windowsHide: true
     });
@@ -8073,7 +8368,7 @@ function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(executable, arguments_, {
+      child = spawn2(executable, arguments_, {
         cwd,
         shell: false,
         detached: process.platform !== "win32",
@@ -8200,7 +8495,7 @@ async function runDeclaredContentCheck(vault, {
 }
 
 // src/knowledge-loom/focus.ts
-import fs4 from "node:fs";
+import fs5 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -8238,11 +8533,11 @@ function checkFocusView(root, name, view) {
   const relative = view.path;
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs5.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
-  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs5.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top;
   const maxActive = view.max_active;
   const findings = [];
@@ -8333,7 +8628,7 @@ function auditDeclaredFiles(root, values, {
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs6.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -8347,25 +8642,25 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs5.existsSync(root)) return result;
+  if (!fs6.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path5.join(current, entry.name);
+    for (const entry of fs6.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path6.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs6.lstatSync(root).isDirectory() && !fs6.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path5.join(root, ...patternValue.split("/"));
-    return fs5.existsSync(candidate) ? [candidate] : [];
+    const candidate = path6.join(root, ...patternValue.split("/"));
+    return fs6.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path5.join(root, ...prefix);
+  const searchRoot = path6.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
 async function auditVault(vault, { registryPath } = {}) {
@@ -8413,7 +8708,7 @@ async function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs6.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path6.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8468,8 +8763,8 @@ async function auditVault(vault, { registryPath } = {}) {
 }
 
 // src/knowledge-loom/initializer.ts
-import fs6 from "node:fs";
-import path6 from "node:path";
+import fs7 from "node:fs";
+import path7 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8491,13 +8786,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8535,25 +8830,27 @@ function buildContract(root, {
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path6.join(rootPath, CONTRACT_NAME);
-  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path7.join(rootPath, CONTRACT_NAME);
+  if (fs7.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs7.existsSync(rootPath) && fs7.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs6.mkdirSync(rootPath, { recursive: true });
-    fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path6.join(rootPath, "INDEX.md");
-    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs7.mkdirSync(rootPath, { recursive: true });
+    fs7.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path7.join(rootPath, "INDEX.md");
+    if (!adopt && !fs7.existsSync(indexPath)) fs7.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
 }
 
 // src/knowledge-loom/cli.ts
-var HELP = `usage: knowledge-loom {audit,probe,resolve,register,associate,init} ...
+var HELP = `usage: knowledge-loom {access,with-vault-lock,audit,probe,resolve,register,associate,init} ...
 
 commands:
+  access      prepare a vault for retrieval with an authorized daily refresh
+  with-vault-lock  run a cooperative writer under the shared mutation lock
   audit       run a read-only vault audit
   probe       resolve only an ancestor or project-associated vault
   resolve     resolve one vault deterministically
@@ -8562,6 +8859,8 @@ commands:
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
+  "with-vault-lock": "usage: knowledge-loom with-vault-lock [selector] [--registry PATH] -- executable [arguments ...]\n",
+  access: "usage: knowledge-loom access [selector] [--registry PATH] [--state-dir PATH] [--json] [--status] [--enable-inbound --remote NAME --branch NAME [--apply]]\n",
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   probe: "usage: knowledge-loom probe [--registry PATH]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
@@ -8573,6 +8872,10 @@ function isCommand(value) {
   return Object.hasOwn(COMMAND_HELP, value);
 }
 function parseArguments(arguments_) {
+  if (arguments_[0] === "with-vault-lock" && arguments_.includes("--")) {
+    const separator = arguments_.indexOf("--");
+    return { ...parseArguments(arguments_.slice(0, separator)), executable: arguments_.slice(separator + 1) };
+  }
   if (!arguments_.length) throw new Error(HELP.trim());
   const first = arguments_[0];
   if (arguments_.includes("-h") || first === "--help") {
@@ -8584,14 +8887,15 @@ function parseArguments(arguments_) {
     };
   }
   if (!isCommand(first)) throw new Error(`unknown command: ${first}`);
-  const command = first;
+  const command2 = first;
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) {
-    return { help: true, command, positional: [], subject: [] };
+    return { help: true, command: command2, positional: [], subject: [] };
   }
-  const options = { help: false, command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
+  const options = { help: false, command: command2, positional: [], subject: [] };
+  const flags = new Set(command2 === "access" ? ["--json", "--enable-inbound", "--apply", "--status"] : command2 === "audit" ? ["--json"] : command2 === "init" ? ["--adopt", "--apply"] : command2 === "register" ? ["--apply"] : command2 === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
-  if (command === "init") {
+  if (command2 === "access") for (const name of ["--state-dir", "--remote", "--branch"]) valueOptions.add(name);
+  if (command2 === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
   }
   for (let index = 1; index < arguments_.length; index += 1) {
@@ -8599,6 +8903,8 @@ function parseArguments(arguments_) {
     if (token === void 0) continue;
     if (flags.has(token)) {
       if (token === "--json") options.json = true;
+      else if (token === "--enable-inbound") options.enable_inbound = true;
+      else if (token === "--status") options.status = true;
       else if (token === "--adopt") options.adopt = true;
       else if (token === "--apply") options.apply = true;
       else if (token === "--replace") options.replace = true;
@@ -8611,6 +8917,9 @@ function parseArguments(arguments_) {
       if (value === void 0 || value.startsWith("--")) throw new Error(`${name} requires a value`);
       const key = name.slice(2).replaceAll("-", "_");
       if (key === "subject") options.subject.push(value);
+      else if (key === "state_dir") options.state_dir = value;
+      else if (key === "remote") options.remote = value;
+      else if (key === "branch") options.branch = value;
       else if (key === "registry") options.registry = value;
       else if (key === "vault_id") options.vault_id = value;
       else if (key === "title") options.title = value;
@@ -8634,11 +8943,35 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr, now = Date.now } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
       stdout.write(options.command ? COMMAND_HELP[options.command] : HELP);
+      return 0;
+    }
+    if (options.command === "with-vault-lock") {
+      if (options.positional.length > 1 || !options.executable?.length) throw new Error(COMMAND_HELP["with-vault-lock"].trim());
+      const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
+      const [executable, ...args] = options.executable;
+      const locked = await withVaultLock(vault.root, (trackWriter) => runLockedProcess(vault.root, executable, args, trackWriter, { stdout, stderr }));
+      if (!locked.acquired) {
+        stderr.write("BUSY another task owns the vault mutation lock\n");
+        return 1;
+      }
+      return locked.value;
+    }
+    if (options.command === "access") {
+      if (options.positional.length > 1) throw new Error(COMMAND_HELP.access.trim());
+      const context = { cwd, registryPath: options.registry };
+      const vault = options.positional[0] ? resolveVault(options.positional[0], context) : resolveApplicableVault(context);
+      if (!options.enable_inbound && (options.apply || options.remote || options.branch)) throw new Error("--apply, --remote and --branch require --enable-inbound");
+      if (options.enable_inbound && options.status) throw new Error("--status cannot enable inbound access");
+      if (options.enable_inbound && (!vault || !options.remote || !options.branch)) throw new Error("enabling inbound requires a vault, --remote and --branch");
+      const result = options.enable_inbound && vault ? await configureInbound(vault, options.remote, options.branch, options.apply === true) : vault ? await accessVault(vault, { stateDir: options.state_dir, now, statusOnly: options.status === true }) : { schema_version: 1, root: null, status: "not-applicable" };
+      stdout.write(options.json ? `${JSON.stringify(result)}
+` : `${result.status}${result.root ? ` ${result.root}` : ""}
+`);
       return 0;
     }
     if (options.command === "audit") {
@@ -8699,7 +9032,7 @@ ${rendered2}`);
     if (!isWritePolicy(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!isCurrentStatePolicy(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!isHistoryType(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path7.resolve(expandHome(options.positional[0]));
+    const root = path8.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,

--- a/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/audit-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7982,6 +7982,16 @@ async function withVaultLock(root, work, waitMs = 2e3) {
   } while (true);
   return { acquired: false };
 }
+var LOCKED_COMMAND_GATE = `
+const { spawn } = require("node:child_process");
+process.stdin.once("data", () => {
+  process.stdin.destroy();
+  const child = spawn(process.argv[1], process.argv.slice(2), { stdio: ["ignore", "inherit", "inherit"] });
+  child.once("error", () => process.exit(1));
+  child.once("exit", (code) => process.exit(code ?? 1));
+});
+process.stdin.once("end", () => process.exit(1));
+`;
 function runLockedProcess(root, executable, args, trackWriter, {
   stdout,
   stderr,
@@ -7990,7 +8000,7 @@ function runLockedProcess(root, executable, args, trackWriter, {
 } = {}) {
   return new Promise((resolve, reject) => {
     const group = process.platform !== "win32";
-    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(process.execPath, ["-e", LOCKED_COMMAND_GATE, "--", executable, ...args], { cwd: root, env, detached: group, stdio: ["pipe", "pipe", "pipe"] });
     let failure;
     let timer;
     const stop = () => {
@@ -8009,8 +8019,15 @@ function runLockedProcess(root, executable, args, trackWriter, {
       if (failure) reject(failure);
       else resolve(code ?? 1);
     });
+    child.stdin.on("error", (error) => {
+      failure = error;
+      stop();
+    });
     try {
-      if (child.pid) trackWriter(child.pid, group);
+      if (child.pid) {
+        trackWriter(child.pid, group);
+        child.stdin.end("start");
+      }
     } catch (error) {
       failure = error;
       stop();

--- a/skills/init-knowledge-vault/references/contract-schema.md
+++ b/skills/init-knowledge-vault/references/contract-schema.md
@@ -29,6 +29,36 @@ available override.
 For `subjects.mode: single`, set `subjects.default` to the only subject. For multiple subjects,
 omit the default unless the vault truly has a safe global default.
 
+## Inbound access
+
+Git vaults can explicitly authorize daily inbound access independently of their outbound
+`sync.mode`. Existing contracts without `sync.inbound` authorize no automatic fetch or integration.
+An outbound `git-remote-push` declaration alone does not grant inbound authority.
+
+```yaml
+sync:
+  mode: git-remote-push
+  remote: origin
+  inbound:
+    mode: fast-forward
+    remote: origin
+    branch: main
+```
+
+`sync.inbound` requires `history.type: git`, `mode: fast-forward`, a configured remote name, and
+a valid remote branch name. The current branch must track that same remote/branch. The initial
+implementation supports vaults at their Git checkout root, including linked worktrees; nested
+vaults return an explicit unavailable state instead of updating unrelated repository files.
+
+Use the `access --enable-inbound --remote NAME --branch NAME` preview and apply the reviewed
+contract with `--apply`. The command preserves policy text and outbound settings. Review any
+incompatible prose policy as part of migration; enabling the field does not rewrite that policy.
+Validate, commit, and synchronize the contract change under its existing lifecycle before relying
+on clean-checkout integration. Removing `sync.inbound` disables future automatic inbound access.
+
+Operational observations are local state, not contract fields. See the protocol's **Prepare inbound
+access** section for observation intervals, deferred integration, and failure behavior.
+
 ## Metadata profiles
 
 Define profiles as a mapping:

--- a/skills/init-knowledge-vault/references/protocol.md
+++ b/skills/init-knowledge-vault/references/protocol.md
@@ -94,6 +94,9 @@ association remains the nearest match.
 
 ## Retrieve
 
+Before ordinary retrieval, complete **Prepare inbound access** for the selected vault. Explicit
+read-only audits and resolution probes retain their read-only behavior.
+
 1. Read `KNOWLEDGE_VAULT.md` completely.
 2. Resolve declared paths inside the vault boundary, then read its instruction roots and
    navigation entrypoints. Follow every instruction-root context pointer whose stated trigger
@@ -135,6 +138,44 @@ association remains the nearest match.
 11. Complete retrieval only when each decisive claim has supporting evidence, or the result states
     that the required evidence is missing, conflicting, stale, or unavailable. If mandatory route
     evidence is absent, say what is missing and abstain from the unsupported conclusion.
+
+## Prepare inbound access
+
+1. Resolve one vault using the applicable selection mode. Read its contract and instruction roots
+   before invoking inbound access; their policy governs whether the operation is authorized.
+2. Invoke `access` on the selected canonical root before reading knowledge. Without a selector it
+   uses automatic applicability only; explicit operations resolve first and pass the root. Missing
+   `sync.inbound` returns `not-enabled` without fetching. Offer a previewed migration when enabling
+   inbound behavior is within the user's request.
+3. Reuse a successful remote observation for 24 elapsed hours on the same device, checkout, local
+   branch, and configured remote/branch identity. Ordinary conversation causes no check. Writing
+   does not bypass this interval. An observation is not evidence of later remote changes.
+4. Integrate a clean, behind-only checkout by fast-forward. Revalidate governing paths afterward
+   and reload the contract, instruction roots, and relevant knowledge. Preserve staged, untracked,
+   unfinished, and unrelated edits. An active Git operation or cooperative writer defers integration.
+   A fetched remote revision with deferred integration remains `behind`.
+5. Report the actual result. `current` means the local commit equals the observed commit; `ahead`
+   means local commits remain; `diverged` requires reconciliation. Upstream rewrites require explicit
+   recovery. `unavailable` and `busy` preserve local work without prohibiting otherwise authorized
+   reading, editing, or committing. Disclose unverified remote state when it affects a judgment.
+   Invalid contracts or escaping governing paths still stop vault access.
+6. Separate last attempt, successful observation, and integration state. Failed remote checks use a
+   bounded five-minute retry backoff. `access --status` reports persisted observations and current
+   local revision without fetching, integrating, or rewriting state.
+
+Store operational records outside tracked vault contents. Cooperating writers use the same
+repository-wide mutation lock as access, including across linked worktrees. `with-vault-lock` runs
+an executable under that lock; its child must finish its writes before exiting. The wrapper adds
+no write authority. Do not claim that arbitrary external file edits bypassing these entry points
+are intercepted.
+
+Recover only confirmed terminated lock owners; elapsed time alone never authorizes stealing a
+live writer's lock. Git lock ownership is local operational metadata: keep these references out of
+explicit mirror/all-reference transfers.
+
+Access performs no outbound push, divergent merge, skill installation, or backup. Continue the
+declared lifecycle separately and report incomplete stages. Immediate reconciliation following a
+non-fast-forward push rejection belongs to the synchronization adapter, not this access operation.
 
 ## Write authorization
 

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path8) {
-      const ctrl = callVisitor(key, node, visitor, path8);
+    function visit_(key, node, visitor, path9) {
+      const ctrl = callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visit_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visit_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path8);
+            const ci = visit_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = visit_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = visit_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path8);
+          const cv = visit_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path8) {
-      const ctrl = await callVisitor(key, node, visitor, path8);
+    async function visitAsync_(key, node, visitor, path9) {
+      const ctrl = await callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visitAsync_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visitAsync_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path8);
+            const ci = await visitAsync_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path8);
+          const cv = await visitAsync_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path8) {
+    function callVisitor(key, node, visitor, path9) {
       if (typeof visitor === "function")
-        return visitor(key, node, path8);
+        return visitor(key, node, path9);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path8);
+        return visitor.Map?.(key, node, path9);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path8);
+        return visitor.Seq?.(key, node, path9);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path8);
+        return visitor.Pair?.(key, node, path9);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path8);
+        return visitor.Scalar?.(key, node, path9);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path8);
+        return visitor.Alias?.(key, node, path9);
       return void 0;
     }
-    function replaceNode(key, path8, node) {
-      const parent = path8[path8.length - 1];
+    function replaceNode(key, path9, node) {
+      const parent = path9[path9.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path8, value) {
+    function collectionFromPath(schema, path9, value) {
       let v = value;
-      for (let i = path8.length - 1; i >= 0; --i) {
-        const k = path8[i];
+      for (let i = path9.length - 1; i >= 0; --i) {
+        const k = path9[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
+    var isEmptyPath = (path9) => path9 == null || typeof path9 === "object" && !!path9[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path8, value) {
-        if (isEmptyPath(path8))
+      addIn(path9, value) {
+        if (isEmptyPath(path9))
           this.add(value);
         else {
-          const [key, ...rest] = path8;
+          const [key, ...rest] = path9;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        const [key, ...rest] = path8;
+      deleteIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        const [key, ...rest] = path8;
+      getIn(path9, keepScalar) {
+        const [key, ...rest] = path9;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path8) {
-        const [key, ...rest] = path8;
+      hasIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        const [key, ...rest] = path8;
+      setIn(path9, value) {
+        const [key, ...rest] = path9;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path8, value) {
+      addIn(path9, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path8, value);
+          this.contents.addIn(path9, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        if (Collection.isEmptyPath(path8)) {
+      deleteIn(path9) {
+        if (Collection.isEmptyPath(path9)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path9) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        if (Collection.isEmptyPath(path8))
+      getIn(path9, keepScalar) {
+        if (Collection.isEmptyPath(path9))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path9, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path8) {
-        if (Collection.isEmptyPath(path8))
+      hasIn(path9) {
+        if (Collection.isEmptyPath(path9))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path9) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        if (Collection.isEmptyPath(path8)) {
+      setIn(path9, value) {
+        if (Collection.isEmptyPath(path9)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path9), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path8, value);
+          this.contents.setIn(path9, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path8) => {
+    visit.itemAtPath = (cst, path9) => {
       let item = cst;
-      for (const [field, index] of path8) {
+      for (const [field, index] of path9) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path8) => {
-      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
-      const field = path8[path8.length - 1][0];
+    visit.parentCollection = (cst, path9) => {
+      const parent = visit.itemAtPath(cst, path9.slice(0, -1));
+      const field = path9[path9.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path8, item, visitor) {
-      let ctrl = visitor(item, path8);
+    function _visit(path9, item, visitor) {
+      let ctrl = visitor(item, path9);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path9.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path8);
+            ctrl = ctrl(item, path9);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path9) : ctrl;
     }
     exports.visit = visit;
   }
@@ -6916,14 +6916,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs7, sep: [] });
+                map.items.push({ start, key: fs8, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               } else {
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -7051,13 +7051,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs7, sep: [] });
+                fc.items.push({ start: [], key: fs8, sep: [] });
               else if (it.sep)
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               else
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -7366,11 +7366,14 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.ts
-import path7 from "node:path";
+import path8 from "node:path";
 
-// src/knowledge-loom/audit.ts
-import fs5 from "node:fs";
-import path5 from "node:path";
+// src/knowledge-loom/access.ts
+import { spawnSync as spawnSync2 } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs4 from "node:fs";
+import os4 from "node:os";
+import path4 from "node:path";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7595,6 +7598,13 @@ function validateContractData(contract) {
   if (sync.mode === "lifecycle-hook" && !sync.adapter) {
     findings.push(finding("error", "contract.sync-adapter", "lifecycle sync requires `adapter`"));
   }
+  if (sync.inbound !== void 0) {
+    const inbound = sync.inbound;
+    if (!isUnknownRecord(inbound) || inbound.mode !== "fast-forward" || typeof inbound.remote !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(inbound.remote) || typeof inbound.branch !== "string" || !inbound.branch || /[\s\0]/.test(inbound.branch)) {
+      findings.push(finding("error", "contract.inbound", "`sync.inbound` requires fast-forward mode, a remote name and a branch"));
+    }
+    if (history.type !== "git") findings.push(finding("error", "contract.inbound-history", "inbound access requires Git history"));
+  }
   const backup = mapping(contract, "backup", findings);
   if (Object.keys(backup).length && backup.mode !== "none" && backup.mode !== "lifecycle-hook") {
     findings.push(finding("error", "contract.backup", "unsupported `backup.mode`"));
@@ -7667,10 +7677,6 @@ function validateContractData(contract) {
   }
   return findings;
 }
-
-// src/knowledge-loom/content-checks.ts
-import { spawn } from "node:child_process";
-import path4 from "node:path";
 
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7821,8 +7827,8 @@ function projectAssociation(start, registry) {
   return nearest[0] ?? null;
 }
 function applicableVaultContext(cwd, registryPath) {
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return { vault: loadVault(ancestor), registry: null };
+  const ancestor2 = findAncestorVault(cwd);
+  if (ancestor2) return { vault: loadVault(ancestor2), registry: null };
   const registry = loadRegistry(registryPath);
   const association = projectAssociation(cwd, registry) ?? (() => {
     const mainCheckout = mainCheckoutEquivalent(cwd);
@@ -7915,7 +7921,296 @@ function associateProject(vaultId, projectRoot, {
   return [resolvedRegistryPath, rendered, root];
 }
 
+// src/knowledge-loom/vault-lock.ts
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import os3 from "node:os";
+import { setTimeout as setTimeout2 } from "node:timers/promises";
+var LOCK_REF = "refs/knowledge-loom/mutation-lock";
+function command(root, args, input) {
+  return spawnSync("git", ["-C", root, ...args], { encoding: "utf8", input, timeout: 1e4 });
+}
+function deadOwner(root, revision) {
+  try {
+    const result = command(root, ["cat-file", "blob", revision]);
+    const owner = JSON.parse(result.stdout);
+    if (!isUnknownRecord(owner) || owner.host !== os3.hostname() || typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid < 1) return false;
+    const pids = [owner.pid];
+    if (owner.writer_pid !== void 0) {
+      if (typeof owner.writer_pid !== "number" || !Number.isInteger(owner.writer_pid) || owner.writer_pid < 1) return false;
+      pids.push(owner.writer_group === true ? -owner.writer_pid : owner.writer_pid);
+    }
+    return pids.every((pid) => {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (error) {
+        return isUnknownRecord(error) && error.code === "ESRCH";
+      }
+    });
+  } catch {
+  }
+  return false;
+}
+async function withVaultLock(root, work, waitMs = 2e3) {
+  const owner = { schema_version: 1, host: os3.hostname(), pid: process.pid, token: randomUUID() };
+  const hashed = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify(owner));
+  if (hashed.status !== 0) throw new Error("cannot create vault mutation lock");
+  let revision = hashed.stdout.trim();
+  const deadline = performance.now() + waitMs;
+  do {
+    const existing = command(root, ["rev-parse", "--verify", "--quiet", LOCK_REF]);
+    const current = existing.status === 0 ? existing.stdout.trim() : "0".repeat(revision.length);
+    if (existing.status !== 0 || deadOwner(root, current)) {
+      const acquired = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, revision, current]);
+      if (acquired.status === 0) {
+        try {
+          return { acquired: true, value: await work((pid, group = false) => {
+            const updated = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify({ ...owner, writer_pid: pid, writer_group: group }));
+            const next = updated.stdout.trim();
+            if (updated.status !== 0 || command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, next, revision]).status !== 0) throw new Error("cannot track the active writer");
+            revision = next;
+          }) };
+        } finally {
+          const released = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", "-d", LOCK_REF, revision]);
+          if (released.status !== 0) throw new Error("vault mutation lock release failed; inspect lock ownership before retrying");
+        }
+      }
+    }
+    if (performance.now() >= deadline) break;
+    await setTimeout2(25);
+  } while (true);
+  return { acquired: false };
+}
+function runLockedProcess(root, executable, args, trackWriter, {
+  stdout,
+  stderr,
+  timeoutMs,
+  env = process.env
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const group = process.platform !== "win32";
+    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    let failure;
+    let timer;
+    const stop = () => {
+      try {
+        if (child.pid) process.kill(group ? -child.pid : child.pid, "SIGKILL");
+      } catch {
+      }
+    };
+    child.stdout.on("data", (data) => stdout?.write(data.toString()));
+    child.stderr.on("data", (data) => stderr?.write(data.toString()));
+    child.on("error", (error) => {
+      failure = error;
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (failure) reject(failure);
+      else resolve(code ?? 1);
+    });
+    try {
+      if (child.pid) trackWriter(child.pid, group);
+    } catch (error) {
+      failure = error;
+      stop();
+    }
+    if (timeoutMs !== void 0) timer = globalThis.setTimeout(() => {
+      failure = new Error("locked command timed out");
+      stop();
+    }, timeoutMs);
+  });
+}
+
+// src/knowledge-loom/access.ts
+var DAY = 864e5;
+var RETRY = 3e5;
+function ancestor(root, older, newer) {
+  const result = spawnSync2("git", ["-C", root, "merge-base", "--is-ancestor", older, newer], { timeout: 1e4 });
+  if (result.status !== 0 && result.status !== 1) throw new Error("could not compare Git history");
+  return result.status === 0;
+}
+function git(root, ...args) {
+  const result = spawnSync2("git", ["-C", root, ...args], { encoding: "utf8", timeout: 1e4 });
+  if (result.status !== 0) throw new Error(`Git ${args[0]} failed`);
+  return result.stdout.trim();
+}
+function validateAuthority(vault) {
+  const errors = validateContractData(vault.contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new ContractError(`invalid contract: ${errors.map((item) => item.message).join("; ")}`);
+  const contract = vault.contract;
+  const navigation = isUnknownRecord(contract.navigation) ? contract.navigation : {};
+  const files = [contract.instruction_roots, navigation.entrypoints].flatMap((value) => Array.isArray(value) ? value : []);
+  const views = isUnknownRecord(contract.focus_views) ? contract.focus_views : {};
+  for (const view of Object.values(views)) if (isUnknownRecord(view)) files.push(view.path);
+  for (const relative of files) {
+    const resolved = resolveVaultPath(vault.root, relative);
+    if (!resolved || !fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) throw new ContractError("contract file is missing or crosses the vault boundary");
+  }
+  const profiles = isUnknownRecord(contract.metadata_profiles) ? contract.metadata_profiles : {};
+  const privacy = isUnknownRecord(contract.privacy) ? contract.privacy : {};
+  const patterns = Array.isArray(privacy.never_track) ? [...privacy.never_track] : [];
+  for (const profile of Object.values(profiles)) if (isUnknownRecord(profile) && Array.isArray(profile.paths)) patterns.push(...profile.paths);
+  for (const pattern of patterns) if (!resolveVaultPatternPrefix(vault.root, pattern)) throw new ContractError("contract pattern crosses the vault boundary");
+}
+function upstreamProblem(root, remote, branch) {
+  try {
+    if (canonicalPath(git(root, "rev-parse", "--show-toplevel")) !== root) return "automatic access requires a vault at its Git checkout root";
+    git(root, "check-ref-format", `refs/heads/${branch}`);
+    const local = git(root, "symbolic-ref", "--quiet", "--short", "HEAD");
+    if (git(root, "config", "--get", `branch.${local}.remote`) !== remote || git(root, "config", "--get", `branch.${local}.merge`) !== `refs/heads/${branch}`) return "current branch upstream differs from authorized inbound remote/branch";
+    git(root, "remote", "get-url", "--", remote);
+    git(root, "rev-parse", "--verify", "HEAD");
+    return null;
+  } catch {
+    return "Git repository, remote, branch or upstream is unavailable; configure the authorized upstream before retrying";
+  }
+}
+function operationInProgress(root) {
+  return ["MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "rebase-merge", "rebase-apply", "sequencer", "index.lock"].some((name) => fs4.existsSync(path4.resolve(root, git(root, "rev-parse", "--git-path", name))));
+}
+async function accessVault(vault, { stateDir, now = Date.now, statusOnly = false } = {}) {
+  validateAuthority(vault);
+  const base = { schema_version: 1, root: vault.root };
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const inbound = isUnknownRecord(sync.inbound) ? sync.inbound : {};
+  if (inbound.mode !== "fast-forward") return { ...base, status: "not-enabled" };
+  if (typeof inbound.remote !== "string" || typeof inbound.branch !== "string") throw new Error("inbound requires remote and branch");
+  const { remote, branch } = inbound;
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  try {
+    if (statusOnly) return await refresh(vault, remote, branch, stateDir, now, true);
+    const locked = await withVaultLock(vault.root, (trackWriter) => refresh(vault, remote, branch, stateDir, now, false, trackWriter));
+    return locked.acquired ? locked.value : { ...base, status: "busy", reason: "another task owns the vault mutation lock; local work is preserved" };
+  } catch (error) {
+    if (error instanceof ContractError) throw error;
+    return { ...base, status: "unavailable", reason: "access could not complete; inspect repository and observation-state permissions before retrying" };
+  }
+}
+async function refresh(vault, remote, branch, stateDir, now, statusOnly, trackWriter) {
+  const base = { schema_version: 1, root: vault.root };
+  const currentVault = loadVault(vault.root);
+  validateAuthority(currentVault);
+  if (JSON.stringify(currentVault.contract.sync) !== JSON.stringify(vault.contract.sync)) return { ...base, status: "unavailable", reason: "inbound authority changed while waiting; reread the contract before retrying" };
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  const url = git(vault.root, "remote", "get-url", "--", remote);
+  const localBranch = git(vault.root, "symbolic-ref", "--short", "HEAD");
+  const key = createHash("sha256").update(JSON.stringify([vault.root, localBranch, remote, url, branch])).digest("hex");
+  const directory = canonicalPath(stateDir ?? path4.join(os4.homedir(), ".local", "state", "knowledge-loom"));
+  const common = canonicalPath(git(vault.root, "rev-parse", "--path-format=absolute", "--git-common-dir"));
+  if (isWithin(vault.root, directory) || isWithin(common, directory)) throw new ContractError("operational state must stay outside the vault and its Git directory");
+  const file = path4.join(directory, `${key}.json`);
+  const ref = `refs/knowledge-loom/observations/${key}`;
+  let previous = null;
+  try {
+    const stat = fs4.lstatSync(file, { throwIfNoEntry: false });
+    if (stat && (!stat.isFile() || stat.size > 16384)) throw new Error("invalid observation file");
+    if (stat) {
+      previous = JSON.parse(fs4.readFileSync(file, "utf8"));
+      if (!isUnknownRecord(previous) || previous.schema_version !== 1) throw new Error("invalid observation format");
+      for (const field of ["checked_at", "attempted_at", "retry_at"]) {
+        const value = previous[field];
+        if (value !== void 0 && (typeof value !== "number" || !Number.isFinite(value) || value < 0)) throw new Error("invalid observation time");
+      }
+      if (previous.remote_revision !== void 0 && (typeof previous.remote_revision !== "string" || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(previous.remote_revision))) throw new Error("invalid observation revision");
+    }
+  } catch {
+    return { ...base, status: "unavailable", reason: "observation file is unreadable or invalid; preserve it for inspection and retry with a repaired state directory", state_file: file };
+  }
+  const observed = isUnknownRecord(previous) ? previous : {};
+  const time = now();
+  if (statusOnly && typeof observed.retry_at === "number") return { ...base, status: "unavailable", check: "read-only", observed };
+  if (statusOnly && typeof observed.remote_revision !== "string") return { ...base, status: "unverified", check: "read-only", observed };
+  if (typeof observed.retry_at === "number" && time < observed.retry_at && typeof observed.attempted_at === "number" && time >= observed.attempted_at) {
+    return { ...base, status: "unavailable", check: statusOnly ? "read-only" : "backoff", observed };
+  }
+  const cached = typeof observed.checked_at === "number" && time >= observed.checked_at && time - observed.checked_at < DAY;
+  if (!cached && !statusOnly) {
+    try {
+      if (!trackWriter) throw new Error("remote observation requires a mutation lock");
+      const code = await runLockedProcess(vault.root, "git", ["fetch", "--no-tags", "--no-recurse-submodules", "--no-write-fetch-head", "--refmap=", "--", remote, `+refs/heads/${branch}:${ref}`], trackWriter, {
+        timeoutMs: 3e4,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" }
+      });
+      if (code !== 0) throw new Error("remote fetch failed");
+    } catch {
+      previous = { ...observed, schema_version: 1, attempted_at: time, retry_at: time + RETRY };
+      atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+      return { ...base, status: "unavailable", check: "failed", observed: previous, reason: "remote fetch failed; local work remains available" };
+    }
+    const revision2 = git(vault.root, "rev-parse", "--verify", ref);
+    const rewritten = typeof observed.remote_revision === "string" && !ancestor(vault.root, observed.remote_revision, revision2);
+    previous = { schema_version: 1, attempted_at: time, checked_at: now(), remote_revision: revision2, recovery_required: observed.recovery_required === true || rewritten };
+    atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+  }
+  if (isUnknownRecord(previous) && previous.recovery_required === true) return { ...base, status: "recovery-required", check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, reason: "upstream history changed; reconcile explicitly before resuming automatic integration" };
+  const latest = loadVault(vault.root);
+  validateAuthority(latest);
+  if (git(vault.root, "symbolic-ref", "--short", "HEAD") !== localBranch || git(vault.root, "remote", "get-url", "--", remote) !== url || upstreamProblem(vault.root, remote, branch) || JSON.stringify(latest.contract.sync) !== JSON.stringify(currentVault.contract.sync)) {
+    return { ...base, status: "unavailable", reason: "checkout or inbound authority changed during observation; retry access on the intended branch", observed: previous };
+  }
+  const head = git(vault.root, "rev-parse", "HEAD");
+  const revision = isUnknownRecord(previous) && typeof previous.remote_revision === "string" ? previous.remote_revision : "";
+  if (!revision) return { ...base, status: "unverified", check: statusOnly ? "read-only" : "cached", observed: previous };
+  let status = "current";
+  if (head !== revision) {
+    if (ancestor(vault.root, revision, head)) status = "ahead";
+    else if (!ancestor(vault.root, head, revision)) status = "diverged";
+    else if (statusOnly || operationInProgress(vault.root) || git(vault.root, "status", "--porcelain", "--untracked-files=all")) status = "behind";
+    else {
+      try {
+        git(vault.root, "-c", `core.hooksPath=${os4.devNull}`, "merge", "--ff-only", "--no-overwrite-ignore", revision);
+        status = "integrated";
+      } catch {
+        status = "behind";
+      }
+      if (status === "integrated") validateAuthority(loadVault(vault.root));
+    }
+  }
+  const localRevision = git(vault.root, "rev-parse", "HEAD");
+  if (!statusOnly && isUnknownRecord(previous)) {
+    const updated = { ...previous, integration_status: status, local_revision: localRevision };
+    if (JSON.stringify(updated) !== JSON.stringify(previous)) atomicWriteText(file, `${JSON.stringify(updated)}
+`);
+    previous = updated;
+  }
+  return { ...base, status, check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, head: localRevision, state_file: file };
+}
+async function configureInbound(vault, remote, branch, apply) {
+  validateAuthority(vault);
+  if (!remote || remote.startsWith("-") || /[\s\0]/.test(remote)) throw new Error("a configured remote name is required");
+  const check = spawnSync2("git", ["-C", vault.root, "check-ref-format", `refs/heads/${branch}`], { encoding: "utf8" });
+  if (!branch || check.status !== 0) throw new Error("a valid remote branch is required");
+  const configured = spawnSync2("git", ["-C", vault.root, "remote", "get-url", "--", remote], { encoding: "utf8" });
+  if (configured.status !== 0) throw new Error("remote is not configured; configure it before enabling inbound access");
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const contract = { ...vault.contract, sync: { ...sync, inbound: { mode: "fast-forward", remote, branch } } };
+  const errors = validateContractData(contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new Error(errors.map((item) => item.message).join("; "));
+  const rendered = renderContract(contract, vault.body);
+  if (apply) {
+    const before = fs4.readFileSync(vault.contractPath, "utf8");
+    const locked = await withVaultLock(vault.root, async () => {
+      validateAuthority(loadVault(vault.root));
+      if (fs4.readFileSync(vault.contractPath, "utf8") !== before) throw new Error("contract changed while waiting; preview again");
+      atomicWriteText(vault.contractPath, rendered);
+    });
+    if (!locked.acquired) throw new Error("another writer owns the vault; preview again after it finishes");
+  }
+  return { schema_version: 1, root: vault.root, status: apply ? "configured" : "preview", contract: rendered };
+}
+
+// src/knowledge-loom/audit.ts
+import fs6 from "node:fs";
+import path6 from "node:path";
+
 // src/knowledge-loom/content-checks.ts
+import { spawn as spawn2 } from "node:child_process";
+import path5 from "node:path";
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -8012,7 +8307,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
+  if (!path5.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
   if (!validValidationDate(result.validationDate)) {
@@ -8047,7 +8342,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
 function killProcessTree(child) {
   if (!child.pid) return;
   if (process.platform === "win32") {
-    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+    const killer = spawn2("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
       stdio: "ignore",
       windowsHide: true
     });
@@ -8073,7 +8368,7 @@ function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(executable, arguments_, {
+      child = spawn2(executable, arguments_, {
         cwd,
         shell: false,
         detached: process.platform !== "win32",
@@ -8200,7 +8495,7 @@ async function runDeclaredContentCheck(vault, {
 }
 
 // src/knowledge-loom/focus.ts
-import fs4 from "node:fs";
+import fs5 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -8238,11 +8533,11 @@ function checkFocusView(root, name, view) {
   const relative = view.path;
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs5.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
-  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs5.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top;
   const maxActive = view.max_active;
   const findings = [];
@@ -8333,7 +8628,7 @@ function auditDeclaredFiles(root, values, {
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs6.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -8347,25 +8642,25 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs5.existsSync(root)) return result;
+  if (!fs6.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path5.join(current, entry.name);
+    for (const entry of fs6.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path6.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs6.lstatSync(root).isDirectory() && !fs6.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path5.join(root, ...patternValue.split("/"));
-    return fs5.existsSync(candidate) ? [candidate] : [];
+    const candidate = path6.join(root, ...patternValue.split("/"));
+    return fs6.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path5.join(root, ...prefix);
+  const searchRoot = path6.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
 async function auditVault(vault, { registryPath } = {}) {
@@ -8413,7 +8708,7 @@ async function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs6.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path6.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8468,8 +8763,8 @@ async function auditVault(vault, { registryPath } = {}) {
 }
 
 // src/knowledge-loom/initializer.ts
-import fs6 from "node:fs";
-import path6 from "node:path";
+import fs7 from "node:fs";
+import path7 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8491,13 +8786,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8535,25 +8830,27 @@ function buildContract(root, {
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path6.join(rootPath, CONTRACT_NAME);
-  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path7.join(rootPath, CONTRACT_NAME);
+  if (fs7.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs7.existsSync(rootPath) && fs7.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs6.mkdirSync(rootPath, { recursive: true });
-    fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path6.join(rootPath, "INDEX.md");
-    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs7.mkdirSync(rootPath, { recursive: true });
+    fs7.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path7.join(rootPath, "INDEX.md");
+    if (!adopt && !fs7.existsSync(indexPath)) fs7.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
 }
 
 // src/knowledge-loom/cli.ts
-var HELP = `usage: knowledge-loom {audit,probe,resolve,register,associate,init} ...
+var HELP = `usage: knowledge-loom {access,with-vault-lock,audit,probe,resolve,register,associate,init} ...
 
 commands:
+  access      prepare a vault for retrieval with an authorized daily refresh
+  with-vault-lock  run a cooperative writer under the shared mutation lock
   audit       run a read-only vault audit
   probe       resolve only an ancestor or project-associated vault
   resolve     resolve one vault deterministically
@@ -8562,6 +8859,8 @@ commands:
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
+  "with-vault-lock": "usage: knowledge-loom with-vault-lock [selector] [--registry PATH] -- executable [arguments ...]\n",
+  access: "usage: knowledge-loom access [selector] [--registry PATH] [--state-dir PATH] [--json] [--status] [--enable-inbound --remote NAME --branch NAME [--apply]]\n",
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   probe: "usage: knowledge-loom probe [--registry PATH]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
@@ -8573,6 +8872,10 @@ function isCommand(value) {
   return Object.hasOwn(COMMAND_HELP, value);
 }
 function parseArguments(arguments_) {
+  if (arguments_[0] === "with-vault-lock" && arguments_.includes("--")) {
+    const separator = arguments_.indexOf("--");
+    return { ...parseArguments(arguments_.slice(0, separator)), executable: arguments_.slice(separator + 1) };
+  }
   if (!arguments_.length) throw new Error(HELP.trim());
   const first = arguments_[0];
   if (arguments_.includes("-h") || first === "--help") {
@@ -8584,14 +8887,15 @@ function parseArguments(arguments_) {
     };
   }
   if (!isCommand(first)) throw new Error(`unknown command: ${first}`);
-  const command = first;
+  const command2 = first;
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) {
-    return { help: true, command, positional: [], subject: [] };
+    return { help: true, command: command2, positional: [], subject: [] };
   }
-  const options = { help: false, command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
+  const options = { help: false, command: command2, positional: [], subject: [] };
+  const flags = new Set(command2 === "access" ? ["--json", "--enable-inbound", "--apply", "--status"] : command2 === "audit" ? ["--json"] : command2 === "init" ? ["--adopt", "--apply"] : command2 === "register" ? ["--apply"] : command2 === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
-  if (command === "init") {
+  if (command2 === "access") for (const name of ["--state-dir", "--remote", "--branch"]) valueOptions.add(name);
+  if (command2 === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
   }
   for (let index = 1; index < arguments_.length; index += 1) {
@@ -8599,6 +8903,8 @@ function parseArguments(arguments_) {
     if (token === void 0) continue;
     if (flags.has(token)) {
       if (token === "--json") options.json = true;
+      else if (token === "--enable-inbound") options.enable_inbound = true;
+      else if (token === "--status") options.status = true;
       else if (token === "--adopt") options.adopt = true;
       else if (token === "--apply") options.apply = true;
       else if (token === "--replace") options.replace = true;
@@ -8611,6 +8917,9 @@ function parseArguments(arguments_) {
       if (value === void 0 || value.startsWith("--")) throw new Error(`${name} requires a value`);
       const key = name.slice(2).replaceAll("-", "_");
       if (key === "subject") options.subject.push(value);
+      else if (key === "state_dir") options.state_dir = value;
+      else if (key === "remote") options.remote = value;
+      else if (key === "branch") options.branch = value;
       else if (key === "registry") options.registry = value;
       else if (key === "vault_id") options.vault_id = value;
       else if (key === "title") options.title = value;
@@ -8634,11 +8943,35 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr, now = Date.now } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
       stdout.write(options.command ? COMMAND_HELP[options.command] : HELP);
+      return 0;
+    }
+    if (options.command === "with-vault-lock") {
+      if (options.positional.length > 1 || !options.executable?.length) throw new Error(COMMAND_HELP["with-vault-lock"].trim());
+      const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
+      const [executable, ...args] = options.executable;
+      const locked = await withVaultLock(vault.root, (trackWriter) => runLockedProcess(vault.root, executable, args, trackWriter, { stdout, stderr }));
+      if (!locked.acquired) {
+        stderr.write("BUSY another task owns the vault mutation lock\n");
+        return 1;
+      }
+      return locked.value;
+    }
+    if (options.command === "access") {
+      if (options.positional.length > 1) throw new Error(COMMAND_HELP.access.trim());
+      const context = { cwd, registryPath: options.registry };
+      const vault = options.positional[0] ? resolveVault(options.positional[0], context) : resolveApplicableVault(context);
+      if (!options.enable_inbound && (options.apply || options.remote || options.branch)) throw new Error("--apply, --remote and --branch require --enable-inbound");
+      if (options.enable_inbound && options.status) throw new Error("--status cannot enable inbound access");
+      if (options.enable_inbound && (!vault || !options.remote || !options.branch)) throw new Error("enabling inbound requires a vault, --remote and --branch");
+      const result = options.enable_inbound && vault ? await configureInbound(vault, options.remote, options.branch, options.apply === true) : vault ? await accessVault(vault, { stateDir: options.state_dir, now, statusOnly: options.status === true }) : { schema_version: 1, root: null, status: "not-applicable" };
+      stdout.write(options.json ? `${JSON.stringify(result)}
+` : `${result.status}${result.root ? ` ${result.root}` : ""}
+`);
       return 0;
     }
     if (options.command === "audit") {
@@ -8699,7 +9032,7 @@ ${rendered2}`);
     if (!isWritePolicy(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!isCurrentStatePolicy(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!isHistoryType(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path7.resolve(expandHome(options.positional[0]));
+    const root = path8.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,

--- a/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/init-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7982,6 +7982,16 @@ async function withVaultLock(root, work, waitMs = 2e3) {
   } while (true);
   return { acquired: false };
 }
+var LOCKED_COMMAND_GATE = `
+const { spawn } = require("node:child_process");
+process.stdin.once("data", () => {
+  process.stdin.destroy();
+  const child = spawn(process.argv[1], process.argv.slice(2), { stdio: ["ignore", "inherit", "inherit"] });
+  child.once("error", () => process.exit(1));
+  child.once("exit", (code) => process.exit(code ?? 1));
+});
+process.stdin.once("end", () => process.exit(1));
+`;
 function runLockedProcess(root, executable, args, trackWriter, {
   stdout,
   stderr,
@@ -7990,7 +8000,7 @@ function runLockedProcess(root, executable, args, trackWriter, {
 } = {}) {
   return new Promise((resolve, reject) => {
     const group = process.platform !== "win32";
-    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(process.execPath, ["-e", LOCKED_COMMAND_GATE, "--", executable, ...args], { cwd: root, env, detached: group, stdio: ["pipe", "pipe", "pipe"] });
     let failure;
     let timer;
     const stop = () => {
@@ -8009,8 +8019,15 @@ function runLockedProcess(root, executable, args, trackWriter, {
       if (failure) reject(failure);
       else resolve(code ?? 1);
     });
+    child.stdin.on("error", (error) => {
+      failure = error;
+      stop();
+    });
     try {
-      if (child.pid) trackWriter(child.pid, group);
+      if (child.pid) {
+        trackWriter(child.pid, group);
+        child.stdin.end("start");
+      }
     } catch (error) {
       failure = error;
       stop();

--- a/skills/manage-current-focus/SKILL.md
+++ b/skills/manage-current-focus/SKILL.md
@@ -16,9 +16,11 @@ Resolve this `SKILL.md` to its canonical path, following symlinks. Set `<skill-r
 directory containing that canonical file. Read `<skill-root>/references/protocol.md` completely.
 From the active project directory, inspect
 `node "<skill-root>/scripts/knowledge-loom.mjs" resolve --help`, then run `resolve`, appending a
-selector only when one was supplied. Treat its returned canonical root as the only selected vault,
-then read its `KNOWLEDGE_VAULT.md`, the selected focus view, and only the linked current notes needed
-for the decision. Stop vault work on any resolution error.
+selector only when one was supplied. Treat its returned canonical root as the only selected vault.
+Read its contract and instruction roots, then follow **Prepare inbound access** before loading the
+selected focus view and linked current notes. Preserve an explicit read-only request. After
+integration, reload governing files before reasoning from the updated view. Stop vault work on
+any resolution error.
 
 - Use an explicitly named view when provided.
 - Use the only configured view when exactly one exists.

--- a/skills/manage-current-focus/references/protocol.md
+++ b/skills/manage-current-focus/references/protocol.md
@@ -94,6 +94,9 @@ association remains the nearest match.
 
 ## Retrieve
 
+Before ordinary retrieval, complete **Prepare inbound access** for the selected vault. Explicit
+read-only audits and resolution probes retain their read-only behavior.
+
 1. Read `KNOWLEDGE_VAULT.md` completely.
 2. Resolve declared paths inside the vault boundary, then read its instruction roots and
    navigation entrypoints. Follow every instruction-root context pointer whose stated trigger
@@ -135,6 +138,44 @@ association remains the nearest match.
 11. Complete retrieval only when each decisive claim has supporting evidence, or the result states
     that the required evidence is missing, conflicting, stale, or unavailable. If mandatory route
     evidence is absent, say what is missing and abstain from the unsupported conclusion.
+
+## Prepare inbound access
+
+1. Resolve one vault using the applicable selection mode. Read its contract and instruction roots
+   before invoking inbound access; their policy governs whether the operation is authorized.
+2. Invoke `access` on the selected canonical root before reading knowledge. Without a selector it
+   uses automatic applicability only; explicit operations resolve first and pass the root. Missing
+   `sync.inbound` returns `not-enabled` without fetching. Offer a previewed migration when enabling
+   inbound behavior is within the user's request.
+3. Reuse a successful remote observation for 24 elapsed hours on the same device, checkout, local
+   branch, and configured remote/branch identity. Ordinary conversation causes no check. Writing
+   does not bypass this interval. An observation is not evidence of later remote changes.
+4. Integrate a clean, behind-only checkout by fast-forward. Revalidate governing paths afterward
+   and reload the contract, instruction roots, and relevant knowledge. Preserve staged, untracked,
+   unfinished, and unrelated edits. An active Git operation or cooperative writer defers integration.
+   A fetched remote revision with deferred integration remains `behind`.
+5. Report the actual result. `current` means the local commit equals the observed commit; `ahead`
+   means local commits remain; `diverged` requires reconciliation. Upstream rewrites require explicit
+   recovery. `unavailable` and `busy` preserve local work without prohibiting otherwise authorized
+   reading, editing, or committing. Disclose unverified remote state when it affects a judgment.
+   Invalid contracts or escaping governing paths still stop vault access.
+6. Separate last attempt, successful observation, and integration state. Failed remote checks use a
+   bounded five-minute retry backoff. `access --status` reports persisted observations and current
+   local revision without fetching, integrating, or rewriting state.
+
+Store operational records outside tracked vault contents. Cooperating writers use the same
+repository-wide mutation lock as access, including across linked worktrees. `with-vault-lock` runs
+an executable under that lock; its child must finish its writes before exiting. The wrapper adds
+no write authority. Do not claim that arbitrary external file edits bypassing these entry points
+are intercepted.
+
+Recover only confirmed terminated lock owners; elapsed time alone never authorizes stealing a
+live writer's lock. Git lock ownership is local operational metadata: keep these references out of
+explicit mirror/all-reference transfers.
+
+Access performs no outbound push, divergent merge, skill installation, or backup. Continue the
+declared lifecycle separately and report incomplete stages. Immediate reconciliation following a
+non-fast-forward push rejection belongs to the synchronization adapter, not this access operation.
 
 ## Write authorization
 

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path8) {
-      const ctrl = callVisitor(key, node, visitor, path8);
+    function visit_(key, node, visitor, path9) {
+      const ctrl = callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visit_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visit_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path8);
+            const ci = visit_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = visit_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = visit_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path8);
+          const cv = visit_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path8) {
-      const ctrl = await callVisitor(key, node, visitor, path8);
+    async function visitAsync_(key, node, visitor, path9) {
+      const ctrl = await callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visitAsync_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visitAsync_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path8);
+            const ci = await visitAsync_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path8);
+          const cv = await visitAsync_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path8) {
+    function callVisitor(key, node, visitor, path9) {
       if (typeof visitor === "function")
-        return visitor(key, node, path8);
+        return visitor(key, node, path9);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path8);
+        return visitor.Map?.(key, node, path9);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path8);
+        return visitor.Seq?.(key, node, path9);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path8);
+        return visitor.Pair?.(key, node, path9);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path8);
+        return visitor.Scalar?.(key, node, path9);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path8);
+        return visitor.Alias?.(key, node, path9);
       return void 0;
     }
-    function replaceNode(key, path8, node) {
-      const parent = path8[path8.length - 1];
+    function replaceNode(key, path9, node) {
+      const parent = path9[path9.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path8, value) {
+    function collectionFromPath(schema, path9, value) {
       let v = value;
-      for (let i = path8.length - 1; i >= 0; --i) {
-        const k = path8[i];
+      for (let i = path9.length - 1; i >= 0; --i) {
+        const k = path9[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
+    var isEmptyPath = (path9) => path9 == null || typeof path9 === "object" && !!path9[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path8, value) {
-        if (isEmptyPath(path8))
+      addIn(path9, value) {
+        if (isEmptyPath(path9))
           this.add(value);
         else {
-          const [key, ...rest] = path8;
+          const [key, ...rest] = path9;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        const [key, ...rest] = path8;
+      deleteIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        const [key, ...rest] = path8;
+      getIn(path9, keepScalar) {
+        const [key, ...rest] = path9;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path8) {
-        const [key, ...rest] = path8;
+      hasIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        const [key, ...rest] = path8;
+      setIn(path9, value) {
+        const [key, ...rest] = path9;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path8, value) {
+      addIn(path9, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path8, value);
+          this.contents.addIn(path9, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        if (Collection.isEmptyPath(path8)) {
+      deleteIn(path9) {
+        if (Collection.isEmptyPath(path9)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path9) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        if (Collection.isEmptyPath(path8))
+      getIn(path9, keepScalar) {
+        if (Collection.isEmptyPath(path9))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path9, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path8) {
-        if (Collection.isEmptyPath(path8))
+      hasIn(path9) {
+        if (Collection.isEmptyPath(path9))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path9) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        if (Collection.isEmptyPath(path8)) {
+      setIn(path9, value) {
+        if (Collection.isEmptyPath(path9)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path9), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path8, value);
+          this.contents.setIn(path9, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path8) => {
+    visit.itemAtPath = (cst, path9) => {
       let item = cst;
-      for (const [field, index] of path8) {
+      for (const [field, index] of path9) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path8) => {
-      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
-      const field = path8[path8.length - 1][0];
+    visit.parentCollection = (cst, path9) => {
+      const parent = visit.itemAtPath(cst, path9.slice(0, -1));
+      const field = path9[path9.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path8, item, visitor) {
-      let ctrl = visitor(item, path8);
+    function _visit(path9, item, visitor) {
+      let ctrl = visitor(item, path9);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path9.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path8);
+            ctrl = ctrl(item, path9);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path9) : ctrl;
     }
     exports.visit = visit;
   }
@@ -6916,14 +6916,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs7, sep: [] });
+                map.items.push({ start, key: fs8, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               } else {
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -7051,13 +7051,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs7, sep: [] });
+                fc.items.push({ start: [], key: fs8, sep: [] });
               else if (it.sep)
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               else
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -7366,11 +7366,14 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.ts
-import path7 from "node:path";
+import path8 from "node:path";
 
-// src/knowledge-loom/audit.ts
-import fs5 from "node:fs";
-import path5 from "node:path";
+// src/knowledge-loom/access.ts
+import { spawnSync as spawnSync2 } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs4 from "node:fs";
+import os4 from "node:os";
+import path4 from "node:path";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7595,6 +7598,13 @@ function validateContractData(contract) {
   if (sync.mode === "lifecycle-hook" && !sync.adapter) {
     findings.push(finding("error", "contract.sync-adapter", "lifecycle sync requires `adapter`"));
   }
+  if (sync.inbound !== void 0) {
+    const inbound = sync.inbound;
+    if (!isUnknownRecord(inbound) || inbound.mode !== "fast-forward" || typeof inbound.remote !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(inbound.remote) || typeof inbound.branch !== "string" || !inbound.branch || /[\s\0]/.test(inbound.branch)) {
+      findings.push(finding("error", "contract.inbound", "`sync.inbound` requires fast-forward mode, a remote name and a branch"));
+    }
+    if (history.type !== "git") findings.push(finding("error", "contract.inbound-history", "inbound access requires Git history"));
+  }
   const backup = mapping(contract, "backup", findings);
   if (Object.keys(backup).length && backup.mode !== "none" && backup.mode !== "lifecycle-hook") {
     findings.push(finding("error", "contract.backup", "unsupported `backup.mode`"));
@@ -7667,10 +7677,6 @@ function validateContractData(contract) {
   }
   return findings;
 }
-
-// src/knowledge-loom/content-checks.ts
-import { spawn } from "node:child_process";
-import path4 from "node:path";
 
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7821,8 +7827,8 @@ function projectAssociation(start, registry) {
   return nearest[0] ?? null;
 }
 function applicableVaultContext(cwd, registryPath) {
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return { vault: loadVault(ancestor), registry: null };
+  const ancestor2 = findAncestorVault(cwd);
+  if (ancestor2) return { vault: loadVault(ancestor2), registry: null };
   const registry = loadRegistry(registryPath);
   const association = projectAssociation(cwd, registry) ?? (() => {
     const mainCheckout = mainCheckoutEquivalent(cwd);
@@ -7915,7 +7921,296 @@ function associateProject(vaultId, projectRoot, {
   return [resolvedRegistryPath, rendered, root];
 }
 
+// src/knowledge-loom/vault-lock.ts
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import os3 from "node:os";
+import { setTimeout as setTimeout2 } from "node:timers/promises";
+var LOCK_REF = "refs/knowledge-loom/mutation-lock";
+function command(root, args, input) {
+  return spawnSync("git", ["-C", root, ...args], { encoding: "utf8", input, timeout: 1e4 });
+}
+function deadOwner(root, revision) {
+  try {
+    const result = command(root, ["cat-file", "blob", revision]);
+    const owner = JSON.parse(result.stdout);
+    if (!isUnknownRecord(owner) || owner.host !== os3.hostname() || typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid < 1) return false;
+    const pids = [owner.pid];
+    if (owner.writer_pid !== void 0) {
+      if (typeof owner.writer_pid !== "number" || !Number.isInteger(owner.writer_pid) || owner.writer_pid < 1) return false;
+      pids.push(owner.writer_group === true ? -owner.writer_pid : owner.writer_pid);
+    }
+    return pids.every((pid) => {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (error) {
+        return isUnknownRecord(error) && error.code === "ESRCH";
+      }
+    });
+  } catch {
+  }
+  return false;
+}
+async function withVaultLock(root, work, waitMs = 2e3) {
+  const owner = { schema_version: 1, host: os3.hostname(), pid: process.pid, token: randomUUID() };
+  const hashed = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify(owner));
+  if (hashed.status !== 0) throw new Error("cannot create vault mutation lock");
+  let revision = hashed.stdout.trim();
+  const deadline = performance.now() + waitMs;
+  do {
+    const existing = command(root, ["rev-parse", "--verify", "--quiet", LOCK_REF]);
+    const current = existing.status === 0 ? existing.stdout.trim() : "0".repeat(revision.length);
+    if (existing.status !== 0 || deadOwner(root, current)) {
+      const acquired = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, revision, current]);
+      if (acquired.status === 0) {
+        try {
+          return { acquired: true, value: await work((pid, group = false) => {
+            const updated = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify({ ...owner, writer_pid: pid, writer_group: group }));
+            const next = updated.stdout.trim();
+            if (updated.status !== 0 || command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, next, revision]).status !== 0) throw new Error("cannot track the active writer");
+            revision = next;
+          }) };
+        } finally {
+          const released = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", "-d", LOCK_REF, revision]);
+          if (released.status !== 0) throw new Error("vault mutation lock release failed; inspect lock ownership before retrying");
+        }
+      }
+    }
+    if (performance.now() >= deadline) break;
+    await setTimeout2(25);
+  } while (true);
+  return { acquired: false };
+}
+function runLockedProcess(root, executable, args, trackWriter, {
+  stdout,
+  stderr,
+  timeoutMs,
+  env = process.env
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const group = process.platform !== "win32";
+    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    let failure;
+    let timer;
+    const stop = () => {
+      try {
+        if (child.pid) process.kill(group ? -child.pid : child.pid, "SIGKILL");
+      } catch {
+      }
+    };
+    child.stdout.on("data", (data) => stdout?.write(data.toString()));
+    child.stderr.on("data", (data) => stderr?.write(data.toString()));
+    child.on("error", (error) => {
+      failure = error;
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (failure) reject(failure);
+      else resolve(code ?? 1);
+    });
+    try {
+      if (child.pid) trackWriter(child.pid, group);
+    } catch (error) {
+      failure = error;
+      stop();
+    }
+    if (timeoutMs !== void 0) timer = globalThis.setTimeout(() => {
+      failure = new Error("locked command timed out");
+      stop();
+    }, timeoutMs);
+  });
+}
+
+// src/knowledge-loom/access.ts
+var DAY = 864e5;
+var RETRY = 3e5;
+function ancestor(root, older, newer) {
+  const result = spawnSync2("git", ["-C", root, "merge-base", "--is-ancestor", older, newer], { timeout: 1e4 });
+  if (result.status !== 0 && result.status !== 1) throw new Error("could not compare Git history");
+  return result.status === 0;
+}
+function git(root, ...args) {
+  const result = spawnSync2("git", ["-C", root, ...args], { encoding: "utf8", timeout: 1e4 });
+  if (result.status !== 0) throw new Error(`Git ${args[0]} failed`);
+  return result.stdout.trim();
+}
+function validateAuthority(vault) {
+  const errors = validateContractData(vault.contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new ContractError(`invalid contract: ${errors.map((item) => item.message).join("; ")}`);
+  const contract = vault.contract;
+  const navigation = isUnknownRecord(contract.navigation) ? contract.navigation : {};
+  const files = [contract.instruction_roots, navigation.entrypoints].flatMap((value) => Array.isArray(value) ? value : []);
+  const views = isUnknownRecord(contract.focus_views) ? contract.focus_views : {};
+  for (const view of Object.values(views)) if (isUnknownRecord(view)) files.push(view.path);
+  for (const relative of files) {
+    const resolved = resolveVaultPath(vault.root, relative);
+    if (!resolved || !fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) throw new ContractError("contract file is missing or crosses the vault boundary");
+  }
+  const profiles = isUnknownRecord(contract.metadata_profiles) ? contract.metadata_profiles : {};
+  const privacy = isUnknownRecord(contract.privacy) ? contract.privacy : {};
+  const patterns = Array.isArray(privacy.never_track) ? [...privacy.never_track] : [];
+  for (const profile of Object.values(profiles)) if (isUnknownRecord(profile) && Array.isArray(profile.paths)) patterns.push(...profile.paths);
+  for (const pattern of patterns) if (!resolveVaultPatternPrefix(vault.root, pattern)) throw new ContractError("contract pattern crosses the vault boundary");
+}
+function upstreamProblem(root, remote, branch) {
+  try {
+    if (canonicalPath(git(root, "rev-parse", "--show-toplevel")) !== root) return "automatic access requires a vault at its Git checkout root";
+    git(root, "check-ref-format", `refs/heads/${branch}`);
+    const local = git(root, "symbolic-ref", "--quiet", "--short", "HEAD");
+    if (git(root, "config", "--get", `branch.${local}.remote`) !== remote || git(root, "config", "--get", `branch.${local}.merge`) !== `refs/heads/${branch}`) return "current branch upstream differs from authorized inbound remote/branch";
+    git(root, "remote", "get-url", "--", remote);
+    git(root, "rev-parse", "--verify", "HEAD");
+    return null;
+  } catch {
+    return "Git repository, remote, branch or upstream is unavailable; configure the authorized upstream before retrying";
+  }
+}
+function operationInProgress(root) {
+  return ["MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "rebase-merge", "rebase-apply", "sequencer", "index.lock"].some((name) => fs4.existsSync(path4.resolve(root, git(root, "rev-parse", "--git-path", name))));
+}
+async function accessVault(vault, { stateDir, now = Date.now, statusOnly = false } = {}) {
+  validateAuthority(vault);
+  const base = { schema_version: 1, root: vault.root };
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const inbound = isUnknownRecord(sync.inbound) ? sync.inbound : {};
+  if (inbound.mode !== "fast-forward") return { ...base, status: "not-enabled" };
+  if (typeof inbound.remote !== "string" || typeof inbound.branch !== "string") throw new Error("inbound requires remote and branch");
+  const { remote, branch } = inbound;
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  try {
+    if (statusOnly) return await refresh(vault, remote, branch, stateDir, now, true);
+    const locked = await withVaultLock(vault.root, (trackWriter) => refresh(vault, remote, branch, stateDir, now, false, trackWriter));
+    return locked.acquired ? locked.value : { ...base, status: "busy", reason: "another task owns the vault mutation lock; local work is preserved" };
+  } catch (error) {
+    if (error instanceof ContractError) throw error;
+    return { ...base, status: "unavailable", reason: "access could not complete; inspect repository and observation-state permissions before retrying" };
+  }
+}
+async function refresh(vault, remote, branch, stateDir, now, statusOnly, trackWriter) {
+  const base = { schema_version: 1, root: vault.root };
+  const currentVault = loadVault(vault.root);
+  validateAuthority(currentVault);
+  if (JSON.stringify(currentVault.contract.sync) !== JSON.stringify(vault.contract.sync)) return { ...base, status: "unavailable", reason: "inbound authority changed while waiting; reread the contract before retrying" };
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  const url = git(vault.root, "remote", "get-url", "--", remote);
+  const localBranch = git(vault.root, "symbolic-ref", "--short", "HEAD");
+  const key = createHash("sha256").update(JSON.stringify([vault.root, localBranch, remote, url, branch])).digest("hex");
+  const directory = canonicalPath(stateDir ?? path4.join(os4.homedir(), ".local", "state", "knowledge-loom"));
+  const common = canonicalPath(git(vault.root, "rev-parse", "--path-format=absolute", "--git-common-dir"));
+  if (isWithin(vault.root, directory) || isWithin(common, directory)) throw new ContractError("operational state must stay outside the vault and its Git directory");
+  const file = path4.join(directory, `${key}.json`);
+  const ref = `refs/knowledge-loom/observations/${key}`;
+  let previous = null;
+  try {
+    const stat = fs4.lstatSync(file, { throwIfNoEntry: false });
+    if (stat && (!stat.isFile() || stat.size > 16384)) throw new Error("invalid observation file");
+    if (stat) {
+      previous = JSON.parse(fs4.readFileSync(file, "utf8"));
+      if (!isUnknownRecord(previous) || previous.schema_version !== 1) throw new Error("invalid observation format");
+      for (const field of ["checked_at", "attempted_at", "retry_at"]) {
+        const value = previous[field];
+        if (value !== void 0 && (typeof value !== "number" || !Number.isFinite(value) || value < 0)) throw new Error("invalid observation time");
+      }
+      if (previous.remote_revision !== void 0 && (typeof previous.remote_revision !== "string" || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(previous.remote_revision))) throw new Error("invalid observation revision");
+    }
+  } catch {
+    return { ...base, status: "unavailable", reason: "observation file is unreadable or invalid; preserve it for inspection and retry with a repaired state directory", state_file: file };
+  }
+  const observed = isUnknownRecord(previous) ? previous : {};
+  const time = now();
+  if (statusOnly && typeof observed.retry_at === "number") return { ...base, status: "unavailable", check: "read-only", observed };
+  if (statusOnly && typeof observed.remote_revision !== "string") return { ...base, status: "unverified", check: "read-only", observed };
+  if (typeof observed.retry_at === "number" && time < observed.retry_at && typeof observed.attempted_at === "number" && time >= observed.attempted_at) {
+    return { ...base, status: "unavailable", check: statusOnly ? "read-only" : "backoff", observed };
+  }
+  const cached = typeof observed.checked_at === "number" && time >= observed.checked_at && time - observed.checked_at < DAY;
+  if (!cached && !statusOnly) {
+    try {
+      if (!trackWriter) throw new Error("remote observation requires a mutation lock");
+      const code = await runLockedProcess(vault.root, "git", ["fetch", "--no-tags", "--no-recurse-submodules", "--no-write-fetch-head", "--refmap=", "--", remote, `+refs/heads/${branch}:${ref}`], trackWriter, {
+        timeoutMs: 3e4,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" }
+      });
+      if (code !== 0) throw new Error("remote fetch failed");
+    } catch {
+      previous = { ...observed, schema_version: 1, attempted_at: time, retry_at: time + RETRY };
+      atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+      return { ...base, status: "unavailable", check: "failed", observed: previous, reason: "remote fetch failed; local work remains available" };
+    }
+    const revision2 = git(vault.root, "rev-parse", "--verify", ref);
+    const rewritten = typeof observed.remote_revision === "string" && !ancestor(vault.root, observed.remote_revision, revision2);
+    previous = { schema_version: 1, attempted_at: time, checked_at: now(), remote_revision: revision2, recovery_required: observed.recovery_required === true || rewritten };
+    atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+  }
+  if (isUnknownRecord(previous) && previous.recovery_required === true) return { ...base, status: "recovery-required", check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, reason: "upstream history changed; reconcile explicitly before resuming automatic integration" };
+  const latest = loadVault(vault.root);
+  validateAuthority(latest);
+  if (git(vault.root, "symbolic-ref", "--short", "HEAD") !== localBranch || git(vault.root, "remote", "get-url", "--", remote) !== url || upstreamProblem(vault.root, remote, branch) || JSON.stringify(latest.contract.sync) !== JSON.stringify(currentVault.contract.sync)) {
+    return { ...base, status: "unavailable", reason: "checkout or inbound authority changed during observation; retry access on the intended branch", observed: previous };
+  }
+  const head = git(vault.root, "rev-parse", "HEAD");
+  const revision = isUnknownRecord(previous) && typeof previous.remote_revision === "string" ? previous.remote_revision : "";
+  if (!revision) return { ...base, status: "unverified", check: statusOnly ? "read-only" : "cached", observed: previous };
+  let status = "current";
+  if (head !== revision) {
+    if (ancestor(vault.root, revision, head)) status = "ahead";
+    else if (!ancestor(vault.root, head, revision)) status = "diverged";
+    else if (statusOnly || operationInProgress(vault.root) || git(vault.root, "status", "--porcelain", "--untracked-files=all")) status = "behind";
+    else {
+      try {
+        git(vault.root, "-c", `core.hooksPath=${os4.devNull}`, "merge", "--ff-only", "--no-overwrite-ignore", revision);
+        status = "integrated";
+      } catch {
+        status = "behind";
+      }
+      if (status === "integrated") validateAuthority(loadVault(vault.root));
+    }
+  }
+  const localRevision = git(vault.root, "rev-parse", "HEAD");
+  if (!statusOnly && isUnknownRecord(previous)) {
+    const updated = { ...previous, integration_status: status, local_revision: localRevision };
+    if (JSON.stringify(updated) !== JSON.stringify(previous)) atomicWriteText(file, `${JSON.stringify(updated)}
+`);
+    previous = updated;
+  }
+  return { ...base, status, check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, head: localRevision, state_file: file };
+}
+async function configureInbound(vault, remote, branch, apply) {
+  validateAuthority(vault);
+  if (!remote || remote.startsWith("-") || /[\s\0]/.test(remote)) throw new Error("a configured remote name is required");
+  const check = spawnSync2("git", ["-C", vault.root, "check-ref-format", `refs/heads/${branch}`], { encoding: "utf8" });
+  if (!branch || check.status !== 0) throw new Error("a valid remote branch is required");
+  const configured = spawnSync2("git", ["-C", vault.root, "remote", "get-url", "--", remote], { encoding: "utf8" });
+  if (configured.status !== 0) throw new Error("remote is not configured; configure it before enabling inbound access");
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const contract = { ...vault.contract, sync: { ...sync, inbound: { mode: "fast-forward", remote, branch } } };
+  const errors = validateContractData(contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new Error(errors.map((item) => item.message).join("; "));
+  const rendered = renderContract(contract, vault.body);
+  if (apply) {
+    const before = fs4.readFileSync(vault.contractPath, "utf8");
+    const locked = await withVaultLock(vault.root, async () => {
+      validateAuthority(loadVault(vault.root));
+      if (fs4.readFileSync(vault.contractPath, "utf8") !== before) throw new Error("contract changed while waiting; preview again");
+      atomicWriteText(vault.contractPath, rendered);
+    });
+    if (!locked.acquired) throw new Error("another writer owns the vault; preview again after it finishes");
+  }
+  return { schema_version: 1, root: vault.root, status: apply ? "configured" : "preview", contract: rendered };
+}
+
+// src/knowledge-loom/audit.ts
+import fs6 from "node:fs";
+import path6 from "node:path";
+
 // src/knowledge-loom/content-checks.ts
+import { spawn as spawn2 } from "node:child_process";
+import path5 from "node:path";
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -8012,7 +8307,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
+  if (!path5.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
   if (!validValidationDate(result.validationDate)) {
@@ -8047,7 +8342,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
 function killProcessTree(child) {
   if (!child.pid) return;
   if (process.platform === "win32") {
-    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+    const killer = spawn2("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
       stdio: "ignore",
       windowsHide: true
     });
@@ -8073,7 +8368,7 @@ function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(executable, arguments_, {
+      child = spawn2(executable, arguments_, {
         cwd,
         shell: false,
         detached: process.platform !== "win32",
@@ -8200,7 +8495,7 @@ async function runDeclaredContentCheck(vault, {
 }
 
 // src/knowledge-loom/focus.ts
-import fs4 from "node:fs";
+import fs5 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -8238,11 +8533,11 @@ function checkFocusView(root, name, view) {
   const relative = view.path;
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs5.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
-  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs5.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top;
   const maxActive = view.max_active;
   const findings = [];
@@ -8333,7 +8628,7 @@ function auditDeclaredFiles(root, values, {
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs6.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -8347,25 +8642,25 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs5.existsSync(root)) return result;
+  if (!fs6.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path5.join(current, entry.name);
+    for (const entry of fs6.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path6.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs6.lstatSync(root).isDirectory() && !fs6.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path5.join(root, ...patternValue.split("/"));
-    return fs5.existsSync(candidate) ? [candidate] : [];
+    const candidate = path6.join(root, ...patternValue.split("/"));
+    return fs6.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path5.join(root, ...prefix);
+  const searchRoot = path6.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
 async function auditVault(vault, { registryPath } = {}) {
@@ -8413,7 +8708,7 @@ async function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs6.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path6.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8468,8 +8763,8 @@ async function auditVault(vault, { registryPath } = {}) {
 }
 
 // src/knowledge-loom/initializer.ts
-import fs6 from "node:fs";
-import path6 from "node:path";
+import fs7 from "node:fs";
+import path7 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8491,13 +8786,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8535,25 +8830,27 @@ function buildContract(root, {
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path6.join(rootPath, CONTRACT_NAME);
-  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path7.join(rootPath, CONTRACT_NAME);
+  if (fs7.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs7.existsSync(rootPath) && fs7.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs6.mkdirSync(rootPath, { recursive: true });
-    fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path6.join(rootPath, "INDEX.md");
-    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs7.mkdirSync(rootPath, { recursive: true });
+    fs7.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path7.join(rootPath, "INDEX.md");
+    if (!adopt && !fs7.existsSync(indexPath)) fs7.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
 }
 
 // src/knowledge-loom/cli.ts
-var HELP = `usage: knowledge-loom {audit,probe,resolve,register,associate,init} ...
+var HELP = `usage: knowledge-loom {access,with-vault-lock,audit,probe,resolve,register,associate,init} ...
 
 commands:
+  access      prepare a vault for retrieval with an authorized daily refresh
+  with-vault-lock  run a cooperative writer under the shared mutation lock
   audit       run a read-only vault audit
   probe       resolve only an ancestor or project-associated vault
   resolve     resolve one vault deterministically
@@ -8562,6 +8859,8 @@ commands:
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
+  "with-vault-lock": "usage: knowledge-loom with-vault-lock [selector] [--registry PATH] -- executable [arguments ...]\n",
+  access: "usage: knowledge-loom access [selector] [--registry PATH] [--state-dir PATH] [--json] [--status] [--enable-inbound --remote NAME --branch NAME [--apply]]\n",
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   probe: "usage: knowledge-loom probe [--registry PATH]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
@@ -8573,6 +8872,10 @@ function isCommand(value) {
   return Object.hasOwn(COMMAND_HELP, value);
 }
 function parseArguments(arguments_) {
+  if (arguments_[0] === "with-vault-lock" && arguments_.includes("--")) {
+    const separator = arguments_.indexOf("--");
+    return { ...parseArguments(arguments_.slice(0, separator)), executable: arguments_.slice(separator + 1) };
+  }
   if (!arguments_.length) throw new Error(HELP.trim());
   const first = arguments_[0];
   if (arguments_.includes("-h") || first === "--help") {
@@ -8584,14 +8887,15 @@ function parseArguments(arguments_) {
     };
   }
   if (!isCommand(first)) throw new Error(`unknown command: ${first}`);
-  const command = first;
+  const command2 = first;
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) {
-    return { help: true, command, positional: [], subject: [] };
+    return { help: true, command: command2, positional: [], subject: [] };
   }
-  const options = { help: false, command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
+  const options = { help: false, command: command2, positional: [], subject: [] };
+  const flags = new Set(command2 === "access" ? ["--json", "--enable-inbound", "--apply", "--status"] : command2 === "audit" ? ["--json"] : command2 === "init" ? ["--adopt", "--apply"] : command2 === "register" ? ["--apply"] : command2 === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
-  if (command === "init") {
+  if (command2 === "access") for (const name of ["--state-dir", "--remote", "--branch"]) valueOptions.add(name);
+  if (command2 === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
   }
   for (let index = 1; index < arguments_.length; index += 1) {
@@ -8599,6 +8903,8 @@ function parseArguments(arguments_) {
     if (token === void 0) continue;
     if (flags.has(token)) {
       if (token === "--json") options.json = true;
+      else if (token === "--enable-inbound") options.enable_inbound = true;
+      else if (token === "--status") options.status = true;
       else if (token === "--adopt") options.adopt = true;
       else if (token === "--apply") options.apply = true;
       else if (token === "--replace") options.replace = true;
@@ -8611,6 +8917,9 @@ function parseArguments(arguments_) {
       if (value === void 0 || value.startsWith("--")) throw new Error(`${name} requires a value`);
       const key = name.slice(2).replaceAll("-", "_");
       if (key === "subject") options.subject.push(value);
+      else if (key === "state_dir") options.state_dir = value;
+      else if (key === "remote") options.remote = value;
+      else if (key === "branch") options.branch = value;
       else if (key === "registry") options.registry = value;
       else if (key === "vault_id") options.vault_id = value;
       else if (key === "title") options.title = value;
@@ -8634,11 +8943,35 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr, now = Date.now } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
       stdout.write(options.command ? COMMAND_HELP[options.command] : HELP);
+      return 0;
+    }
+    if (options.command === "with-vault-lock") {
+      if (options.positional.length > 1 || !options.executable?.length) throw new Error(COMMAND_HELP["with-vault-lock"].trim());
+      const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
+      const [executable, ...args] = options.executable;
+      const locked = await withVaultLock(vault.root, (trackWriter) => runLockedProcess(vault.root, executable, args, trackWriter, { stdout, stderr }));
+      if (!locked.acquired) {
+        stderr.write("BUSY another task owns the vault mutation lock\n");
+        return 1;
+      }
+      return locked.value;
+    }
+    if (options.command === "access") {
+      if (options.positional.length > 1) throw new Error(COMMAND_HELP.access.trim());
+      const context = { cwd, registryPath: options.registry };
+      const vault = options.positional[0] ? resolveVault(options.positional[0], context) : resolveApplicableVault(context);
+      if (!options.enable_inbound && (options.apply || options.remote || options.branch)) throw new Error("--apply, --remote and --branch require --enable-inbound");
+      if (options.enable_inbound && options.status) throw new Error("--status cannot enable inbound access");
+      if (options.enable_inbound && (!vault || !options.remote || !options.branch)) throw new Error("enabling inbound requires a vault, --remote and --branch");
+      const result = options.enable_inbound && vault ? await configureInbound(vault, options.remote, options.branch, options.apply === true) : vault ? await accessVault(vault, { stateDir: options.state_dir, now, statusOnly: options.status === true }) : { schema_version: 1, root: null, status: "not-applicable" };
+      stdout.write(options.json ? `${JSON.stringify(result)}
+` : `${result.status}${result.root ? ` ${result.root}` : ""}
+`);
       return 0;
     }
     if (options.command === "audit") {
@@ -8699,7 +9032,7 @@ ${rendered2}`);
     if (!isWritePolicy(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!isCurrentStatePolicy(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!isHistoryType(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path7.resolve(expandHome(options.positional[0]));
+    const root = path8.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,

--- a/skills/manage-current-focus/scripts/knowledge-loom.mjs
+++ b/skills/manage-current-focus/scripts/knowledge-loom.mjs
@@ -7982,6 +7982,16 @@ async function withVaultLock(root, work, waitMs = 2e3) {
   } while (true);
   return { acquired: false };
 }
+var LOCKED_COMMAND_GATE = `
+const { spawn } = require("node:child_process");
+process.stdin.once("data", () => {
+  process.stdin.destroy();
+  const child = spawn(process.argv[1], process.argv.slice(2), { stdio: ["ignore", "inherit", "inherit"] });
+  child.once("error", () => process.exit(1));
+  child.once("exit", (code) => process.exit(code ?? 1));
+});
+process.stdin.once("end", () => process.exit(1));
+`;
 function runLockedProcess(root, executable, args, trackWriter, {
   stdout,
   stderr,
@@ -7990,7 +8000,7 @@ function runLockedProcess(root, executable, args, trackWriter, {
 } = {}) {
   return new Promise((resolve, reject) => {
     const group = process.platform !== "win32";
-    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(process.execPath, ["-e", LOCKED_COMMAND_GATE, "--", executable, ...args], { cwd: root, env, detached: group, stdio: ["pipe", "pipe", "pipe"] });
     let failure;
     let timer;
     const stop = () => {
@@ -8009,8 +8019,15 @@ function runLockedProcess(root, executable, args, trackWriter, {
       if (failure) reject(failure);
       else resolve(code ?? 1);
     });
+    child.stdin.on("error", (error) => {
+      failure = error;
+      stop();
+    });
     try {
-      if (child.pid) trackWriter(child.pid, group);
+      if (child.pid) {
+        trackWriter(child.pid, group);
+        child.stdin.end("start");
+      }
     } catch (error) {
       failure = error;
       stop();

--- a/skills/use-knowledge-vault/SKILL.md
+++ b/skills/use-knowledge-vault/SKILL.md
@@ -29,9 +29,12 @@ policy, lifecycle, and failure behavior.
    - When the user explicitly requests a vault operation, run `resolve`. Append a selector only
      when the user or invoking wrapper supplied one, and apply the protocol's selection failure
      behavior.
-3. Treat the returned canonical root as the only selected vault, read its contract completely, and
-   complete **Retrieve** before finishing the primary task. Use only context that materially affects
-   its result.
+3. Treat the returned canonical root as the only selected vault. Read its contract and instruction
+   roots, then follow **Prepare inbound access** with
+   `node "<skill-root>/scripts/knowledge-loom.mjs" access <vault-path> --json` before ordinary
+   retrieval. Preserve an explicit read-only request. After integration, reload governing files and
+   complete **Retrieve** using the updated knowledge. Carry degraded access state into claims that
+   depend on remote freshness; use only context that materially affects the primary task.
 4. Evaluate **Write authorization** after the primary task. Enter **Distill** only when the selected
    policy and current request authorize a vault change. When that branch will create or restructure
    an agent-consumed note or navigation pointer, apply the protocol's **Agent-readable

--- a/skills/use-knowledge-vault/references/protocol.md
+++ b/skills/use-knowledge-vault/references/protocol.md
@@ -94,6 +94,9 @@ association remains the nearest match.
 
 ## Retrieve
 
+Before ordinary retrieval, complete **Prepare inbound access** for the selected vault. Explicit
+read-only audits and resolution probes retain their read-only behavior.
+
 1. Read `KNOWLEDGE_VAULT.md` completely.
 2. Resolve declared paths inside the vault boundary, then read its instruction roots and
    navigation entrypoints. Follow every instruction-root context pointer whose stated trigger
@@ -135,6 +138,44 @@ association remains the nearest match.
 11. Complete retrieval only when each decisive claim has supporting evidence, or the result states
     that the required evidence is missing, conflicting, stale, or unavailable. If mandatory route
     evidence is absent, say what is missing and abstain from the unsupported conclusion.
+
+## Prepare inbound access
+
+1. Resolve one vault using the applicable selection mode. Read its contract and instruction roots
+   before invoking inbound access; their policy governs whether the operation is authorized.
+2. Invoke `access` on the selected canonical root before reading knowledge. Without a selector it
+   uses automatic applicability only; explicit operations resolve first and pass the root. Missing
+   `sync.inbound` returns `not-enabled` without fetching. Offer a previewed migration when enabling
+   inbound behavior is within the user's request.
+3. Reuse a successful remote observation for 24 elapsed hours on the same device, checkout, local
+   branch, and configured remote/branch identity. Ordinary conversation causes no check. Writing
+   does not bypass this interval. An observation is not evidence of later remote changes.
+4. Integrate a clean, behind-only checkout by fast-forward. Revalidate governing paths afterward
+   and reload the contract, instruction roots, and relevant knowledge. Preserve staged, untracked,
+   unfinished, and unrelated edits. An active Git operation or cooperative writer defers integration.
+   A fetched remote revision with deferred integration remains `behind`.
+5. Report the actual result. `current` means the local commit equals the observed commit; `ahead`
+   means local commits remain; `diverged` requires reconciliation. Upstream rewrites require explicit
+   recovery. `unavailable` and `busy` preserve local work without prohibiting otherwise authorized
+   reading, editing, or committing. Disclose unverified remote state when it affects a judgment.
+   Invalid contracts or escaping governing paths still stop vault access.
+6. Separate last attempt, successful observation, and integration state. Failed remote checks use a
+   bounded five-minute retry backoff. `access --status` reports persisted observations and current
+   local revision without fetching, integrating, or rewriting state.
+
+Store operational records outside tracked vault contents. Cooperating writers use the same
+repository-wide mutation lock as access, including across linked worktrees. `with-vault-lock` runs
+an executable under that lock; its child must finish its writes before exiting. The wrapper adds
+no write authority. Do not claim that arbitrary external file edits bypassing these entry points
+are intercepted.
+
+Recover only confirmed terminated lock owners; elapsed time alone never authorizes stealing a
+live writer's lock. Git lock ownership is local operational metadata: keep these references out of
+explicit mirror/all-reference transfers.
+
+Access performs no outbound push, divergent merge, skill installation, or backup. Continue the
+declared lifecycle separately and report incomplete stages. Immediate reconciliation following a
+non-fast-forward push rejection belongs to the synchronization adapter, not this access operation.
 
 ## Write authorization
 

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -115,17 +115,17 @@ var require_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    function visit_(key, node, visitor, path8) {
-      const ctrl = callVisitor(key, node, visitor, path8);
+    function visit_(key, node, visitor, path9) {
+      const ctrl = callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visit_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visit_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = visit_(i, node.items[i], visitor, path8);
+            const ci = visit_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -136,13 +136,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = visit_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = visit_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = visit_("value", node.value, visitor, path8);
+          const cv = visit_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -163,17 +163,17 @@ var require_visit = __commonJS({
     visitAsync.BREAK = BREAK;
     visitAsync.SKIP = SKIP;
     visitAsync.REMOVE = REMOVE;
-    async function visitAsync_(key, node, visitor, path8) {
-      const ctrl = await callVisitor(key, node, visitor, path8);
+    async function visitAsync_(key, node, visitor, path9) {
+      const ctrl = await callVisitor(key, node, visitor, path9);
       if (identity.isNode(ctrl) || identity.isPair(ctrl)) {
-        replaceNode(key, path8, ctrl);
-        return visitAsync_(key, ctrl, visitor, path8);
+        replaceNode(key, path9, ctrl);
+        return visitAsync_(key, ctrl, visitor, path9);
       }
       if (typeof ctrl !== "symbol") {
         if (identity.isCollection(node)) {
-          path8 = Object.freeze(path8.concat(node));
+          path9 = Object.freeze(path9.concat(node));
           for (let i = 0; i < node.items.length; ++i) {
-            const ci = await visitAsync_(i, node.items[i], visitor, path8);
+            const ci = await visitAsync_(i, node.items[i], visitor, path9);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -184,13 +184,13 @@ var require_visit = __commonJS({
             }
           }
         } else if (identity.isPair(node)) {
-          path8 = Object.freeze(path8.concat(node));
-          const ck = await visitAsync_("key", node.key, visitor, path8);
+          path9 = Object.freeze(path9.concat(node));
+          const ck = await visitAsync_("key", node.key, visitor, path9);
           if (ck === BREAK)
             return BREAK;
           else if (ck === REMOVE)
             node.key = null;
-          const cv = await visitAsync_("value", node.value, visitor, path8);
+          const cv = await visitAsync_("value", node.value, visitor, path9);
           if (cv === BREAK)
             return BREAK;
           else if (cv === REMOVE)
@@ -217,23 +217,23 @@ var require_visit = __commonJS({
       }
       return visitor;
     }
-    function callVisitor(key, node, visitor, path8) {
+    function callVisitor(key, node, visitor, path9) {
       if (typeof visitor === "function")
-        return visitor(key, node, path8);
+        return visitor(key, node, path9);
       if (identity.isMap(node))
-        return visitor.Map?.(key, node, path8);
+        return visitor.Map?.(key, node, path9);
       if (identity.isSeq(node))
-        return visitor.Seq?.(key, node, path8);
+        return visitor.Seq?.(key, node, path9);
       if (identity.isPair(node))
-        return visitor.Pair?.(key, node, path8);
+        return visitor.Pair?.(key, node, path9);
       if (identity.isScalar(node))
-        return visitor.Scalar?.(key, node, path8);
+        return visitor.Scalar?.(key, node, path9);
       if (identity.isAlias(node))
-        return visitor.Alias?.(key, node, path8);
+        return visitor.Alias?.(key, node, path9);
       return void 0;
     }
-    function replaceNode(key, path8, node) {
-      const parent = path8[path8.length - 1];
+    function replaceNode(key, path9, node) {
+      const parent = path9[path9.length - 1];
       if (identity.isCollection(parent)) {
         parent.items[key] = node;
       } else if (identity.isPair(parent)) {
@@ -843,10 +843,10 @@ var require_Collection = __commonJS({
     var createNode = require_createNode();
     var identity = require_identity();
     var Node = require_Node();
-    function collectionFromPath(schema, path8, value) {
+    function collectionFromPath(schema, path9, value) {
       let v = value;
-      for (let i = path8.length - 1; i >= 0; --i) {
-        const k = path8[i];
+      for (let i = path9.length - 1; i >= 0; --i) {
+        const k = path9[i];
         if (typeof k === "number" && Number.isInteger(k) && k >= 0) {
           const a = [];
           a[k] = v;
@@ -865,7 +865,7 @@ var require_Collection = __commonJS({
         sourceObjects: /* @__PURE__ */ new Map()
       });
     }
-    var isEmptyPath = (path8) => path8 == null || typeof path8 === "object" && !!path8[Symbol.iterator]().next().done;
+    var isEmptyPath = (path9) => path9 == null || typeof path9 === "object" && !!path9[Symbol.iterator]().next().done;
     var Collection = class extends Node.NodeBase {
       constructor(type, schema) {
         super(type);
@@ -895,11 +895,11 @@ var require_Collection = __commonJS({
        * be a Pair instance or a `{ key, value }` object, which may not have a key
        * that already exists in the map.
        */
-      addIn(path8, value) {
-        if (isEmptyPath(path8))
+      addIn(path9, value) {
+        if (isEmptyPath(path9))
           this.add(value);
         else {
-          const [key, ...rest] = path8;
+          const [key, ...rest] = path9;
           const node = this.get(key, true);
           if (identity.isCollection(node))
             node.addIn(rest, value);
@@ -913,8 +913,8 @@ var require_Collection = __commonJS({
        * Removes a value from the collection.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        const [key, ...rest] = path8;
+      deleteIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.delete(key);
         const node = this.get(key, true);
@@ -928,8 +928,8 @@ var require_Collection = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        const [key, ...rest] = path8;
+      getIn(path9, keepScalar) {
+        const [key, ...rest] = path9;
         const node = this.get(key, true);
         if (rest.length === 0)
           return !keepScalar && identity.isScalar(node) ? node.value : node;
@@ -947,8 +947,8 @@ var require_Collection = __commonJS({
       /**
        * Checks if the collection includes a value with the key `key`.
        */
-      hasIn(path8) {
-        const [key, ...rest] = path8;
+      hasIn(path9) {
+        const [key, ...rest] = path9;
         if (rest.length === 0)
           return this.has(key);
         const node = this.get(key, true);
@@ -958,8 +958,8 @@ var require_Collection = __commonJS({
        * Sets a value in this collection. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        const [key, ...rest] = path8;
+      setIn(path9, value) {
+        const [key, ...rest] = path9;
         if (rest.length === 0) {
           this.set(key, value);
         } else {
@@ -3474,9 +3474,9 @@ var require_Document = __commonJS({
           this.contents.add(value);
       }
       /** Adds a value to the document. */
-      addIn(path8, value) {
+      addIn(path9, value) {
         if (assertCollection(this.contents))
-          this.contents.addIn(path8, value);
+          this.contents.addIn(path9, value);
       }
       /**
        * Create a new `Alias` node, ensuring that the target `node` has the required anchor.
@@ -3551,14 +3551,14 @@ var require_Document = __commonJS({
        * Removes a value from the document.
        * @returns `true` if the item was found and removed.
        */
-      deleteIn(path8) {
-        if (Collection.isEmptyPath(path8)) {
+      deleteIn(path9) {
+        if (Collection.isEmptyPath(path9)) {
           if (this.contents == null)
             return false;
           this.contents = null;
           return true;
         }
-        return assertCollection(this.contents) ? this.contents.deleteIn(path8) : false;
+        return assertCollection(this.contents) ? this.contents.deleteIn(path9) : false;
       }
       /**
        * Returns item at `key`, or `undefined` if not found. By default unwraps
@@ -3573,10 +3573,10 @@ var require_Document = __commonJS({
        * scalar values from their surrounding node; to disable set `keepScalar` to
        * `true` (collections are always returned intact).
        */
-      getIn(path8, keepScalar) {
-        if (Collection.isEmptyPath(path8))
+      getIn(path9, keepScalar) {
+        if (Collection.isEmptyPath(path9))
           return !keepScalar && identity.isScalar(this.contents) ? this.contents.value : this.contents;
-        return identity.isCollection(this.contents) ? this.contents.getIn(path8, keepScalar) : void 0;
+        return identity.isCollection(this.contents) ? this.contents.getIn(path9, keepScalar) : void 0;
       }
       /**
        * Checks if the document includes a value with the key `key`.
@@ -3587,10 +3587,10 @@ var require_Document = __commonJS({
       /**
        * Checks if the document includes a value at `path`.
        */
-      hasIn(path8) {
-        if (Collection.isEmptyPath(path8))
+      hasIn(path9) {
+        if (Collection.isEmptyPath(path9))
           return this.contents !== void 0;
-        return identity.isCollection(this.contents) ? this.contents.hasIn(path8) : false;
+        return identity.isCollection(this.contents) ? this.contents.hasIn(path9) : false;
       }
       /**
        * Sets a value in this document. For `!!set`, `value` needs to be a
@@ -3607,13 +3607,13 @@ var require_Document = __commonJS({
        * Sets a value in this document. For `!!set`, `value` needs to be a
        * boolean to add/remove the item from the set.
        */
-      setIn(path8, value) {
-        if (Collection.isEmptyPath(path8)) {
+      setIn(path9, value) {
+        if (Collection.isEmptyPath(path9)) {
           this.contents = value;
         } else if (this.contents == null) {
-          this.contents = Collection.collectionFromPath(this.schema, Array.from(path8), value);
+          this.contents = Collection.collectionFromPath(this.schema, Array.from(path9), value);
         } else if (assertCollection(this.contents)) {
-          this.contents.setIn(path8, value);
+          this.contents.setIn(path9, value);
         }
       }
       /**
@@ -5573,9 +5573,9 @@ var require_cst_visit = __commonJS({
     visit.BREAK = BREAK;
     visit.SKIP = SKIP;
     visit.REMOVE = REMOVE;
-    visit.itemAtPath = (cst, path8) => {
+    visit.itemAtPath = (cst, path9) => {
       let item = cst;
-      for (const [field, index] of path8) {
+      for (const [field, index] of path9) {
         const tok = item?.[field];
         if (tok && "items" in tok) {
           item = tok.items[index];
@@ -5584,23 +5584,23 @@ var require_cst_visit = __commonJS({
       }
       return item;
     };
-    visit.parentCollection = (cst, path8) => {
-      const parent = visit.itemAtPath(cst, path8.slice(0, -1));
-      const field = path8[path8.length - 1][0];
+    visit.parentCollection = (cst, path9) => {
+      const parent = visit.itemAtPath(cst, path9.slice(0, -1));
+      const field = path9[path9.length - 1][0];
       const coll = parent?.[field];
       if (coll && "items" in coll)
         return coll;
       throw new Error("Parent collection not found");
     };
-    function _visit(path8, item, visitor) {
-      let ctrl = visitor(item, path8);
+    function _visit(path9, item, visitor) {
+      let ctrl = visitor(item, path9);
       if (typeof ctrl === "symbol")
         return ctrl;
       for (const field of ["key", "value"]) {
         const token = item[field];
         if (token && "items" in token) {
           for (let i = 0; i < token.items.length; ++i) {
-            const ci = _visit(Object.freeze(path8.concat([[field, i]])), token.items[i], visitor);
+            const ci = _visit(Object.freeze(path9.concat([[field, i]])), token.items[i], visitor);
             if (typeof ci === "number")
               i = ci - 1;
             else if (ci === BREAK)
@@ -5611,10 +5611,10 @@ var require_cst_visit = __commonJS({
             }
           }
           if (typeof ctrl === "function" && field === "key")
-            ctrl = ctrl(item, path8);
+            ctrl = ctrl(item, path9);
         }
       }
-      return typeof ctrl === "function" ? ctrl(item, path8) : ctrl;
+      return typeof ctrl === "function" ? ctrl(item, path9) : ctrl;
     }
     exports.visit = visit;
   }
@@ -6916,14 +6916,14 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (atNextItem || it.value) {
-                map.items.push({ start, key: fs7, sep: [] });
+                map.items.push({ start, key: fs8, sep: [] });
                 this.onKeyLine = true;
               } else if (it.sep) {
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               } else {
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
                 this.onKeyLine = true;
               }
               return;
@@ -7051,13 +7051,13 @@ var require_parser = __commonJS({
             case "scalar":
             case "single-quoted-scalar":
             case "double-quoted-scalar": {
-              const fs7 = this.flowScalar(this.type);
+              const fs8 = this.flowScalar(this.type);
               if (!it || it.value)
-                fc.items.push({ start: [], key: fs7, sep: [] });
+                fc.items.push({ start: [], key: fs8, sep: [] });
               else if (it.sep)
-                this.stack.push(fs7);
+                this.stack.push(fs8);
               else
-                Object.assign(it, { key: fs7, sep: [] });
+                Object.assign(it, { key: fs8, sep: [] });
               return;
             }
             case "flow-map-end":
@@ -7366,11 +7366,14 @@ var require_dist = __commonJS({
 });
 
 // src/knowledge-loom/cli.ts
-import path7 from "node:path";
+import path8 from "node:path";
 
-// src/knowledge-loom/audit.ts
-import fs5 from "node:fs";
-import path5 from "node:path";
+// src/knowledge-loom/access.ts
+import { spawnSync as spawnSync2 } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs4 from "node:fs";
+import os4 from "node:os";
+import path4 from "node:path";
 
 // src/knowledge-loom/contract.ts
 var import_yaml = __toESM(require_dist(), 1);
@@ -7595,6 +7598,13 @@ function validateContractData(contract) {
   if (sync.mode === "lifecycle-hook" && !sync.adapter) {
     findings.push(finding("error", "contract.sync-adapter", "lifecycle sync requires `adapter`"));
   }
+  if (sync.inbound !== void 0) {
+    const inbound = sync.inbound;
+    if (!isUnknownRecord(inbound) || inbound.mode !== "fast-forward" || typeof inbound.remote !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(inbound.remote) || typeof inbound.branch !== "string" || !inbound.branch || /[\s\0]/.test(inbound.branch)) {
+      findings.push(finding("error", "contract.inbound", "`sync.inbound` requires fast-forward mode, a remote name and a branch"));
+    }
+    if (history.type !== "git") findings.push(finding("error", "contract.inbound-history", "inbound access requires Git history"));
+  }
   const backup = mapping(contract, "backup", findings);
   if (Object.keys(backup).length && backup.mode !== "none" && backup.mode !== "lifecycle-hook") {
     findings.push(finding("error", "contract.backup", "unsupported `backup.mode`"));
@@ -7667,10 +7677,6 @@ function validateContractData(contract) {
   }
   return findings;
 }
-
-// src/knowledge-loom/content-checks.ts
-import { spawn } from "node:child_process";
-import path4 from "node:path";
 
 // src/knowledge-loom/registry.ts
 var import_yaml2 = __toESM(require_dist(), 1);
@@ -7821,8 +7827,8 @@ function projectAssociation(start, registry) {
   return nearest[0] ?? null;
 }
 function applicableVaultContext(cwd, registryPath) {
-  const ancestor = findAncestorVault(cwd);
-  if (ancestor) return { vault: loadVault(ancestor), registry: null };
+  const ancestor2 = findAncestorVault(cwd);
+  if (ancestor2) return { vault: loadVault(ancestor2), registry: null };
   const registry = loadRegistry(registryPath);
   const association = projectAssociation(cwd, registry) ?? (() => {
     const mainCheckout = mainCheckoutEquivalent(cwd);
@@ -7915,7 +7921,296 @@ function associateProject(vaultId, projectRoot, {
   return [resolvedRegistryPath, rendered, root];
 }
 
+// src/knowledge-loom/vault-lock.ts
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import os3 from "node:os";
+import { setTimeout as setTimeout2 } from "node:timers/promises";
+var LOCK_REF = "refs/knowledge-loom/mutation-lock";
+function command(root, args, input) {
+  return spawnSync("git", ["-C", root, ...args], { encoding: "utf8", input, timeout: 1e4 });
+}
+function deadOwner(root, revision) {
+  try {
+    const result = command(root, ["cat-file", "blob", revision]);
+    const owner = JSON.parse(result.stdout);
+    if (!isUnknownRecord(owner) || owner.host !== os3.hostname() || typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid < 1) return false;
+    const pids = [owner.pid];
+    if (owner.writer_pid !== void 0) {
+      if (typeof owner.writer_pid !== "number" || !Number.isInteger(owner.writer_pid) || owner.writer_pid < 1) return false;
+      pids.push(owner.writer_group === true ? -owner.writer_pid : owner.writer_pid);
+    }
+    return pids.every((pid) => {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (error) {
+        return isUnknownRecord(error) && error.code === "ESRCH";
+      }
+    });
+  } catch {
+  }
+  return false;
+}
+async function withVaultLock(root, work, waitMs = 2e3) {
+  const owner = { schema_version: 1, host: os3.hostname(), pid: process.pid, token: randomUUID() };
+  const hashed = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify(owner));
+  if (hashed.status !== 0) throw new Error("cannot create vault mutation lock");
+  let revision = hashed.stdout.trim();
+  const deadline = performance.now() + waitMs;
+  do {
+    const existing = command(root, ["rev-parse", "--verify", "--quiet", LOCK_REF]);
+    const current = existing.status === 0 ? existing.stdout.trim() : "0".repeat(revision.length);
+    if (existing.status !== 0 || deadOwner(root, current)) {
+      const acquired = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, revision, current]);
+      if (acquired.status === 0) {
+        try {
+          return { acquired: true, value: await work((pid, group = false) => {
+            const updated = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify({ ...owner, writer_pid: pid, writer_group: group }));
+            const next = updated.stdout.trim();
+            if (updated.status !== 0 || command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", LOCK_REF, next, revision]).status !== 0) throw new Error("cannot track the active writer");
+            revision = next;
+          }) };
+        } finally {
+          const released = command(root, ["-c", `core.hooksPath=${os3.devNull}`, "update-ref", "-d", LOCK_REF, revision]);
+          if (released.status !== 0) throw new Error("vault mutation lock release failed; inspect lock ownership before retrying");
+        }
+      }
+    }
+    if (performance.now() >= deadline) break;
+    await setTimeout2(25);
+  } while (true);
+  return { acquired: false };
+}
+function runLockedProcess(root, executable, args, trackWriter, {
+  stdout,
+  stderr,
+  timeoutMs,
+  env = process.env
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const group = process.platform !== "win32";
+    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    let failure;
+    let timer;
+    const stop = () => {
+      try {
+        if (child.pid) process.kill(group ? -child.pid : child.pid, "SIGKILL");
+      } catch {
+      }
+    };
+    child.stdout.on("data", (data) => stdout?.write(data.toString()));
+    child.stderr.on("data", (data) => stderr?.write(data.toString()));
+    child.on("error", (error) => {
+      failure = error;
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (failure) reject(failure);
+      else resolve(code ?? 1);
+    });
+    try {
+      if (child.pid) trackWriter(child.pid, group);
+    } catch (error) {
+      failure = error;
+      stop();
+    }
+    if (timeoutMs !== void 0) timer = globalThis.setTimeout(() => {
+      failure = new Error("locked command timed out");
+      stop();
+    }, timeoutMs);
+  });
+}
+
+// src/knowledge-loom/access.ts
+var DAY = 864e5;
+var RETRY = 3e5;
+function ancestor(root, older, newer) {
+  const result = spawnSync2("git", ["-C", root, "merge-base", "--is-ancestor", older, newer], { timeout: 1e4 });
+  if (result.status !== 0 && result.status !== 1) throw new Error("could not compare Git history");
+  return result.status === 0;
+}
+function git(root, ...args) {
+  const result = spawnSync2("git", ["-C", root, ...args], { encoding: "utf8", timeout: 1e4 });
+  if (result.status !== 0) throw new Error(`Git ${args[0]} failed`);
+  return result.stdout.trim();
+}
+function validateAuthority(vault) {
+  const errors = validateContractData(vault.contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new ContractError(`invalid contract: ${errors.map((item) => item.message).join("; ")}`);
+  const contract = vault.contract;
+  const navigation = isUnknownRecord(contract.navigation) ? contract.navigation : {};
+  const files = [contract.instruction_roots, navigation.entrypoints].flatMap((value) => Array.isArray(value) ? value : []);
+  const views = isUnknownRecord(contract.focus_views) ? contract.focus_views : {};
+  for (const view of Object.values(views)) if (isUnknownRecord(view)) files.push(view.path);
+  for (const relative of files) {
+    const resolved = resolveVaultPath(vault.root, relative);
+    if (!resolved || !fs4.statSync(resolved, { throwIfNoEntry: false })?.isFile()) throw new ContractError("contract file is missing or crosses the vault boundary");
+  }
+  const profiles = isUnknownRecord(contract.metadata_profiles) ? contract.metadata_profiles : {};
+  const privacy = isUnknownRecord(contract.privacy) ? contract.privacy : {};
+  const patterns = Array.isArray(privacy.never_track) ? [...privacy.never_track] : [];
+  for (const profile of Object.values(profiles)) if (isUnknownRecord(profile) && Array.isArray(profile.paths)) patterns.push(...profile.paths);
+  for (const pattern of patterns) if (!resolveVaultPatternPrefix(vault.root, pattern)) throw new ContractError("contract pattern crosses the vault boundary");
+}
+function upstreamProblem(root, remote, branch) {
+  try {
+    if (canonicalPath(git(root, "rev-parse", "--show-toplevel")) !== root) return "automatic access requires a vault at its Git checkout root";
+    git(root, "check-ref-format", `refs/heads/${branch}`);
+    const local = git(root, "symbolic-ref", "--quiet", "--short", "HEAD");
+    if (git(root, "config", "--get", `branch.${local}.remote`) !== remote || git(root, "config", "--get", `branch.${local}.merge`) !== `refs/heads/${branch}`) return "current branch upstream differs from authorized inbound remote/branch";
+    git(root, "remote", "get-url", "--", remote);
+    git(root, "rev-parse", "--verify", "HEAD");
+    return null;
+  } catch {
+    return "Git repository, remote, branch or upstream is unavailable; configure the authorized upstream before retrying";
+  }
+}
+function operationInProgress(root) {
+  return ["MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "rebase-merge", "rebase-apply", "sequencer", "index.lock"].some((name) => fs4.existsSync(path4.resolve(root, git(root, "rev-parse", "--git-path", name))));
+}
+async function accessVault(vault, { stateDir, now = Date.now, statusOnly = false } = {}) {
+  validateAuthority(vault);
+  const base = { schema_version: 1, root: vault.root };
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const inbound = isUnknownRecord(sync.inbound) ? sync.inbound : {};
+  if (inbound.mode !== "fast-forward") return { ...base, status: "not-enabled" };
+  if (typeof inbound.remote !== "string" || typeof inbound.branch !== "string") throw new Error("inbound requires remote and branch");
+  const { remote, branch } = inbound;
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  try {
+    if (statusOnly) return await refresh(vault, remote, branch, stateDir, now, true);
+    const locked = await withVaultLock(vault.root, (trackWriter) => refresh(vault, remote, branch, stateDir, now, false, trackWriter));
+    return locked.acquired ? locked.value : { ...base, status: "busy", reason: "another task owns the vault mutation lock; local work is preserved" };
+  } catch (error) {
+    if (error instanceof ContractError) throw error;
+    return { ...base, status: "unavailable", reason: "access could not complete; inspect repository and observation-state permissions before retrying" };
+  }
+}
+async function refresh(vault, remote, branch, stateDir, now, statusOnly, trackWriter) {
+  const base = { schema_version: 1, root: vault.root };
+  const currentVault = loadVault(vault.root);
+  validateAuthority(currentVault);
+  if (JSON.stringify(currentVault.contract.sync) !== JSON.stringify(vault.contract.sync)) return { ...base, status: "unavailable", reason: "inbound authority changed while waiting; reread the contract before retrying" };
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  const url = git(vault.root, "remote", "get-url", "--", remote);
+  const localBranch = git(vault.root, "symbolic-ref", "--short", "HEAD");
+  const key = createHash("sha256").update(JSON.stringify([vault.root, localBranch, remote, url, branch])).digest("hex");
+  const directory = canonicalPath(stateDir ?? path4.join(os4.homedir(), ".local", "state", "knowledge-loom"));
+  const common = canonicalPath(git(vault.root, "rev-parse", "--path-format=absolute", "--git-common-dir"));
+  if (isWithin(vault.root, directory) || isWithin(common, directory)) throw new ContractError("operational state must stay outside the vault and its Git directory");
+  const file = path4.join(directory, `${key}.json`);
+  const ref = `refs/knowledge-loom/observations/${key}`;
+  let previous = null;
+  try {
+    const stat = fs4.lstatSync(file, { throwIfNoEntry: false });
+    if (stat && (!stat.isFile() || stat.size > 16384)) throw new Error("invalid observation file");
+    if (stat) {
+      previous = JSON.parse(fs4.readFileSync(file, "utf8"));
+      if (!isUnknownRecord(previous) || previous.schema_version !== 1) throw new Error("invalid observation format");
+      for (const field of ["checked_at", "attempted_at", "retry_at"]) {
+        const value = previous[field];
+        if (value !== void 0 && (typeof value !== "number" || !Number.isFinite(value) || value < 0)) throw new Error("invalid observation time");
+      }
+      if (previous.remote_revision !== void 0 && (typeof previous.remote_revision !== "string" || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(previous.remote_revision))) throw new Error("invalid observation revision");
+    }
+  } catch {
+    return { ...base, status: "unavailable", reason: "observation file is unreadable or invalid; preserve it for inspection and retry with a repaired state directory", state_file: file };
+  }
+  const observed = isUnknownRecord(previous) ? previous : {};
+  const time = now();
+  if (statusOnly && typeof observed.retry_at === "number") return { ...base, status: "unavailable", check: "read-only", observed };
+  if (statusOnly && typeof observed.remote_revision !== "string") return { ...base, status: "unverified", check: "read-only", observed };
+  if (typeof observed.retry_at === "number" && time < observed.retry_at && typeof observed.attempted_at === "number" && time >= observed.attempted_at) {
+    return { ...base, status: "unavailable", check: statusOnly ? "read-only" : "backoff", observed };
+  }
+  const cached = typeof observed.checked_at === "number" && time >= observed.checked_at && time - observed.checked_at < DAY;
+  if (!cached && !statusOnly) {
+    try {
+      if (!trackWriter) throw new Error("remote observation requires a mutation lock");
+      const code = await runLockedProcess(vault.root, "git", ["fetch", "--no-tags", "--no-recurse-submodules", "--no-write-fetch-head", "--refmap=", "--", remote, `+refs/heads/${branch}:${ref}`], trackWriter, {
+        timeoutMs: 3e4,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" }
+      });
+      if (code !== 0) throw new Error("remote fetch failed");
+    } catch {
+      previous = { ...observed, schema_version: 1, attempted_at: time, retry_at: time + RETRY };
+      atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+      return { ...base, status: "unavailable", check: "failed", observed: previous, reason: "remote fetch failed; local work remains available" };
+    }
+    const revision2 = git(vault.root, "rev-parse", "--verify", ref);
+    const rewritten = typeof observed.remote_revision === "string" && !ancestor(vault.root, observed.remote_revision, revision2);
+    previous = { schema_version: 1, attempted_at: time, checked_at: now(), remote_revision: revision2, recovery_required: observed.recovery_required === true || rewritten };
+    atomicWriteText(file, `${JSON.stringify(previous)}
+`);
+  }
+  if (isUnknownRecord(previous) && previous.recovery_required === true) return { ...base, status: "recovery-required", check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, reason: "upstream history changed; reconcile explicitly before resuming automatic integration" };
+  const latest = loadVault(vault.root);
+  validateAuthority(latest);
+  if (git(vault.root, "symbolic-ref", "--short", "HEAD") !== localBranch || git(vault.root, "remote", "get-url", "--", remote) !== url || upstreamProblem(vault.root, remote, branch) || JSON.stringify(latest.contract.sync) !== JSON.stringify(currentVault.contract.sync)) {
+    return { ...base, status: "unavailable", reason: "checkout or inbound authority changed during observation; retry access on the intended branch", observed: previous };
+  }
+  const head = git(vault.root, "rev-parse", "HEAD");
+  const revision = isUnknownRecord(previous) && typeof previous.remote_revision === "string" ? previous.remote_revision : "";
+  if (!revision) return { ...base, status: "unverified", check: statusOnly ? "read-only" : "cached", observed: previous };
+  let status = "current";
+  if (head !== revision) {
+    if (ancestor(vault.root, revision, head)) status = "ahead";
+    else if (!ancestor(vault.root, head, revision)) status = "diverged";
+    else if (statusOnly || operationInProgress(vault.root) || git(vault.root, "status", "--porcelain", "--untracked-files=all")) status = "behind";
+    else {
+      try {
+        git(vault.root, "-c", `core.hooksPath=${os4.devNull}`, "merge", "--ff-only", "--no-overwrite-ignore", revision);
+        status = "integrated";
+      } catch {
+        status = "behind";
+      }
+      if (status === "integrated") validateAuthority(loadVault(vault.root));
+    }
+  }
+  const localRevision = git(vault.root, "rev-parse", "HEAD");
+  if (!statusOnly && isUnknownRecord(previous)) {
+    const updated = { ...previous, integration_status: status, local_revision: localRevision };
+    if (JSON.stringify(updated) !== JSON.stringify(previous)) atomicWriteText(file, `${JSON.stringify(updated)}
+`);
+    previous = updated;
+  }
+  return { ...base, status, check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, head: localRevision, state_file: file };
+}
+async function configureInbound(vault, remote, branch, apply) {
+  validateAuthority(vault);
+  if (!remote || remote.startsWith("-") || /[\s\0]/.test(remote)) throw new Error("a configured remote name is required");
+  const check = spawnSync2("git", ["-C", vault.root, "check-ref-format", `refs/heads/${branch}`], { encoding: "utf8" });
+  if (!branch || check.status !== 0) throw new Error("a valid remote branch is required");
+  const configured = spawnSync2("git", ["-C", vault.root, "remote", "get-url", "--", remote], { encoding: "utf8" });
+  if (configured.status !== 0) throw new Error("remote is not configured; configure it before enabling inbound access");
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const contract = { ...vault.contract, sync: { ...sync, inbound: { mode: "fast-forward", remote, branch } } };
+  const errors = validateContractData(contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new Error(errors.map((item) => item.message).join("; "));
+  const rendered = renderContract(contract, vault.body);
+  if (apply) {
+    const before = fs4.readFileSync(vault.contractPath, "utf8");
+    const locked = await withVaultLock(vault.root, async () => {
+      validateAuthority(loadVault(vault.root));
+      if (fs4.readFileSync(vault.contractPath, "utf8") !== before) throw new Error("contract changed while waiting; preview again");
+      atomicWriteText(vault.contractPath, rendered);
+    });
+    if (!locked.acquired) throw new Error("another writer owns the vault; preview again after it finishes");
+  }
+  return { schema_version: 1, root: vault.root, status: apply ? "configured" : "preview", contract: rendered };
+}
+
+// src/knowledge-loom/audit.ts
+import fs6 from "node:fs";
+import path6 from "node:path";
+
 // src/knowledge-loom/content-checks.ts
+import { spawn as spawn2 } from "node:child_process";
+import path5 from "node:path";
 var VALIDATION_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 var ALLOWED_SEVERITIES = /* @__PURE__ */ new Set(["error", "warning", "info"]);
 var STATUS_EXIT_CODES = { pass: 0, fail: 1, error: 2 };
@@ -8012,7 +8307,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
   if (typeof result.root !== "string") {
     return invalid("content checker output requires `root`");
   }
-  if (!path4.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
+  if (!path5.isAbsolute(result.root) || result.root !== canonicalPath(vaultRoot)) {
     return invalid("content checker root does not match the selected vault", "root");
   }
   if (!validValidationDate(result.validationDate)) {
@@ -8047,7 +8342,7 @@ function normalizedResult(adapterId, result, vaultRoot) {
 function killProcessTree(child) {
   if (!child.pid) return;
   if (process.platform === "win32") {
-    const killer = spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+    const killer = spawn2("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
       stdio: "ignore",
       windowsHide: true
     });
@@ -8073,7 +8368,7 @@ function executeAdapter(executable, arguments_, { cwd, timeoutMs }) {
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(executable, arguments_, {
+      child = spawn2(executable, arguments_, {
         cwd,
         shell: false,
         detached: process.platform !== "win32",
@@ -8200,7 +8495,7 @@ async function runDeclaredContentCheck(vault, {
 }
 
 // src/knowledge-loom/focus.ts
-import fs4 from "node:fs";
+import fs5 from "node:fs";
 var HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 function activeItems(text, sectionName) {
   let inSection = false;
@@ -8238,11 +8533,11 @@ function checkFocusView(root, name, view) {
   const relative = view.path;
   const focusPath = resolveVaultPath(root, relative);
   if (focusPath === null) return [finding("error", "focus.boundary", `focus view \`${name}\` resolves outside the vault`, relative)];
-  if (!fs4.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
+  if (!fs5.statSync(focusPath, { throwIfNoEntry: false })?.isFile()) {
     return [finding("error", "focus.missing", `focus view \`${name}\` file is missing`, relative)];
   }
   const section = view.active_section ?? "Top of mind";
-  const items = activeItems(fs4.readFileSync(focusPath, "utf8"), section);
+  const items = activeItems(fs5.readFileSync(focusPath, "utf8"), section);
   const maxTop = view.max_top;
   const maxActive = view.max_active;
   const findings = [];
@@ -8333,7 +8628,7 @@ function auditDeclaredFiles(root, values, {
     if (typeof relative !== "string" || !isVaultRelativePath(relative)) continue;
     const resolved = resolveVaultPath(root, relative);
     if (resolved === null) findings.push(finding("error", boundaryCode, boundaryMessage, relative));
-    else if (!fs5.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
+    else if (!fs6.statSync(resolved, { throwIfNoEntry: false })?.isFile()) findings.push(finding("error", missingCode, missingMessage, relative));
   }
   return findings;
 }
@@ -8347,25 +8642,25 @@ function patternPrefix(patternValue) {
 }
 function walk(root) {
   const result = [];
-  if (!fs5.existsSync(root)) return result;
+  if (!fs6.existsSync(root)) return result;
   const visit = (current) => {
-    for (const entry of fs5.readdirSync(current, { withFileTypes: true })) {
-      const candidate = path5.join(current, entry.name);
+    for (const entry of fs6.readdirSync(current, { withFileTypes: true })) {
+      const candidate = path6.join(current, entry.name);
       result.push(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) visit(candidate);
     }
   };
-  if (fs5.lstatSync(root).isDirectory() && !fs5.lstatSync(root).isSymbolicLink()) visit(root);
+  if (fs6.lstatSync(root).isDirectory() && !fs6.lstatSync(root).isSymbolicLink()) visit(root);
   else result.push(root);
   return result;
 }
 function globPaths(root, patternValue) {
   if (!/[*?[]/.test(patternValue)) {
-    const candidate = path5.join(root, ...patternValue.split("/"));
-    return fs5.existsSync(candidate) ? [candidate] : [];
+    const candidate = path6.join(root, ...patternValue.split("/"));
+    return fs6.existsSync(candidate) ? [candidate] : [];
   }
   const prefix = patternPrefix(patternValue);
-  const searchRoot = path5.join(root, ...prefix);
+  const searchRoot = path6.join(root, ...prefix);
   return walk(searchRoot).filter((candidate) => matchesPath(patternValue, toPosixRelative(root, candidate)));
 }
 async function auditVault(vault, { registryPath } = {}) {
@@ -8413,7 +8708,7 @@ async function auditVault(vault, { registryPath } = {}) {
           findings.push(finding("error", "path.metadata-boundary", `profile \`${profileName}\` matched a file outside the vault`, relative));
           continue;
         }
-        if (!fs5.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path5.extname(candidate).toLocaleLowerCase() !== ".md") continue;
+        if (!fs6.statSync(candidate, { throwIfNoEntry: false })?.isFile() || path6.extname(candidate).toLocaleLowerCase() !== ".md") continue;
         const key = `${profileName}\0${relative}`;
         if (checked.has(key)) continue;
         checked.add(key);
@@ -8468,8 +8763,8 @@ async function auditVault(vault, { registryPath } = {}) {
 }
 
 // src/knowledge-loom/initializer.ts
-import fs6 from "node:fs";
-import path6 from "node:path";
+import fs7 from "node:fs";
+import path7 from "node:path";
 var DEFAULT_BODY = `# Vault policy
 
 ## Purpose and boundary
@@ -8491,13 +8786,13 @@ Describe naming, linking, metadata, and archival conventions.
 `;
 function discoverInstructionRoots(root) {
   for (const candidate of ["AGENTS.md", "LLM_CONTEXT.md", "CLAUDE.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return [];
 }
 function discoverEntrypoints(root) {
   for (const candidate of ["INDEX.md", "Home.md", "README.md"]) {
-    if (fs6.statSync(path6.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
+    if (fs7.statSync(path7.join(root, candidate), { throwIfNoEntry: false })?.isFile()) return [candidate];
   }
   return ["INDEX.md"];
 }
@@ -8535,25 +8830,27 @@ function buildContract(root, {
 }
 function initializeVault(root, { contract, adopt, apply }) {
   const rootPath = canonicalPath(root);
-  const contractPath = path6.join(rootPath, CONTRACT_NAME);
-  if (fs6.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
-  if (fs6.existsSync(rootPath) && fs6.readdirSync(rootPath).length && !adopt) {
+  const contractPath = path7.join(rootPath, CONTRACT_NAME);
+  if (fs7.existsSync(contractPath)) throw new Error(`${contractPath} already exists`);
+  if (fs7.existsSync(rootPath) && fs7.readdirSync(rootPath).length && !adopt) {
     throw new Error("target is not empty; use adoption mode for an existing vault");
   }
   const rendered = renderContract(contract, DEFAULT_BODY);
   if (apply) {
-    fs6.mkdirSync(rootPath, { recursive: true });
-    fs6.writeFileSync(contractPath, rendered, "utf8");
-    const indexPath = path6.join(rootPath, "INDEX.md");
-    if (!adopt && !fs6.existsSync(indexPath)) fs6.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
+    fs7.mkdirSync(rootPath, { recursive: true });
+    fs7.writeFileSync(contractPath, rendered, "utf8");
+    const indexPath = path7.join(rootPath, "INDEX.md");
+    if (!adopt && !fs7.existsSync(indexPath)) fs7.writeFileSync(indexPath, "# Index\n\n- Add vault entrypoints here.\n", "utf8");
   }
   return [contractPath, rendered];
 }
 
 // src/knowledge-loom/cli.ts
-var HELP = `usage: knowledge-loom {audit,probe,resolve,register,associate,init} ...
+var HELP = `usage: knowledge-loom {access,with-vault-lock,audit,probe,resolve,register,associate,init} ...
 
 commands:
+  access      prepare a vault for retrieval with an authorized daily refresh
+  with-vault-lock  run a cooperative writer under the shared mutation lock
   audit       run a read-only vault audit
   probe       resolve only an ancestor or project-associated vault
   resolve     resolve one vault deterministically
@@ -8562,6 +8859,8 @@ commands:
   init        preview or initialize a vault contract
 `;
 var COMMAND_HELP = {
+  "with-vault-lock": "usage: knowledge-loom with-vault-lock [selector] [--registry PATH] -- executable [arguments ...]\n",
+  access: "usage: knowledge-loom access [selector] [--registry PATH] [--state-dir PATH] [--json] [--status] [--enable-inbound --remote NAME --branch NAME [--apply]]\n",
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   probe: "usage: knowledge-loom probe [--registry PATH]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
@@ -8573,6 +8872,10 @@ function isCommand(value) {
   return Object.hasOwn(COMMAND_HELP, value);
 }
 function parseArguments(arguments_) {
+  if (arguments_[0] === "with-vault-lock" && arguments_.includes("--")) {
+    const separator = arguments_.indexOf("--");
+    return { ...parseArguments(arguments_.slice(0, separator)), executable: arguments_.slice(separator + 1) };
+  }
   if (!arguments_.length) throw new Error(HELP.trim());
   const first = arguments_[0];
   if (arguments_.includes("-h") || first === "--help") {
@@ -8584,14 +8887,15 @@ function parseArguments(arguments_) {
     };
   }
   if (!isCommand(first)) throw new Error(`unknown command: ${first}`);
-  const command = first;
+  const command2 = first;
   if (arguments_.slice(1).includes("--help") || arguments_.slice(1).includes("-h")) {
-    return { help: true, command, positional: [], subject: [] };
+    return { help: true, command: command2, positional: [], subject: [] };
   }
-  const options = { help: false, command, positional: [], subject: [] };
-  const flags = new Set(command === "audit" ? ["--json"] : command === "init" ? ["--adopt", "--apply"] : command === "register" ? ["--apply"] : command === "associate" ? ["--replace", "--apply"] : []);
+  const options = { help: false, command: command2, positional: [], subject: [] };
+  const flags = new Set(command2 === "access" ? ["--json", "--enable-inbound", "--apply", "--status"] : command2 === "audit" ? ["--json"] : command2 === "init" ? ["--adopt", "--apply"] : command2 === "register" ? ["--apply"] : command2 === "associate" ? ["--replace", "--apply"] : []);
   const valueOptions = /* @__PURE__ */ new Set(["--registry"]);
-  if (command === "init") {
+  if (command2 === "access") for (const name of ["--state-dir", "--remote", "--branch"]) valueOptions.add(name);
+  if (command2 === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
   }
   for (let index = 1; index < arguments_.length; index += 1) {
@@ -8599,6 +8903,8 @@ function parseArguments(arguments_) {
     if (token === void 0) continue;
     if (flags.has(token)) {
       if (token === "--json") options.json = true;
+      else if (token === "--enable-inbound") options.enable_inbound = true;
+      else if (token === "--status") options.status = true;
       else if (token === "--adopt") options.adopt = true;
       else if (token === "--apply") options.apply = true;
       else if (token === "--replace") options.replace = true;
@@ -8611,6 +8917,9 @@ function parseArguments(arguments_) {
       if (value === void 0 || value.startsWith("--")) throw new Error(`${name} requires a value`);
       const key = name.slice(2).replaceAll("-", "_");
       if (key === "subject") options.subject.push(value);
+      else if (key === "state_dir") options.state_dir = value;
+      else if (key === "remote") options.remote = value;
+      else if (key === "branch") options.branch = value;
       else if (key === "registry") options.registry = value;
       else if (key === "vault_id") options.vault_id = value;
       else if (key === "title") options.title = value;
@@ -8634,11 +8943,35 @@ function formatFindings(findings, { json = false } = {}) {
 function requirePositionals(options, count, usage) {
   if (options.positional.length !== count) throw new Error(usage.trim());
 }
-async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr } = {}) {
+async function runCli(arguments_ = process.argv.slice(2), { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr, now = Date.now } = {}) {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
       stdout.write(options.command ? COMMAND_HELP[options.command] : HELP);
+      return 0;
+    }
+    if (options.command === "with-vault-lock") {
+      if (options.positional.length > 1 || !options.executable?.length) throw new Error(COMMAND_HELP["with-vault-lock"].trim());
+      const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
+      const [executable, ...args] = options.executable;
+      const locked = await withVaultLock(vault.root, (trackWriter) => runLockedProcess(vault.root, executable, args, trackWriter, { stdout, stderr }));
+      if (!locked.acquired) {
+        stderr.write("BUSY another task owns the vault mutation lock\n");
+        return 1;
+      }
+      return locked.value;
+    }
+    if (options.command === "access") {
+      if (options.positional.length > 1) throw new Error(COMMAND_HELP.access.trim());
+      const context = { cwd, registryPath: options.registry };
+      const vault = options.positional[0] ? resolveVault(options.positional[0], context) : resolveApplicableVault(context);
+      if (!options.enable_inbound && (options.apply || options.remote || options.branch)) throw new Error("--apply, --remote and --branch require --enable-inbound");
+      if (options.enable_inbound && options.status) throw new Error("--status cannot enable inbound access");
+      if (options.enable_inbound && (!vault || !options.remote || !options.branch)) throw new Error("enabling inbound requires a vault, --remote and --branch");
+      const result = options.enable_inbound && vault ? await configureInbound(vault, options.remote, options.branch, options.apply === true) : vault ? await accessVault(vault, { stateDir: options.state_dir, now, statusOnly: options.status === true }) : { schema_version: 1, root: null, status: "not-applicable" };
+      stdout.write(options.json ? `${JSON.stringify(result)}
+` : `${result.status}${result.root ? ` ${result.root}` : ""}
+`);
       return 0;
     }
     if (options.command === "audit") {
@@ -8699,7 +9032,7 @@ ${rendered2}`);
     if (!isWritePolicy(writePolicy)) throw new Error(`unsupported write policy: ${writePolicy}`);
     if (!isCurrentStatePolicy(currentStatePolicy)) throw new Error(`unsupported current-state policy: ${currentStatePolicy}`);
     if (!isHistoryType(historyType)) throw new Error(`unsupported history type: ${historyType}`);
-    const root = path7.resolve(expandHome(options.positional[0]));
+    const root = path8.resolve(expandHome(options.positional[0]));
     const contract = buildContract(root, {
       vaultId: options.vault_id,
       title: options.title,

--- a/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
+++ b/skills/use-knowledge-vault/scripts/knowledge-loom.mjs
@@ -7982,6 +7982,16 @@ async function withVaultLock(root, work, waitMs = 2e3) {
   } while (true);
   return { acquired: false };
 }
+var LOCKED_COMMAND_GATE = `
+const { spawn } = require("node:child_process");
+process.stdin.once("data", () => {
+  process.stdin.destroy();
+  const child = spawn(process.argv[1], process.argv.slice(2), { stdio: ["ignore", "inherit", "inherit"] });
+  child.once("error", () => process.exit(1));
+  child.once("exit", (code) => process.exit(code ?? 1));
+});
+process.stdin.once("end", () => process.exit(1));
+`;
 function runLockedProcess(root, executable, args, trackWriter, {
   stdout,
   stderr,
@@ -7990,7 +8000,7 @@ function runLockedProcess(root, executable, args, trackWriter, {
 } = {}) {
   return new Promise((resolve, reject) => {
     const group = process.platform !== "win32";
-    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(process.execPath, ["-e", LOCKED_COMMAND_GATE, "--", executable, ...args], { cwd: root, env, detached: group, stdio: ["pipe", "pipe", "pipe"] });
     let failure;
     let timer;
     const stop = () => {
@@ -8009,8 +8019,15 @@ function runLockedProcess(root, executable, args, trackWriter, {
       if (failure) reject(failure);
       else resolve(code ?? 1);
     });
+    child.stdin.on("error", (error) => {
+      failure = error;
+      stop();
+    });
     try {
-      if (child.pid) trackWriter(child.pid, group);
+      if (child.pid) {
+        trackWriter(child.pid, group);
+        child.stdin.end("start");
+      }
     } catch (error) {
       failure = error;
       stop();

--- a/src/knowledge-loom/access.ts
+++ b/src/knowledge-loom/access.ts
@@ -1,0 +1,197 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { ContractError, isUnknownRecord, loadVault, renderContract, validateContractData } from "./contract.js";
+import { canonicalPath, isWithin, resolveVaultPath, resolveVaultPatternPrefix } from "./pathing.js";
+import { atomicWriteText } from "./registry.js";
+import { runLockedProcess, withVaultLock } from "./vault-lock.js";
+import type { LoadedVault } from "./types.js";
+
+const DAY = 86_400_000;
+const RETRY = 300_000;
+
+function ancestor(root: string, older: string, newer: string): boolean {
+  const result = spawnSync("git", ["-C", root, "merge-base", "--is-ancestor", older, newer], { timeout: 10_000 });
+  if (result.status !== 0 && result.status !== 1) throw new Error("could not compare Git history");
+  return result.status === 0;
+}
+
+function git(root: string, ...args: string[]): string {
+  const result = spawnSync("git", ["-C", root, ...args], { encoding: "utf8", timeout: 10_000 });
+  if (result.status !== 0) throw new Error(`Git ${args[0]} failed`);
+  return result.stdout.trim();
+}
+
+function validateAuthority(vault: LoadedVault): void {
+  const errors = validateContractData(vault.contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new ContractError(`invalid contract: ${errors.map((item) => item.message).join("; ")}`);
+  const contract = vault.contract;
+  const navigation = isUnknownRecord(contract.navigation) ? contract.navigation : {};
+  const files = [contract.instruction_roots, navigation.entrypoints].flatMap((value) => Array.isArray(value) ? value : []);
+  const views = isUnknownRecord(contract.focus_views) ? contract.focus_views : {};
+  for (const view of Object.values(views)) if (isUnknownRecord(view)) files.push(view.path);
+  for (const relative of files) {
+    const resolved = resolveVaultPath(vault.root, relative);
+    if (!resolved || !fs.statSync(resolved, { throwIfNoEntry: false })?.isFile()) throw new ContractError("contract file is missing or crosses the vault boundary");
+  }
+  const profiles = isUnknownRecord(contract.metadata_profiles) ? contract.metadata_profiles : {};
+  const privacy = isUnknownRecord(contract.privacy) ? contract.privacy : {};
+  const patterns: unknown[] = Array.isArray(privacy.never_track) ? [...privacy.never_track] : [];
+  for (const profile of Object.values(profiles)) if (isUnknownRecord(profile) && Array.isArray(profile.paths)) patterns.push(...profile.paths);
+  for (const pattern of patterns) if (!resolveVaultPatternPrefix(vault.root, pattern)) throw new ContractError("contract pattern crosses the vault boundary");
+}
+
+function upstreamProblem(root: string, remote: string, branch: string): string | null {
+  try {
+    if (canonicalPath(git(root, "rev-parse", "--show-toplevel")) !== root) return "automatic access requires a vault at its Git checkout root";
+    git(root, "check-ref-format", `refs/heads/${branch}`);
+    const local = git(root, "symbolic-ref", "--quiet", "--short", "HEAD");
+    if (git(root, "config", "--get", `branch.${local}.remote`) !== remote
+      || git(root, "config", "--get", `branch.${local}.merge`) !== `refs/heads/${branch}`) return "current branch upstream differs from authorized inbound remote/branch";
+    git(root, "remote", "get-url", "--", remote);
+    git(root, "rev-parse", "--verify", "HEAD");
+    return null;
+  } catch { return "Git repository, remote, branch or upstream is unavailable; configure the authorized upstream before retrying"; }
+}
+
+function operationInProgress(root: string): boolean {
+  return ["MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "rebase-merge", "rebase-apply", "sequencer", "index.lock"].some((name) =>
+    fs.existsSync(path.resolve(root, git(root, "rev-parse", "--git-path", name))));
+}
+
+export async function accessVault(vault: LoadedVault, { stateDir, now = Date.now, statusOnly = false }: { stateDir?: string | undefined; now?: () => number; statusOnly?: boolean } = {}) {
+  validateAuthority(vault);
+  const base = { schema_version: 1, root: vault.root };
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const inbound = isUnknownRecord(sync.inbound) ? sync.inbound : {};
+  if (inbound.mode !== "fast-forward") return { ...base, status: "not-enabled" };
+  if (typeof inbound.remote !== "string" || typeof inbound.branch !== "string") throw new Error("inbound requires remote and branch");
+  const { remote, branch } = inbound;
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  try {
+    if (statusOnly) return await refresh(vault, remote, branch, stateDir, now, true);
+    const locked = await withVaultLock(vault.root, (trackWriter) => refresh(vault, remote, branch, stateDir, now, false, trackWriter));
+    return locked.acquired ? locked.value : { ...base, status: "busy", reason: "another task owns the vault mutation lock; local work is preserved" };
+  } catch (error) {
+    if (error instanceof ContractError) throw error;
+    return { ...base, status: "unavailable", reason: "access could not complete; inspect repository and observation-state permissions before retrying" };
+  }
+}
+
+async function refresh(vault: LoadedVault, remote: string, branch: string, stateDir: string | undefined, now: () => number, statusOnly: boolean, trackWriter?: (pid: number, group?: boolean) => void) {
+  const base = { schema_version: 1, root: vault.root };
+  const currentVault = loadVault(vault.root);
+  validateAuthority(currentVault);
+  if (JSON.stringify(currentVault.contract.sync) !== JSON.stringify(vault.contract.sync)) return { ...base, status: "unavailable", reason: "inbound authority changed while waiting; reread the contract before retrying" };
+  const problem = upstreamProblem(vault.root, remote, branch);
+  if (problem) return { ...base, status: "unavailable", reason: problem };
+  const url = git(vault.root, "remote", "get-url", "--", remote);
+  const localBranch = git(vault.root, "symbolic-ref", "--short", "HEAD");
+  const key = createHash("sha256").update(JSON.stringify([vault.root, localBranch, remote, url, branch])).digest("hex");
+  const directory = canonicalPath(stateDir ?? path.join(os.homedir(), ".local", "state", "knowledge-loom"));
+  const common = canonicalPath(git(vault.root, "rev-parse", "--path-format=absolute", "--git-common-dir"));
+  if (isWithin(vault.root, directory) || isWithin(common, directory)) throw new ContractError("operational state must stay outside the vault and its Git directory");
+  const file = path.join(directory, `${key}.json`);
+  const ref = `refs/knowledge-loom/observations/${key}`;
+  let previous: unknown = null;
+  try {
+    const stat = fs.lstatSync(file, { throwIfNoEntry: false });
+    if (stat && (!stat.isFile() || stat.size > 16_384)) throw new Error("invalid observation file");
+    if (stat) {
+      previous = JSON.parse(fs.readFileSync(file, "utf8"));
+      if (!isUnknownRecord(previous) || previous.schema_version !== 1) throw new Error("invalid observation format");
+      for (const field of ["checked_at", "attempted_at", "retry_at"]) {
+        const value = previous[field];
+        if (value !== undefined && (typeof value !== "number" || !Number.isFinite(value) || value < 0)) throw new Error("invalid observation time");
+      }
+      if (previous.remote_revision !== undefined && (typeof previous.remote_revision !== "string" || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(previous.remote_revision))) throw new Error("invalid observation revision");
+    }
+  } catch {
+    return { ...base, status: "unavailable", reason: "observation file is unreadable or invalid; preserve it for inspection and retry with a repaired state directory", state_file: file };
+  }
+  const observed = isUnknownRecord(previous) ? previous : {};
+  const time = now();
+  if (statusOnly && typeof observed.retry_at === "number") return { ...base, status: "unavailable", check: "read-only", observed };
+  if (statusOnly && typeof observed.remote_revision !== "string") return { ...base, status: "unverified", check: "read-only", observed };
+  if (typeof observed.retry_at === "number" && time < observed.retry_at && typeof observed.attempted_at === "number" && time >= observed.attempted_at) {
+    return { ...base, status: "unavailable", check: statusOnly ? "read-only" : "backoff", observed };
+  }
+  const cached = typeof observed.checked_at === "number" && time >= observed.checked_at && time - observed.checked_at < DAY;
+  if (!cached && !statusOnly) {
+    try {
+      if (!trackWriter) throw new Error("remote observation requires a mutation lock");
+      const code = await runLockedProcess(vault.root, "git", ["fetch", "--no-tags", "--no-recurse-submodules", "--no-write-fetch-head", "--refmap=", "--", remote, `+refs/heads/${branch}:${ref}`], trackWriter, {
+        timeoutMs: 30_000, env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      });
+      if (code !== 0) throw new Error("remote fetch failed");
+    } catch {
+      previous = { ...observed, schema_version: 1, attempted_at: time, retry_at: time + RETRY };
+      atomicWriteText(file, `${JSON.stringify(previous)}\n`);
+      return { ...base, status: "unavailable", check: "failed", observed: previous, reason: "remote fetch failed; local work remains available" };
+    }
+    const revision = git(vault.root, "rev-parse", "--verify", ref);
+    const rewritten = typeof observed.remote_revision === "string" && !ancestor(vault.root, observed.remote_revision, revision);
+    previous = { schema_version: 1, attempted_at: time, checked_at: now(), remote_revision: revision, recovery_required: observed.recovery_required === true || rewritten };
+    atomicWriteText(file, `${JSON.stringify(previous)}\n`);
+  }
+  if (isUnknownRecord(previous) && previous.recovery_required === true) return { ...base, status: "recovery-required", check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, reason: "upstream history changed; reconcile explicitly before resuming automatic integration" };
+  const latest = loadVault(vault.root);
+  validateAuthority(latest);
+  if (git(vault.root, "symbolic-ref", "--short", "HEAD") !== localBranch
+    || git(vault.root, "remote", "get-url", "--", remote) !== url
+    || upstreamProblem(vault.root, remote, branch)
+    || JSON.stringify(latest.contract.sync) !== JSON.stringify(currentVault.contract.sync)) {
+    return { ...base, status: "unavailable", reason: "checkout or inbound authority changed during observation; retry access on the intended branch", observed: previous };
+  }
+  const head = git(vault.root, "rev-parse", "HEAD");
+  const revision = isUnknownRecord(previous) && typeof previous.remote_revision === "string" ? previous.remote_revision : "";
+  if (!revision) return { ...base, status: "unverified", check: statusOnly ? "read-only" : "cached", observed: previous };
+  let status = "current";
+  if (head !== revision) {
+    if (ancestor(vault.root, revision, head)) status = "ahead";
+    else if (!ancestor(vault.root, head, revision)) status = "diverged";
+    else if (statusOnly || operationInProgress(vault.root) || git(vault.root, "status", "--porcelain", "--untracked-files=all")) status = "behind";
+    else {
+      try {
+        git(vault.root, "-c", `core.hooksPath=${os.devNull}`, "merge", "--ff-only", "--no-overwrite-ignore", revision);
+        status = "integrated";
+      } catch { status = "behind"; }
+      if (status === "integrated") validateAuthority(loadVault(vault.root));
+    }
+  }
+  const localRevision = git(vault.root, "rev-parse", "HEAD");
+  if (!statusOnly && isUnknownRecord(previous)) {
+    const updated = { ...previous, integration_status: status, local_revision: localRevision };
+    if (JSON.stringify(updated) !== JSON.stringify(previous)) atomicWriteText(file, `${JSON.stringify(updated)}\n`);
+    previous = updated;
+  }
+  return { ...base, status, check: statusOnly ? "read-only" : cached ? "cached" : "performed", observed: previous, head: localRevision, state_file: file };
+}
+
+export async function configureInbound(vault: LoadedVault, remote: string, branch: string, apply: boolean) {
+  validateAuthority(vault);
+  if (!remote || remote.startsWith("-") || /[\s\0]/.test(remote)) throw new Error("a configured remote name is required");
+  const check = spawnSync("git", ["-C", vault.root, "check-ref-format", `refs/heads/${branch}`], { encoding: "utf8" });
+  if (!branch || check.status !== 0) throw new Error("a valid remote branch is required");
+  const configured = spawnSync("git", ["-C", vault.root, "remote", "get-url", "--", remote], { encoding: "utf8" });
+  if (configured.status !== 0) throw new Error("remote is not configured; configure it before enabling inbound access");
+  const sync = isUnknownRecord(vault.contract.sync) ? vault.contract.sync : {};
+  const contract = { ...vault.contract, sync: { ...sync, inbound: { mode: "fast-forward", remote, branch } } };
+  const errors = validateContractData(contract).filter((item) => item.severity === "error");
+  if (errors.length) throw new Error(errors.map((item) => item.message).join("; "));
+  const rendered = renderContract(contract, vault.body);
+  if (apply) {
+    const before = fs.readFileSync(vault.contractPath, "utf8");
+    const locked = await withVaultLock(vault.root, async () => {
+      validateAuthority(loadVault(vault.root));
+      if (fs.readFileSync(vault.contractPath, "utf8") !== before) throw new Error("contract changed while waiting; preview again");
+      atomicWriteText(vault.contractPath, rendered);
+    });
+    if (!locked.acquired) throw new Error("another writer owns the vault; preview again after it finishes");
+  }
+  return { schema_version: 1, root: vault.root, status: apply ? "configured" : "preview", contract: rendered };
+}

--- a/src/knowledge-loom/cli.ts
+++ b/src/knowledge-loom/cli.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
 
+import { accessVault, configureInbound } from "./access.js";
+import { runLockedProcess, withVaultLock } from "./vault-lock.js";
+
 import { auditVault } from "./audit.js";
 import { validateContractData } from "./contract.js";
 import { buildContract, initializeVault } from "./initializer.js";
@@ -9,9 +12,11 @@ import { errorMessage } from "./errors.js";
 import { isCurrentStatePolicy, isHistoryType, isWritePolicy } from "./types.js";
 import type { CliIo, Finding } from "./types.js";
 
-const HELP = `usage: knowledge-loom {audit,probe,resolve,register,associate,init} ...
+const HELP = `usage: knowledge-loom {access,with-vault-lock,audit,probe,resolve,register,associate,init} ...
 
 commands:
+  access      prepare a vault for retrieval with an authorized daily refresh
+  with-vault-lock  run a cooperative writer under the shared mutation lock
   audit       run a read-only vault audit
   probe       resolve only an ancestor or project-associated vault
   resolve     resolve one vault deterministically
@@ -21,6 +26,8 @@ commands:
 `;
 
 const COMMAND_HELP = {
+  "with-vault-lock": "usage: knowledge-loom with-vault-lock [selector] [--registry PATH] -- executable [arguments ...]\n",
+  access: "usage: knowledge-loom access [selector] [--registry PATH] [--state-dir PATH] [--json] [--status] [--enable-inbound --remote NAME --branch NAME [--apply]]\n",
   audit: "usage: knowledge-loom audit [selector] [--registry PATH] [--json]\n",
   probe: "usage: knowledge-loom probe [--registry PATH]\n",
   resolve: "usage: knowledge-loom resolve [selector] [--registry PATH]\n",
@@ -41,6 +48,12 @@ interface ParsedOptions {
   adopt?: boolean;
   apply?: boolean;
   replace?: boolean;
+  state_dir?: string;
+  enable_inbound?: boolean;
+  remote?: string;
+  branch?: string;
+  status?: boolean;
+  executable?: string[];
   vault_id?: string;
   title?: string;
   write_policy?: string;
@@ -53,6 +66,10 @@ function isCommand(value: string): value is Command {
 }
 
 function parseArguments(arguments_: string[]): ParsedOptions {
+  if (arguments_[0] === "with-vault-lock" && arguments_.includes("--")) {
+    const separator = arguments_.indexOf("--");
+    return { ...parseArguments(arguments_.slice(0, separator)), executable: arguments_.slice(separator + 1) };
+  }
   if (!arguments_.length) throw new Error(HELP.trim());
   const first = arguments_[0]!;
   if (arguments_.includes("-h") || first === "--help") {
@@ -70,7 +87,9 @@ function parseArguments(arguments_: string[]): ParsedOptions {
   }
 
   const options: ParsedOptions = { help: false, command, positional: [], subject: [] };
-  const flags = new Set(command === "audit"
+  const flags = new Set(command === "access"
+    ? ["--json", "--enable-inbound", "--apply", "--status"]
+    : command === "audit"
     ? ["--json"]
     : command === "init"
       ? ["--adopt", "--apply"]
@@ -80,6 +99,7 @@ function parseArguments(arguments_: string[]): ParsedOptions {
           ? ["--replace", "--apply"]
           : []);
   const valueOptions = new Set(["--registry"]);
+  if (command === "access") for (const name of ["--state-dir", "--remote", "--branch"]) valueOptions.add(name);
   if (command === "init") {
     for (const name of ["--vault-id", "--title", "--subject", "--write-policy", "--current-state-policy", "--history"]) valueOptions.add(name);
   }
@@ -88,6 +108,8 @@ function parseArguments(arguments_: string[]): ParsedOptions {
     if (token === undefined) continue;
     if (flags.has(token)) {
       if (token === "--json") options.json = true;
+      else if (token === "--enable-inbound") options.enable_inbound = true;
+      else if (token === "--status") options.status = true;
       else if (token === "--adopt") options.adopt = true;
       else if (token === "--apply") options.apply = true;
       else if (token === "--replace") options.replace = true;
@@ -100,6 +122,9 @@ function parseArguments(arguments_: string[]): ParsedOptions {
       if (value === undefined || value.startsWith("--")) throw new Error(`${name} requires a value`);
       const key = name.slice(2).replaceAll("-", "_");
       if (key === "subject") options.subject.push(value);
+      else if (key === "state_dir") options.state_dir = value;
+      else if (key === "remote") options.remote = value;
+      else if (key === "branch") options.branch = value;
       else if (key === "registry") options.registry = value;
       else if (key === "vault_id") options.vault_id = value;
       else if (key === "title") options.title = value;
@@ -126,12 +151,36 @@ function requirePositionals(options: ParsedOptions, count: number, usage: string
 
 export async function runCli(
   arguments_: string[] = process.argv.slice(2),
-  { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr }: CliIo = {},
+  { cwd = process.cwd(), stdout = process.stdout, stderr = process.stderr, now = Date.now }: CliIo = {},
 ): Promise<number> {
   try {
     const options = parseArguments(arguments_);
     if (options.help) {
       stdout.write(options.command ? COMMAND_HELP[options.command] : HELP);
+      return 0;
+    }
+
+    if (options.command === "with-vault-lock") {
+      if (options.positional.length > 1 || !options.executable?.length) throw new Error(COMMAND_HELP["with-vault-lock"].trim());
+      const vault = resolveVault(options.positional[0] ?? null, { cwd, registryPath: options.registry });
+      const [executable, ...args] = options.executable;
+      const locked = await withVaultLock(vault.root, (trackWriter) => runLockedProcess(vault.root, executable!, args, trackWriter, { stdout, stderr }));
+      if (!locked.acquired) { stderr.write("BUSY another task owns the vault mutation lock\n"); return 1; }
+      return locked.value;
+    }
+
+    if (options.command === "access") {
+      if (options.positional.length > 1) throw new Error(COMMAND_HELP.access.trim());
+      const context = { cwd, registryPath: options.registry };
+      const vault = options.positional[0] ? resolveVault(options.positional[0], context) : resolveApplicableVault(context);
+      if (!options.enable_inbound && (options.apply || options.remote || options.branch)) throw new Error("--apply, --remote and --branch require --enable-inbound");
+      if (options.enable_inbound && options.status) throw new Error("--status cannot enable inbound access");
+      if (options.enable_inbound && (!vault || !options.remote || !options.branch)) throw new Error("enabling inbound requires a vault, --remote and --branch");
+      const result = options.enable_inbound && vault
+        ? await configureInbound(vault, options.remote!, options.branch!, options.apply === true)
+        : vault ? await accessVault(vault, { stateDir: options.state_dir, now, statusOnly: options.status === true })
+          : { schema_version: 1, root: null, status: "not-applicable" };
+      stdout.write(options.json ? `${JSON.stringify(result)}\n` : `${result.status}${result.root ? ` ${result.root}` : ""}\n`);
       return 0;
     }
 

--- a/src/knowledge-loom/contract.ts
+++ b/src/knowledge-loom/contract.ts
@@ -160,6 +160,15 @@ export function validateContractData(contract: unknown): Finding[] {
   if (sync.mode === "lifecycle-hook" && !sync.adapter) {
     findings.push(finding("error", "contract.sync-adapter", "lifecycle sync requires `adapter`"));
   }
+  if (sync.inbound !== undefined) {
+    const inbound = sync.inbound;
+    if (!isUnknownRecord(inbound) || inbound.mode !== "fast-forward"
+      || typeof inbound.remote !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(inbound.remote)
+      || typeof inbound.branch !== "string" || !inbound.branch || /[\s\0]/.test(inbound.branch)) {
+      findings.push(finding("error", "contract.inbound", "`sync.inbound` requires fast-forward mode, a remote name and a branch"));
+    }
+    if (history.type !== "git") findings.push(finding("error", "contract.inbound-history", "inbound access requires Git history"));
+  }
 
   const backup = mapping(contract, "backup", findings);
   if (Object.keys(backup).length && backup.mode !== "none" && backup.mode !== "lifecycle-hook") {

--- a/src/knowledge-loom/types.ts
+++ b/src/knowledge-loom/types.ts
@@ -100,6 +100,7 @@ export interface TextWriter {
 }
 
 export interface CliIo {
+  now?: (() => number) | undefined;
   cwd?: string | undefined;
   stdout?: TextWriter | undefined;
   stderr?: TextWriter | undefined;

--- a/src/knowledge-loom/vault-lock.ts
+++ b/src/knowledge-loom/vault-lock.ts
@@ -1,0 +1,94 @@
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import os from "node:os";
+import { setTimeout } from "node:timers/promises";
+
+import { isUnknownRecord } from "./contract.js";
+import type { TextWriter } from "./types.js";
+
+const LOCK_REF = "refs/knowledge-loom/mutation-lock";
+
+function command(root: string, args: string[], input?: string) {
+  return spawnSync("git", ["-C", root, ...args], { encoding: "utf8", input, timeout: 10_000 });
+}
+
+function deadOwner(root: string, revision: string): boolean {
+  try {
+    const result = command(root, ["cat-file", "blob", revision]);
+    const owner: unknown = JSON.parse(result.stdout);
+    if (!isUnknownRecord(owner) || owner.host !== os.hostname() || typeof owner.pid !== "number" || !Number.isInteger(owner.pid) || owner.pid < 1) return false;
+    const pids = [owner.pid];
+    if (owner.writer_pid !== undefined) {
+      if (typeof owner.writer_pid !== "number" || !Number.isInteger(owner.writer_pid) || owner.writer_pid < 1) return false;
+      pids.push(owner.writer_group === true ? -owner.writer_pid : owner.writer_pid);
+    }
+    return pids.every((pid) => {
+      try { process.kill(pid, 0); return false; } catch (error) { return isUnknownRecord(error) && error.code === "ESRCH"; }
+    });
+  } catch { /* An unrecognized owner is preserved for explicit recovery. */ }
+  return false;
+}
+
+/** Git's compare-and-swap reference update serializes all cooperating worktrees.
+ * Dead-owner recovery and release compare the exact owner object, so neither
+ * can accidentally remove a successor's lock. Live owners never expire by age.
+ */
+type TrackWriter = (pid: number, group?: boolean) => void;
+
+export async function withVaultLock<T>(root: string, work: (trackWriter: TrackWriter) => Promise<T>, waitMs = 2_000): Promise<{ acquired: true; value: T } | { acquired: false }> {
+  const owner = { schema_version: 1, host: os.hostname(), pid: process.pid, token: randomUUID() };
+  const hashed = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify(owner));
+  if (hashed.status !== 0) throw new Error("cannot create vault mutation lock");
+  let revision = hashed.stdout.trim();
+  const deadline = performance.now() + waitMs;
+  do {
+    const existing = command(root, ["rev-parse", "--verify", "--quiet", LOCK_REF]);
+    const current = existing.status === 0 ? existing.stdout.trim() : "0".repeat(revision.length);
+    if (existing.status !== 0 || deadOwner(root, current)) {
+      const acquired = command(root, ["-c", `core.hooksPath=${os.devNull}`, "update-ref", LOCK_REF, revision, current]);
+      if (acquired.status === 0) {
+        try {
+          return { acquired: true, value: await work((pid, group = false) => {
+            const updated = command(root, ["hash-object", "-w", "--stdin"], JSON.stringify({ ...owner, writer_pid: pid, writer_group: group }));
+            const next = updated.stdout.trim();
+            if (updated.status !== 0 || command(root, ["-c", `core.hooksPath=${os.devNull}`, "update-ref", LOCK_REF, next, revision]).status !== 0) throw new Error("cannot track the active writer");
+            revision = next;
+          }) };
+        }
+        finally {
+          const released = command(root, ["-c", `core.hooksPath=${os.devNull}`, "update-ref", "-d", LOCK_REF, revision]);
+          if (released.status !== 0) throw new Error("vault mutation lock release failed; inspect lock ownership before retrying");
+        }
+      }
+    }
+    if (performance.now() >= deadline) break;
+    await setTimeout(25);
+  } while (true);
+  return { acquired: false };
+}
+
+/** Keep child lifetime inside ownership, including failed PID registration. */
+export function runLockedProcess(root: string, executable: string, args: string[], trackWriter: TrackWriter, {
+  stdout, stderr, timeoutMs, env = process.env,
+}: { stdout?: TextWriter; stderr?: TextWriter; timeoutMs?: number; env?: NodeJS.ProcessEnv } = {}): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const group = process.platform !== "win32";
+    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    let failure: unknown;
+    let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+    const stop = () => {
+      try { if (child.pid) process.kill(group ? -child.pid : child.pid, "SIGKILL"); } catch { /* Already exited. */ }
+    };
+    child.stdout.on("data", (data: Buffer) => stdout?.write(data.toString()));
+    child.stderr.on("data", (data: Buffer) => stderr?.write(data.toString()));
+    child.on("error", (error) => { failure = error; });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (failure) reject(failure);
+      else resolve(code ?? 1);
+    });
+    try { if (child.pid) trackWriter(child.pid, group); }
+    catch (error) { failure = error; stop(); }
+    if (timeoutMs !== undefined) timer = globalThis.setTimeout(() => { failure = new Error("locked command timed out"); stop(); }, timeoutMs);
+  });
+}

--- a/src/knowledge-loom/vault-lock.ts
+++ b/src/knowledge-loom/vault-lock.ts
@@ -67,13 +67,26 @@ export async function withVaultLock<T>(root: string, work: (trackWriter: TrackWr
   return { acquired: false };
 }
 
+// The child cannot start the command until its process group is recorded in the lock.
+// EOF before authorization (including parent termination) exits without spawning work.
+const LOCKED_COMMAND_GATE = `
+const { spawn } = require("node:child_process");
+process.stdin.once("data", () => {
+  process.stdin.destroy();
+  const child = spawn(process.argv[1], process.argv.slice(2), { stdio: ["ignore", "inherit", "inherit"] });
+  child.once("error", () => process.exit(1));
+  child.once("exit", (code) => process.exit(code ?? 1));
+});
+process.stdin.once("end", () => process.exit(1));
+`;
+
 /** Keep child lifetime inside ownership, including failed PID registration. */
 export function runLockedProcess(root: string, executable: string, args: string[], trackWriter: TrackWriter, {
   stdout, stderr, timeoutMs, env = process.env,
 }: { stdout?: TextWriter; stderr?: TextWriter; timeoutMs?: number; env?: NodeJS.ProcessEnv } = {}): Promise<number> {
   return new Promise((resolve, reject) => {
     const group = process.platform !== "win32";
-    const child = spawn(executable, args, { cwd: root, env, detached: group, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(process.execPath, ["-e", LOCKED_COMMAND_GATE, "--", executable, ...args], { cwd: root, env, detached: group, stdio: ["pipe", "pipe", "pipe"] });
     let failure: unknown;
     let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
     const stop = () => {
@@ -87,7 +100,13 @@ export function runLockedProcess(root: string, executable: string, args: string[
       if (failure) reject(failure);
       else resolve(code ?? 1);
     });
-    try { if (child.pid) trackWriter(child.pid, group); }
+    child.stdin.on("error", (error) => { failure = error; stop(); });
+    try {
+      if (child.pid) {
+        trackWriter(child.pid, group);
+        child.stdin.end("start");
+      }
+    }
     catch (error) { failure = error; stop(); }
     if (timeoutMs !== undefined) timer = globalThis.setTimeout(() => { failure = new Error("locked command timed out"); stop(); }, timeoutMs);
   });

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -1,0 +1,375 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import test, { type TestContext } from "node:test";
+
+import { runCli } from "../src/knowledge-loom/cli.ts";
+import { asRecord, copyFixture, PACKAGE_ROOT, temporaryDirectory } from "./helpers.ts";
+
+function git(root: string, ...args: string[]): string {
+  const result = spawnSync("git", ["-C", root, "-c", "user.name=Example", "-c", "user.email=example@example.com", ...args], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function devices(t: TestContext) {
+  const root = temporaryDirectory(t);
+  const remote = path.join(root, "remote.git");
+  git(root, "init", "--bare", "--initial-branch=main", remote);
+  const a = copyFixture("single-proactive", path.join(root, "a"));
+  const contract = path.join(a, "KNOWLEDGE_VAULT.md");
+  fs.writeFileSync(contract, fs.readFileSync(contract, "utf8").replace("type: none", "type: git"));
+  git(a, "init", "--initial-branch=main");
+  git(a, "add", ".");
+  git(a, "commit", "-m", "Initial vault");
+  git(a, "remote", "add", "origin", remote);
+  git(a, "push", "-u", "origin", "main");
+  const b = path.join(root, "b");
+  git(root, "clone", remote, b);
+  return { root, remote, a, b, state: path.join(root, "state") };
+}
+
+async function invoke(args: string[], cwd: string, now = 1_800_000_000_000) {
+  let stdout = "";
+  let stderr = "";
+  const code = await runCli(args, {
+    cwd, now: () => now, stdout: { write(value) { stdout += value; } }, stderr: { write(value) { stderr += value; } },
+  });
+  return { code, stdout, stderr, now };
+}
+
+async function enabledDevices(t: TestContext) {
+  const setup = devices(t);
+  const result = await invoke(["access", "--enable-inbound", "--remote", "origin", "--branch", "main", "--apply", "--json"], setup.a);
+  assert.equal(result.code, 0, result.stderr);
+  git(setup.a, "add", "KNOWLEDGE_VAULT.md"); git(setup.a, "commit", "-m", "Enable inbound"); git(setup.a, "push");
+  git(setup.b, "pull", "--ff-only");
+  return setup;
+}
+
+test("access without an applicable vault is a successful no-op without operational state", async (t) => {
+  const root = temporaryDirectory(t);
+  const state = path.join(root, "state");
+  const result = await invoke(["access", "--registry", path.join(root, "registry.yaml"), "--state-dir", state, "--json"], root);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "not-applicable");
+  assert.equal(fs.existsSync(state), false);
+});
+
+test("access fast-forwards due knowledge and reuses the observation until exactly 24 hours", async (t) => {
+  const { a, b, state } = devices(t);
+  const enabled = await invoke(["access", "--enable-inbound", "--remote", "origin", "--branch", "main", "--apply", "--json"], a);
+  assert.equal(enabled.code, 0, enabled.stderr);
+  git(a, "add", "KNOWLEDGE_VAULT.md");
+  git(a, "commit", "-m", "Enable inbound");
+  git(a, "push");
+  git(b, "pull", "--ff-only");
+  fs.writeFileSync(path.join(a, "new.md"), "# New knowledge\n");
+  git(a, "add", "new.md"); git(a, "commit", "-m", "Add knowledge"); git(a, "push");
+  const args = ["access", "--state-dir", state, "--json"];
+  const first = await invoke(args, b);
+  assert.equal(first.code, 0, first.stderr);
+  assert.equal(asRecord(JSON.parse(first.stdout)).status, "integrated");
+  assert.equal(fs.readFileSync(path.join(b, "new.md"), "utf8"), "# New knowledge\n");
+  fs.writeFileSync(path.join(a, "later.md"), "# Later knowledge\n");
+  git(a, "add", "later.md"); git(a, "commit", "-m", "Later knowledge"); git(a, "push");
+  const cached = await invoke(args, b, first.now + 86_399_999);
+  assert.equal(asRecord(JSON.parse(cached.stdout)).check, "cached");
+  assert.equal(fs.existsSync(path.join(b, "later.md")), false);
+  const due = await invoke(args, b, first.now + 86_400_000);
+  assert.equal(asRecord(JSON.parse(due.stdout)).status, "integrated");
+  assert.equal(fs.existsSync(path.join(b, "later.md")), true);
+});
+
+test("enabling inbound access previews the exact contract and only applies on request", async (t) => {
+  const { b, state } = devices(t);
+  const contract = path.join(b, "KNOWLEDGE_VAULT.md");
+  const original = fs.readFileSync(contract, "utf8");
+  const args = ["access", "--enable-inbound", "--remote", "origin", "--branch", "main", "--state-dir", state, "--json"];
+  const preview = await invoke(args, b);
+  assert.equal(preview.code, 0, preview.stderr);
+  const rendered = asRecord(JSON.parse(preview.stdout)).contract;
+  assert.equal(typeof rendered, "string");
+  assert.match(String(rendered), /inbound:/);
+  assert.equal(fs.readFileSync(contract, "utf8"), original);
+  const applied = await invoke([...args, "--apply"], b);
+  assert.equal(applied.code, 0, applied.stderr);
+  assert.equal(fs.readFileSync(contract, "utf8"), rendered);
+  assert.equal(fs.existsSync(state), false);
+});
+
+test("a dirty reader observes remote changes without integrating them or losing unfinished work", async (t) => {
+  const { a, b, state } = await enabledDevices(t);
+  fs.writeFileSync(path.join(a, "remote.md"), "# Remote addition\n");
+  git(a, "add", "remote.md"); git(a, "commit", "-m", "Remote addition"); git(a, "push");
+  fs.writeFileSync(path.join(b, "unfinished.md"), "# Unfinished local work\n");
+  const head = git(b, "rev-parse", "HEAD");
+  const result = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "behind");
+  assert.equal(git(b, "rev-parse", "HEAD"), head);
+  assert.equal(fs.readFileSync(path.join(b, "unfinished.md"), "utf8"), "# Unfinished local work\n");
+  assert.equal(fs.existsSync(path.join(b, "remote.md")), false);
+});
+
+test("remote failure allows local commits and backs off without claiming a successful check", async (t) => {
+  const { a, b, remote, state } = await enabledDevices(t);
+  const args = ["access", "--state-dir", state, "--json"];
+  fs.renameSync(remote, `${remote}.offline`);
+  const failed = await invoke(args, b);
+  assert.equal(failed.code, 0, failed.stderr);
+  assert.equal(asRecord(JSON.parse(failed.stdout)).status, "unavailable");
+  fs.writeFileSync(path.join(b, "local.md"), "# Local work remains possible\n");
+  git(b, "add", "local.md"); git(b, "commit", "-m", "Local work");
+  fs.renameSync(`${remote}.offline`, remote);
+  fs.writeFileSync(path.join(a, "remote.md"), "# Restored remote\n");
+  git(a, "add", "remote.md"); git(a, "commit", "-m", "Remote work"); git(a, "push");
+  const retry = await invoke(args, b, failed.now + 1);
+  assert.equal(asRecord(JSON.parse(retry.stdout)).check, "backoff");
+  const recovered = await invoke(args, b, failed.now + 300_000);
+  assert.equal(recovered.code, 0, recovered.stderr);
+  assert.equal(asRecord(JSON.parse(recovered.stdout)).status, "diverged");
+  assert.equal(asRecord(JSON.parse(recovered.stdout)).check, "performed");
+  assert.equal(fs.readFileSync(path.join(b, "local.md"), "utf8"), "# Local work remains possible\n");
+});
+
+test("concurrent tasks share one due access operation", async (t) => {
+  const { b, state } = await enabledDevices(t);
+  const args = ["access", "--state-dir", state, "--json"];
+  const results = await Promise.all([invoke(args, b), invoke(args, b)]);
+  for (const result of results) assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(results.map((result) => asRecord(JSON.parse(result.stdout)).check).sort(), ["cached", "performed"]);
+});
+
+test("status is read-only even when a cached remote revision could now be integrated", async (t) => {
+  const { a, b, state } = await enabledDevices(t);
+  fs.writeFileSync(path.join(a, "new.md"), "# Available remotely\n");
+  git(a, "add", "new.md"); git(a, "commit", "-m", "Remote work"); git(a, "push");
+  const args = ["access", "--state-dir", state, "--json"];
+  fs.writeFileSync(path.join(b, "working.md"), "# Working\n");
+  await invoke(args, b);
+  fs.unlinkSync(path.join(b, "working.md"));
+  const before = git(b, "rev-parse", "HEAD");
+  const records = fs.readdirSync(state).map((file) => fs.readFileSync(path.join(state, file), "utf8"));
+  const status = await invoke([...args, "--status"], b);
+  assert.equal(status.code, 0, status.stderr);
+  assert.equal(asRecord(JSON.parse(status.stdout)).status, "behind");
+  assert.equal(asRecord(JSON.parse(status.stdout)).check, "read-only");
+  assert.equal(git(b, "rev-parse", "HEAD"), before);
+  assert.deepEqual(fs.readdirSync(state).map((file) => fs.readFileSync(path.join(state, file), "utf8")), records);
+  const access = await invoke(args, b);
+  assert.equal(asRecord(JSON.parse(access.stdout)).status, "integrated");
+  assert.equal(asRecord(JSON.parse(access.stdout)).check, "cached");
+});
+
+test("invalid authority and in-vault state paths stop access before a fetch", async (t) => {
+  const { b, state } = await enabledDevices(t);
+  const contract = path.join(b, "KNOWLEDGE_VAULT.md");
+  const original = fs.readFileSync(contract, "utf8");
+  fs.writeFileSync(contract, original.replace("- INDEX.md", "- ../outside.md"));
+  const result = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /boundary|within|contract/);
+  assert.equal(fs.existsSync(state), false);
+  fs.writeFileSync(contract, original);
+  const inside = await invoke(["access", "--state-dir", path.join(b, "state"), "--json"], b);
+  assert.equal(inside.code, 2);
+  assert.match(inside.stderr, /outside/);
+  assert.equal(fs.existsSync(path.join(b, "state")), false);
+});
+
+test("access revalidates governing paths after a remote fast-forward", async (t) => {
+  const { a, b, state } = await enabledDevices(t);
+  const contract = path.join(a, "KNOWLEDGE_VAULT.md");
+  fs.writeFileSync(contract, fs.readFileSync(contract, "utf8").replace("- INDEX.md", "- ../outside.md"));
+  git(a, "add", "KNOWLEDGE_VAULT.md"); git(a, "commit", "-m", "Invalid remote navigation"); git(a, "push");
+  const result = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(result.code, 2);
+  assert.match(result.stderr, /contract|boundary/);
+});
+
+test("a different branch without the authorized upstream cannot inherit a vault refresh", async (t) => {
+  const { b, state } = await enabledDevices(t);
+  git(b, "switch", "-c", "scratch");
+  const result = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "unavailable");
+  assert.match(String(asRecord(JSON.parse(result.stdout)).reason), /upstream/);
+  assert.equal(fs.existsSync(state), false);
+});
+
+test("cooperating writers hold the shared lock until they finish", async (t) => {
+  const { root, b, state } = await enabledDevices(t);
+  const marker = path.join(root, "writer-ready");
+  const release = path.join(root, "release-writer");
+  const writer = invoke(["with-vault-lock", b, "--", process.execPath, "-e", `const fs = require('node:fs'); fs.writeFileSync(${JSON.stringify(marker)}, 'ready'); const timer=setInterval(() => { if(fs.existsSync(${JSON.stringify(release)})) { clearInterval(timer); } }, 10);`], root);
+  const start = Date.now();
+  while (!fs.existsSync(marker) && Date.now() - start < 2000) await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(fs.existsSync(marker), true);
+  try {
+    const busy = await invoke(["access", "--state-dir", state, "--json"], b);
+    assert.equal(asRecord(JSON.parse(busy.stdout)).status, "busy");
+    assert.equal(fs.existsSync(state), false);
+  } finally { fs.writeFileSync(release, "release"); await writer; }
+  const recovered = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(asRecord(JSON.parse(recovered.stdout)).check, "performed");
+});
+
+test("a rewritten remote is reported for recovery instead of being silently integrated", async (t) => {
+  const { a, b, state } = await enabledDevices(t);
+  const args = ["access", "--state-dir", state, "--json"];
+  const first = await invoke(args, b);
+  git(a, "reset", "--hard", "HEAD~1");
+  git(a, "push", "--force");
+  const result = await invoke(args, b, first.now + 86_400_000);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "recovery-required");
+  const repeated = await invoke(args, b, first.now + 86_400_001);
+  assert.equal(asRecord(JSON.parse(repeated.stdout)).status, "recovery-required");
+});
+
+test("access preserves an in-progress Git operation even with a clean index", async (t) => {
+  const { a, b, state } = await enabledDevices(t);
+  fs.writeFileSync(path.join(a, "later.md"), "# Later\n");
+  git(a, "add", "later.md"); git(a, "commit", "-m", "Later"); git(a, "push");
+  const operation = path.join(b, ".git", "rebase-merge");
+  fs.mkdirSync(operation);
+  const result = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "behind");
+  assert.equal(fs.existsSync(operation), true);
+  assert.equal(fs.existsSync(path.join(b, "later.md")), false);
+});
+
+test("a terminated lock owner is recovered without a lease timeout", async (t) => {
+  const { b, state } = await enabledDevices(t);
+  const crashed = spawnSync(process.execPath, ["--import", "tsx", "src/knowledge-loom/runner.ts", "with-vault-lock", b, "--", process.execPath, "-e", "process.kill(process.ppid, 'SIGKILL'); process.exit(0);"], { cwd: PACKAGE_ROOT, encoding: "utf8", timeout: 5000 });
+  assert.equal(crashed.signal, "SIGKILL", crashed.stderr);
+  const result = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).check, "performed");
+});
+
+test("status retains a failed check after backoff expires without attempting recovery", async (t) => {
+  const { b, remote, state } = await enabledDevices(t);
+  fs.renameSync(remote, `${remote}.offline`);
+  const args = ["access", "--state-dir", state, "--json"];
+  const failed = await invoke(args, b);
+  const status = await invoke([...args, "--status"], b, failed.now + 300_001);
+  assert.equal(status.code, 0, status.stderr);
+  assert.equal(asRecord(JSON.parse(status.stdout)).status, "unavailable");
+  assert.equal(asRecord(JSON.parse(status.stdout)).check, "read-only");
+});
+
+test("a corrupt observation does not make local knowledge unreadable", async (t) => {
+  const { b, state } = await enabledDevices(t);
+  const args = ["access", "--state-dir", state, "--json"];
+  await invoke(args, b);
+  const file = path.join(state, fs.readdirSync(state)[0]!);
+  fs.writeFileSync(file, "interrupted data");
+  const result = await invoke(args, b);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "unavailable");
+  assert.match(String(asRecord(JSON.parse(result.stdout)).reason), /observation/);
+  assert.equal(fs.readFileSync(file, "utf8"), "interrupted data");
+});
+
+test("inbound integration preserves ignored local files that collide with remote additions", async (t) => {
+  const { a, b, state } = await enabledDevices(t);
+  fs.writeFileSync(path.join(b, ".git", "info", "exclude"), "local.md\n");
+  fs.writeFileSync(path.join(b, "local.md"), "PRIVATE LOCAL WORK\n");
+  fs.writeFileSync(path.join(a, "local.md"), "REMOTE\n");
+  git(a, "add", "local.md"); git(a, "commit", "-m", "Remote addition"); git(a, "push");
+  const head = git(b, "rev-parse", "HEAD");
+  const result = await invoke(["access", "--state-dir", state, "--json"], b);
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(fs.readFileSync(path.join(b, "local.md"), "utf8"), "PRIVATE LOCAL WORK\n");
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "behind");
+  assert.equal(git(b, "rev-parse", "HEAD"), head);
+});
+
+test("separate state directories cannot change the revision a cached observation integrates", async (t) => {
+  const { a, b, root, state } = await enabledDevices(t);
+  const args = ["access", "--state-dir", state, "--json"];
+  await invoke(args, b);
+  const head = git(b, "rev-parse", "HEAD");
+  fs.writeFileSync(path.join(a, "new.md"), "# Later remote\n");
+  git(a, "add", "new.md"); git(a, "commit", "-m", "Later remote"); git(a, "push");
+  fs.writeFileSync(path.join(b, "working.md"), "# Keep checkout unchanged\n");
+  await invoke(["access", "--state-dir", path.join(root, "other-state"), "--json"], b);
+  fs.unlinkSync(path.join(b, "working.md"));
+  const cached = await invoke(args, b);
+  assert.equal(asRecord(JSON.parse(cached.stdout)).check, "cached");
+  assert.equal(git(b, "rev-parse", "HEAD"), head);
+  assert.equal(fs.existsSync(path.join(b, "new.md")), false);
+});
+
+test("a surviving fetch remains protected after its access owner is terminated", async (t) => {
+  const { root, b, state } = await enabledDevices(t);
+  const marker = path.join(root, "fetch-ready");
+  const release = path.join(root, "release-fetch");
+  const script = path.join(root, "delayed-upload-pack");
+  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  fs.writeFileSync(script, `#!/bin/sh\nprintf ready > ${quote(marker)}\nwhile [ ! -f ${quote(release)} ]; do sleep 0.05; done\nexec git-upload-pack "$@"\n`, { mode: 0o755 });
+  git(b, "config", "remote.origin.uploadpack", quote(script));
+  const owner = spawn(process.execPath, ["--import", "tsx", "src/knowledge-loom/runner.ts", "access", b, "--state-dir", state, "--json"], { cwd: PACKAGE_ROOT, stdio: "ignore" });
+  const exited = new Promise<void>((resolve) => owner.once("exit", () => resolve()));
+  try {
+    const deadline = Date.now() + 10_000;
+    while (!fs.existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(fs.existsSync(marker), true);
+    owner.kill("SIGKILL");
+    await exited;
+    const waiting = invoke(["access", "--state-dir", state, "--json"], b);
+    const unblock = setTimeout(() => fs.writeFileSync(release, "release"), 4000);
+    const result = await waiting;
+    clearTimeout(unblock);
+    assert.equal(asRecord(JSON.parse(result.stdout)).status, "busy");
+  } finally {
+    fs.writeFileSync(release, "release");
+    if (owner.exitCode === null && owner.signalCode === null) owner.kill("SIGKILL");
+    await exited;
+    // Wait for the surviving fetch to finish before removing its temporary repository.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+});
+
+test("failed writer registration terminates and awaits the child before releasing ownership", async (t) => {
+  const { root, b } = await enabledDevices(t);
+  const bin = path.join(root, "bin"); fs.mkdirSync(bin);
+  const counter = path.join(root, "updates");
+  const lateWrite = path.join(root, "unprotected-write");
+  const realGit = spawnSync("which", ["git"], { encoding: "utf8" }).stdout.trim();
+  assert.ok(realGit);
+  fs.writeFileSync(path.join(bin, "git"), `#!/usr/bin/env node\nconst fs=require('node:fs'); const cp=require('node:child_process'); const args=process.argv.slice(2); const counter=${JSON.stringify(counter)}; if(args.includes('update-ref')&&!args.includes('-d')) { const n=fs.existsSync(counter)?Number(fs.readFileSync(counter,'utf8'))+1:1; fs.writeFileSync(counter,String(n)); if(n===2) process.exit(1); } const r=cp.spawnSync(${JSON.stringify(realGit)},args,{stdio:'inherit'}); process.exit(r.status??1);\n`, { mode: 0o755 });
+  const result = spawnSync(process.execPath, ["--import", "tsx", "src/knowledge-loom/runner.ts", "with-vault-lock", b, "--", process.execPath, "-e", `setTimeout(()=>require('node:fs').writeFileSync(${JSON.stringify(lateWrite)},'unprotected'),1000);`], {
+    cwd: PACKAGE_ROOT, env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}` }, encoding: "utf8", timeout: 10_000,
+  });
+  assert.equal(result.status, 2, result.stderr);
+  assert.match(result.stderr, /track the active writer/);
+  assert.equal(fs.existsSync(lateWrite), false);
+});
+
+test("a branch switch during fetch defers integration into the newly selected branch", async (t) => {
+  const { root, a, b, state } = await enabledDevices(t);
+  fs.writeFileSync(path.join(a, "new.md"), "# Remote change\n");
+  git(a, "add", "new.md"); git(a, "commit", "-m", "Remote change"); git(a, "push");
+  const marker = path.join(root, "fetch-ready");
+  const release = path.join(root, "release-fetch");
+  const script = path.join(root, "delayed-upload-pack");
+  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  fs.writeFileSync(script, `#!/bin/sh\nprintf ready > ${quote(marker)}\nwhile [ ! -f ${quote(release)} ]; do sleep 0.05; done\nexec git-upload-pack "$@"\n`, { mode: 0o755 });
+  git(b, "config", "remote.origin.uploadpack", quote(script));
+  const pending = invoke(["access", "--state-dir", state, "--json"], b);
+  try {
+    const deadline = Date.now() + 10_000;
+    while (!fs.existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(fs.existsSync(marker), true);
+    git(b, "switch", "-c", "unrelated");
+  } finally { fs.writeFileSync(release, "release"); }
+  const result = await pending;
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(asRecord(JSON.parse(result.stdout)).status, "unavailable");
+  assert.equal(fs.existsSync(path.join(b, "new.md")), false);
+});

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -244,7 +244,7 @@ test("access preserves an in-progress Git operation even with a clean index", as
 
 test("a terminated lock owner is recovered without a lease timeout", async (t) => {
   const { b, state } = await enabledDevices(t);
-  const crashed = spawnSync(process.execPath, ["--import", "tsx", "src/knowledge-loom/runner.ts", "with-vault-lock", b, "--", process.execPath, "-e", "process.kill(process.ppid, 'SIGKILL'); process.exit(0);"], { cwd: PACKAGE_ROOT, encoding: "utf8", timeout: 5000 });
+  const crashed = spawnSync(process.execPath, ["--import", "tsx", "src/knowledge-loom/runner.ts", "with-vault-lock", b, "--", process.execPath, "-e", "const owner=JSON.parse(require('node:child_process').execFileSync('git',['cat-file','blob','refs/knowledge-loom/mutation-lock'],{encoding:'utf8'})); process.kill(owner.pid, 'SIGKILL'); process.exit(0);"], { cwd: PACKAGE_ROOT, encoding: "utf8", timeout: 5000 });
   assert.equal(crashed.signal, "SIGKILL", crashed.stderr);
   const result = await invoke(["access", "--state-dir", state, "--json"], b);
   assert.equal(result.code, 0, result.stderr);
@@ -319,12 +319,18 @@ test("a surviving fetch remains protected after its access owner is terminated",
     const deadline = Date.now() + 10_000;
     while (!fs.existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
     assert.equal(fs.existsSync(marker), true);
+    // Verify that the fixture established registered surviving-writer ownership
+    // before terminating the access owner.
+    let registered = false;
+    while (!registered && Date.now() < deadline) {
+      const lock = asRecord(JSON.parse(git(b, "cat-file", "blob", "refs/knowledge-loom/mutation-lock")));
+      registered = typeof lock.writer_pid === "number" && lock.writer_group === true;
+      if (!registered) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(registered, true, "fetch must be registered before terminating its owner");
     owner.kill("SIGKILL");
     await exited;
-    const waiting = invoke(["access", "--state-dir", state, "--json"], b);
-    const unblock = setTimeout(() => fs.writeFileSync(release, "release"), 4000);
-    const result = await waiting;
-    clearTimeout(unblock);
+    const result = await invoke(["access", "--state-dir", state, "--json"], b);
     assert.equal(asRecord(JSON.parse(result.stdout)).status, "busy");
   } finally {
     fs.writeFileSync(release, "release");
@@ -332,6 +338,48 @@ test("a surviving fetch remains protected after its access owner is terminated",
     await exited;
     // Wait for the surviving fetch to finish before removing its temporary repository.
     await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+});
+
+test("termination before writer registration cannot start unprotected work", async (t) => {
+  const { root, b, state } = await enabledDevices(t);
+  const bin = path.join(root, "bin"); fs.mkdirSync(bin);
+  const marker = path.join(root, "registering");
+  const release = path.join(root, "release-registration");
+  const counter = path.join(root, "updates");
+  const write = path.join(root, "unprotected-write");
+  const realGit = spawnSync("which", ["git"], { encoding: "utf8" }).stdout.trim();
+  assert.ok(realGit);
+  fs.writeFileSync(path.join(bin, "git"), `#!/usr/bin/env node
+const fs=require('node:fs'); const cp=require('node:child_process');
+const args=process.argv.slice(2); const counter=${JSON.stringify(counter)};
+if(args.includes('update-ref')&&!args.includes('-d')) {
+  const n=fs.existsSync(counter)?Number(fs.readFileSync(counter,'utf8'))+1:1;
+  fs.writeFileSync(counter,String(n));
+  if(n===2) {
+    fs.writeFileSync(${JSON.stringify(marker)},'ready');
+    const timer=setInterval(()=>{ if(fs.existsSync(${JSON.stringify(release)})) { clearInterval(timer); process.exit(1); } },10);
+  } else { const r=cp.spawnSync(${JSON.stringify(realGit)},args,{stdio:'inherit'}); process.exit(r.status??1); }
+} else { const r=cp.spawnSync(${JSON.stringify(realGit)},args,{stdio:'inherit'}); process.exit(r.status??1); }
+`, { mode: 0o755 });
+  const owner = spawn(process.execPath, ["--import", "tsx", "src/knowledge-loom/runner.ts", "with-vault-lock", b, "--", process.execPath, "-e", `require('node:fs').writeFileSync(${JSON.stringify(write)},'unprotected');`], {
+    cwd: PACKAGE_ROOT, env: { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH}` }, stdio: "ignore",
+  });
+  const exited = new Promise<void>((resolve) => owner.once("exit", () => resolve()));
+  try {
+    const deadline = Date.now() + 10_000;
+    while (!fs.existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(fs.existsSync(marker), true);
+    owner.kill("SIGKILL");
+    await exited;
+    const recovered = await invoke(["access", "--state-dir", state, "--json"], b);
+    assert.equal(asRecord(JSON.parse(recovered.stdout)).status, "current");
+    assert.equal(fs.existsSync(write), false, "the command must not start before registration");
+  } finally {
+    fs.writeFileSync(release, "release");
+    if (owner.exitCode === null && owner.signalCode === null) owner.kill("SIGKILL");
+    await exited;
+    await new Promise((resolve) => setTimeout(resolve, 100));
   }
 });
 


### PR DESCRIPTION
Vault retrieval can use an outdated local checkout without checking whether another device has pushed new knowledge. This adds an explicitly authorized `access` command that checks the configured upstream after 24 elapsed hours and fast-forwards a clean, behind-only checkout before retrieval.

Observations are shared across tasks and runtimes on the device. Failed checks preserve local read/write access and report unavailable freshness with bounded retry. Dirty or diverged checkouts defer integration. A shared Git lock coordinates access with cooperative writers, and existing probe, resolve, audit, and status operations remain read-only.

Closes #44. Part of #43. Conflict reconciliation, weekly skill updates, and automatic Codex/Claude Code setup remain in #45–#47.

Validation:

- `npm run validate:npx`: passed on the current main baseline, including public-command tests with temporary remotes, two clones, and a controlled clock; generated distributions and isolated npx installation checks passed.
- Standards review: no remaining findings.
- Spec review: no remaining findings.
- Behavior evaluations run in dry-run mode; live runtime adapter verification belongs to #47.
