### PR TITLE
Maintain stable skill releases outside installed skills

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
         run: >-
           gh release create "$GITHUB_REF_NAME"
           "dist/knowledge-loom-claude-desktop-${GITHUB_REF_NAME}.zip#Claude Desktop skill"
+          "dist/maintenance.cjs#External release maintenance entry point"
           --verify-tag
           --notes-file dist/release-notes.md
           --title "$GITHUB_REF_NAME"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Each installed skill includes one self-contained JavaScript runner and does not 
 npx skills@latest add magickaichen/knowledge-loom
 ```
 
-Select **Knowledge Loom** for all four skills, then choose your agent. Update with `npx skills update`.
+Select **Knowledge Loom** for all four skills, then choose your agent. Update with `npx skills update`,
+or explicitly [bootstrap weekly stable release maintenance](docs/release-maintenance.md) outside the
+installed skills. Release publication alone does not upgrade existing devices.
 
 <details>
 <summary>Plugin installation for Claude Code or Codex</summary>

--- a/docs/release-maintenance.md
+++ b/docs/release-maintenance.md
@@ -1,0 +1,94 @@
+# Stable release maintenance
+
+Bootstrap a device once to keep the four Knowledge Loom skills on published stable releases.
+The maintenance entry point lives outside the replaceable skills. Publishing a release does not
+upgrade devices that have not completed bootstrap and wired the external call into their use path.
+Requires Node.js 20+, Git, and a local POSIX filesystem with atomic symlink rename.
+
+## Bootstrap and verify
+
+Build the external entry point from a trusted checkout with `npm ci && npm run build:maintenance`,
+or download `maintenance.cjs` from a published Knowledge Loom GitHub Release. Keep that file until
+bootstrap succeeds. The `--source` checkout must contain the same four skills as the installation;
+it may be an older release with no maintenance code. Local differences stop adoption before any
+installed skill changes.
+
+Run the entry point with the source checkout and every installation directory to maintain:
+
+```bash
+node dist/maintenance.cjs bootstrap --source /path/to/knowledge-loom \
+  --target "$HOME/.agents/skills" --target "$HOME/.claude/skills"
+node "$HOME/.local/share/knowledge-loom/maintenance.cjs" status
+```
+
+Bootstrap verifies the copied executable with `--help`, stages and validates the complete original
+bundle, and converts only the four selected skill paths into links. `bootstrapped`, then `ready`,
+confirms the external entry point and installation. Original directories or symlinks remain under
+`~/.local/share/knowledge-loom/backups/`. An interrupted adoption resumes through `status` or
+`bootstrap` without needing the source checkout.
+
+The result identifies each original route: copied directory, checkout symlink, or `skills-cli`
+bookkeeping. Existing manager records remain byte-identical; they describe the original manager
+installation, while `status` owns the maintained version. Use this entry point for subsequent
+updates. If another installer replaces the links, maintenance stops on a collision. Plugin-owned
+Codex and Claude caches are refused: use the owning plugin manager for those installations rather
+than editing its versioned cache or records. Bootstrap does not edit runtime configuration.
+
+## Run on due use
+
+Add this instruction to the runtime's user-level instructions, outside installed skill directories:
+
+> Before using Knowledge Loom, run `node "$HOME/.local/share/knowledge-loom/maintenance.cjs" use`.
+> Read its result, then resolve the installed skill to its canonical directory for this invocation.
+> If maintenance reports failure, backoff, or busy, retain the usable installed bundle and report
+> the recovery state when relevant to the task.
+
+Verify the wiring by invoking it from each runtime and checking that they report the same
+`entryPoint`, installed version, and `lastCheck`. This explicit caller setup is required even for
+old skills; no ordinary-chat polling, background service, or scheduler is installed.
+
+The first `use` checks immediately. Successful observations are shared across tasks and runtimes
+using the same home. The next check becomes due after exactly seven elapsed days. A failed lookup
+or installation leaves `lastCheck` unchanged. Each call makes at most one attempt; retry delay
+starts at one minute, doubles, and caps at six hours. `recovery` retains the error and retry time.
+A changed pin schedules a check but does not bypass an outstanding failure backoff.
+
+```bash
+node "$HOME/.local/share/knowledge-loom/maintenance.cjs" use --pin 0.8.0
+node "$HOME/.local/share/knowledge-loom/maintenance.cjs" use --pin none
+```
+
+Pins persist across calls. Only a published stable release can satisfy a pin; it may explicitly
+select an older release. Without a pin, maintenance selects the newest stable semantic version and
+never downgrades. Drafts, prereleases, and unpublished branch changes are excluded. The selected
+release tag resolves to a specific commit before its archive is downloaded. The archive is bounded
+in size and only Knowledge Loom skill artifacts are extracted. Release code is syntax-checked,
+not executed during staging.
+
+## Status and recovery
+
+`installedVersion` describes the disk installation. `loadedVersion` is `unknown` unless the caller
+supplies `--loaded-version`; the tool never guesses it from the installed version. An update does
+not require a routine active session to restart. A later invocation resolves the new bundle.
+
+Published releases may include `data-integrity-advisories.json`, an array of objects with `id`,
+`affectedVersions` (exact stable versions), `message`, and a Knowledge Loom GitHub `url`. Only
+advisories obtained with a validated release at a resolved commit are retained. The result includes
+those matching the installed version or a known caller-loaded version. Unknown loaded versions
+remain unknown; version age alone never generates a data-integrity advisory. Advisory text is data,
+not instructions or permission to perform recovery writes.
+
+The external state directory contains complete bundles, preserved originals, a transaction record,
+and a private Git object store used only for the installation lock. The lock waits at most two
+seconds by default, never steals a live owner's lock because it is old, and reclaims a dead local
+owner with a compare-and-swap operation. A killed check or staging process leaves the prior bundle
+active and a durable recovery record on the next call.
+
+Before switching, maintenance validates all four skill packages and checks every adopted path for
+local changes. A single symlink rename selects the complete new bundle. A transaction interrupted
+around that rename is reconciled to the previous or new bundle by the next call. `recovered` marks
+that reconciliation. No rollback deletes local edits or original installation backups. Preserve the
+state directory when diagnosing a collision; it identifies each original target and backup.
+
+`--home PATH` isolates the entire maintenance installation and state for testing. All installation
+and update tests use temporary homes. This mechanism does not synchronize vault Git repositories.

--- a/docs/release-maintenance.md
+++ b/docs/release-maintenance.md
@@ -3,7 +3,9 @@
 Bootstrap a device once to keep the four Knowledge Loom skills on published stable releases.
 The maintenance entry point lives outside the replaceable skills. Publishing a release does not
 upgrade devices that have not completed bootstrap and wired the external call into their use path.
-Requires Node.js 20+, Git, and a local POSIX filesystem with atomic symlink rename.
+Requires Node.js 20+ and Git. One-time adoption also requires Python 3 and a macOS or Linux
+filesystem that supports atomic directory-entry exchange. Target and backup must share that
+filesystem; unsupported cases preserve the original installation and stop.
 
 ## Bootstrap and verify
 
@@ -21,8 +23,9 @@ node dist/maintenance.cjs bootstrap --source /path/to/knowledge-loom \
 node "$HOME/.local/share/knowledge-loom/maintenance.cjs" status
 ```
 
-Bootstrap verifies the copied executable with `--help`, stages and validates the complete original
-bundle, and converts only the four selected skill paths into links. `bootstrapped`, then `ready`,
+Bootstrap checks Python availability, verifies the copied executable with `--help`, stages and validates the complete original
+bundle, and atomically exchanges each selected skill path with a prepared link to that same bundle.
+An interruption between exchanges still leaves every original skill usable. `bootstrapped`, then `ready`,
 confirms the external entry point and installation. Original directories or symlinks remain under
 `~/.local/share/knowledge-loom/backups/`. An interrupted adoption resumes through `status` or
 `bootstrap` without needing the source checkout.
@@ -60,7 +63,7 @@ node "$HOME/.local/share/knowledge-loom/maintenance.cjs" use --pin none
 
 Pins persist across calls. Only a published stable release can satisfy a pin; it may explicitly
 select an older release. Without a pin, maintenance selects the newest stable semantic version and
-never downgrades. Drafts, prereleases, and unpublished branch changes are excluded. The selected
+never downgrades. Drafts, prereleases, and unpublished branch changes are excluded. Even a pinned current version is checked for verified advisories when due. The selected
 release tag resolves to a specific commit before its archive is downloaded. The archive is bounded
 in size and only Knowledge Loom skill artifacts are extracted. Release code is syntax-checked,
 not executed during staging.

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
     "knowledge-loom": "skills/use-knowledge-vault/scripts/knowledge-loom.mjs"
   },
   "scripts": {
-    "build": "node --import tsx scripts/build-skill-packages.ts && node --import tsx scripts/build-claude-desktop-skill.ts",
+    "build": "node --import tsx scripts/build-skill-packages.ts && node --import tsx scripts/build-claude-desktop-skill.ts && node --import tsx scripts/build-maintenance.ts",
     "build:check": "node --import tsx scripts/build-skill-packages.ts --check",
     "cli": "node --import tsx src/knowledge-loom/runner.ts",
     "install:skills": "node --import tsx scripts/install.ts",
-    "test": "node --import tsx scripts/run-tests.ts",
+    "test": "node --import tsx scripts/build-maintenance.ts && node --import tsx scripts/run-tests.ts",
     "typecheck": "tsc --noEmit",
     "validate": "node --import tsx scripts/validate.ts",
-    "validate:npx": "node --import tsx scripts/validate.ts --npx"
+    "validate:npx": "node --import tsx scripts/validate.ts --npx",
+    "build:maintenance": "node --import tsx scripts/build-maintenance.ts"
   },
   "dependencies": {
     "yaml": "2.9.0"

--- a/scripts/build-maintenance.ts
+++ b/scripts/build-maintenance.ts
@@ -1,0 +1,2 @@
+import { build } from "esbuild";
+await build({ entryPoints: ["src/maintenance/runner.ts"], outfile: "dist/maintenance.cjs", bundle: true, platform: "node", format: "cjs", target: "node20" });

--- a/scripts/test-npx-install.ts
+++ b/scripts/test-npx-install.ts
@@ -13,6 +13,8 @@ const SKILL_NAMES = new Set(["audit-knowledge-vault", "init-knowledge-vault", "m
 const RUNNER_CHECK_ROOTS = [path.join(".agents", "skills"), path.join(".claude", "skills")];
 const INTERACTIVE_GROUP_PROMPT = "Select all 4 skills in Knowledge Loom.";
 
+let isolatedHome: string;
+
 interface RunOptions {
   cwd?: string;
   capture?: boolean;
@@ -25,7 +27,7 @@ function commandPath(name: string): string | null {
 }
 
 function environment(): NodeJS.ProcessEnv {
-  const result: NodeJS.ProcessEnv = { ...process.env, DISABLE_TELEMETRY: "1" };
+  const result: NodeJS.ProcessEnv = { ...process.env, HOME: isolatedHome, USERPROFILE: isolatedHome, XDG_CONFIG_HOME: path.join(isolatedHome, ".config"), XDG_CACHE_HOME: path.join(isolatedHome, ".cache"), DISABLE_TELEMETRY: "1" };
   for (const key of Object.keys(result)) if (key.startsWith("CODEX_")) delete result[key];
   return result;
 }
@@ -126,6 +128,7 @@ export async function main(): Promise<number> {
   const npx = commandPath("npx");
   if (!npx) throw new Error("missing required command: npx");
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-loom-npx-"));
+  isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "knowledge-loom-npx-home-"));
   try {
     await assertInteractiveGroup(npx, workspace);
     const listing = run(npx, ["--yes", SKILLS_CLI, "add", PACKAGE_ROOT, "--list"], { cwd: workspace, capture: true });
@@ -152,6 +155,7 @@ export async function main(): Promise<number> {
     return 0;
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
+    fs.rmSync(isolatedHome, { recursive: true, force: true });
   }
 }
 

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -16,6 +16,7 @@ export function main(arguments_: string[] = process.argv.slice(2)): number {
   if (arguments_.some((argument) => argument !== "--npx")) throw new Error(`unknown argument: ${arguments_.find((argument) => argument !== "--npx")}`);
   run("node_modules/typescript/bin/tsc", "--noEmit");
   run("--import", "tsx", "scripts/build-skill-packages.ts", "--check");
+  run("--import", "tsx", "scripts/build-maintenance.ts");
   run("--import", "tsx", "scripts/run-tests.ts");
   for (const fixture of ["single-proactive", "shared-explicit"]) {
     run("--import", "tsx", "src/knowledge-loom/runner.ts", "audit", `tests/fixtures/${fixture}`);

--- a/src/maintenance/bundle.ts
+++ b/src/maintenance/bundle.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+export const SKILLS = ["use-knowledge-vault", "init-knowledge-vault", "audit-knowledge-vault", "manage-current-focus"] as const;
+
+/** Hash the complete tree, including extra files; never follow release symlinks. */
+export function fingerprint(root: string): string {
+  const hash = createHash("sha256");
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const candidate = path.join(directory, entry.name);
+      hash.update(JSON.stringify(path.relative(root, candidate)));
+      if (entry.isDirectory()) { hash.update("directory"); visit(candidate); }
+      else if (entry.isFile()) { const contents = fs.readFileSync(candidate); hash.update(JSON.stringify(["file", contents.length, fs.statSync(candidate).mode & 0o777])); hash.update(contents); }
+      else throw new Error(`unsupported file in bundle: ${candidate}`);
+    }
+  };
+  visit(root);
+  return hash.digest("hex");
+}
+
+export function validateBundle(root: string): string {
+  const manifest: unknown = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
+  if (!manifest || typeof manifest !== "object" || !("version" in manifest) || typeof manifest.version !== "string" || !/^\d+\.\d+\.\d+$/.test(manifest.version)) throw new Error("invalid stable bundle version");
+  let runner: string | undefined;
+  for (const name of SKILLS) {
+    const skill = path.join(root, "skills", name);
+    fingerprint(skill);
+    for (const required of ["licenses/yaml.txt", ...(name === "init-knowledge-vault" || name === "audit-knowledge-vault" ? ["references/contract-schema.md"] : [])]) {
+      if (!fs.statSync(path.join(skill, required)).isFile()) throw new Error(`missing bundle file: ${required}`);
+    }
+    if (!fs.readFileSync(path.join(skill, "SKILL.md"), "utf8").includes(`name: ${name}`)) throw new Error(`invalid skill: ${name}`);
+    const script = path.join(skill, "scripts", "knowledge-loom.mjs");
+    const contents = fs.readFileSync(script, "utf8");
+    if (runner !== undefined && contents !== runner) throw new Error("incoherent bundle runners");
+    runner = contents;
+    if (spawnSync(process.execPath, ["--check", script], { timeout: 10_000 }).status !== 0) throw new Error("invalid bundle runner");
+    if (!fs.statSync(path.join(skill, "references", "protocol.md")).isFile()) throw new Error("missing protocol");
+  }
+  return manifest.version;
+}
+
+export function copyBundle(source: string, destination: string): void {
+  validateBundle(source);
+  fs.mkdirSync(destination, { recursive: true });
+  fs.copyFileSync(path.join(source, "package.json"), path.join(destination, "package.json"));
+  for (const name of SKILLS) fs.cpSync(path.join(source, "skills", name), path.join(destination, "skills", name), { recursive: true });
+  validateBundle(destination);
+}
+
+export interface Advisory { id: string; affectedVersions: string[]; message: string; url: string; }
+export function readAdvisories(root: string): Advisory[] {
+  const file = path.join(root, "data-integrity-advisories.json");
+  if (!fs.existsSync(file)) return [];
+  const data: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (!Array.isArray(data)) throw new Error("invalid data-integrity advisories");
+  return data.map((item: unknown) => {
+    if (!item || typeof item !== "object" || !("id" in item) || typeof item.id !== "string" || !("message" in item) || typeof item.message !== "string" || !("url" in item) || typeof item.url !== "string" || !item.url.startsWith("https://github.com/magickaichen/knowledge-loom/") || !("affectedVersions" in item) || !Array.isArray(item.affectedVersions) || !item.affectedVersions.every((version: unknown) => typeof version === "string" && /^\d+\.\d+\.\d+$/.test(version))) throw new Error("invalid data-integrity advisory");
+    return { id: item.id, message: item.message, url: item.url, affectedVersions: item.affectedVersions as string[] };
+  });
+}

--- a/src/maintenance/bundle.ts
+++ b/src/maintenance/bundle.ts
@@ -1,3 +1,4 @@
+import { isStableVersion } from "./version.js";
 import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
@@ -23,7 +24,7 @@ export function fingerprint(root: string): string {
 
 export function validateBundle(root: string): string {
   const manifest: unknown = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
-  if (!manifest || typeof manifest !== "object" || !("version" in manifest) || typeof manifest.version !== "string" || !/^\d+\.\d+\.\d+$/.test(manifest.version)) throw new Error("invalid stable bundle version");
+  if (!manifest || typeof manifest !== "object" || !("version" in manifest) || typeof manifest.version !== "string" || !isStableVersion(manifest.version)) throw new Error("invalid stable bundle version");
   let runner: string | undefined;
   for (const name of SKILLS) {
     const skill = path.join(root, "skills", name);
@@ -57,7 +58,7 @@ export function readAdvisories(root: string): Advisory[] {
   const data: unknown = JSON.parse(fs.readFileSync(file, "utf8"));
   if (!Array.isArray(data)) throw new Error("invalid data-integrity advisories");
   return data.map((item: unknown) => {
-    if (!item || typeof item !== "object" || !("id" in item) || typeof item.id !== "string" || !("message" in item) || typeof item.message !== "string" || !("url" in item) || typeof item.url !== "string" || !item.url.startsWith("https://github.com/magickaichen/knowledge-loom/") || !("affectedVersions" in item) || !Array.isArray(item.affectedVersions) || !item.affectedVersions.every((version: unknown) => typeof version === "string" && /^\d+\.\d+\.\d+$/.test(version))) throw new Error("invalid data-integrity advisory");
+    if (!item || typeof item !== "object" || !("id" in item) || typeof item.id !== "string" || !("message" in item) || typeof item.message !== "string" || !("url" in item) || typeof item.url !== "string" || !item.url.startsWith("https://github.com/magickaichen/knowledge-loom/") || !("affectedVersions" in item) || !Array.isArray(item.affectedVersions) || !item.affectedVersions.every((version: unknown) => typeof version === "string" && isStableVersion(version))) throw new Error("invalid data-integrity advisory");
     return { id: item.id, message: item.message, url: item.url, affectedVersions: item.affectedVersions as string[] };
   });
 }

--- a/src/maintenance/exchange.ts
+++ b/src/maintenance/exchange.ts
@@ -1,0 +1,34 @@
+import { runLockedProcess } from "../knowledge-loom/vault-lock.js";
+
+export type TrackWriter = (pid: number, group?: boolean) => void;
+
+// Node cannot atomically replace a directory with a symlink. Use the OS exchange
+// primitive through Python's standard-library FFI, only during explicit adoption.
+// There is deliberately no two-rename fallback on unsupported filesystems.
+const EXCHANGE = `
+import ctypes, os, sys
+libc = ctypes.CDLL(None, use_errno=True)
+a, b = os.fsencode(sys.argv[1]), os.fsencode(sys.argv[2])
+if sys.platform == 'darwin':
+    fn = libc.renamex_np
+    fn.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
+    result = fn(a, b, 2)
+elif sys.platform.startswith('linux'):
+    fn = libc.renameat2
+    fn.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+    result = fn(-100, a, -100, b, 2)
+else:
+    raise RuntimeError('atomic adoption requires macOS or Linux')
+if result != 0:
+    error = ctypes.get_errno()
+    raise OSError(error, os.strerror(error))
+`;
+
+export async function exchangeInstallation(root: string, target: string, backup: string, trackWriter: TrackWriter): Promise<void> {
+  let diagnostic = "";
+  const status = await runLockedProcess(root, "python3", ["-c", EXCHANGE, target, backup], trackWriter, {
+    timeoutMs: 10_000,
+    stderr: { write(message: string) { diagnostic += message; } },
+  });
+  if (status !== 0) throw new Error(`atomic adoption unavailable; original installation preserved: ${diagnostic.trim()}`);
+}

--- a/src/maintenance/maintenance.ts
+++ b/src/maintenance/maintenance.ts
@@ -1,0 +1,231 @@
+import { spawnSync } from "node:child_process";
+import { withVaultLock } from "../knowledge-loom/vault-lock.js";
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { githubReleases, type ReleaseSource } from "./releases.js";
+import { copyBundle, readAdvisories, type Advisory, fingerprint, SKILLS, validateBundle } from "./bundle.js";
+
+export interface MaintenanceOptions {
+  command: "bootstrap" | "status" | "use";
+  home: string;
+  source?: string;
+  bootstrapRunner?: string;
+  targets?: string[];
+  loadedVersion?: string;
+  pin?: string;
+  lockWaitMs?: number;
+}
+interface InstallationLink { target: string; backup: string; route: "copy" | "symlink" | "skills-cli"; }
+interface Recovery { attempts: number; retryAt: number; error: string; }
+interface Pending { advisories: Advisory[]; bundle: string; installedVersion: string; installedRevision: string; fingerprints: Record<string, string>; lastCheck: number; }
+interface State {
+  checkRequested?: boolean;
+  attempt?: number;
+  advisories?: Advisory[];
+  adopting?: boolean;
+  pending?: Pending;
+  recovery?: Recovery;
+  schema: 1;
+  installedRevision?: string;
+  lastCheck?: number;
+  pin?: string;
+  links: InstallationLink[];
+  installedVersion: string;
+  bundle: string;
+  fingerprints: Record<string, string>;
+}
+export interface MaintenanceResult {
+  installations?: InstallationLink[];
+  advisories?: Advisory[];
+  restartRequired?: false;
+  status: string;
+  installedVersion: string;
+  loadedVersion: string;
+  entryPoint: string;
+  installedRevision?: string;
+  lastCheck?: number;
+  recovery?: Recovery;
+}
+function save(file: string, value: unknown): void {
+  const temporary = `${file}.${randomUUID()}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(value, null, 2));
+  fs.renameSync(temporary, file);
+}
+function installationRoute(target: string): InstallationLink["route"] {
+  let directory = path.dirname(target);
+  while (true) {
+    for (const file of ["skills-lock.json", ".skill-lock.json"]) {
+      const candidate = path.join(directory, file);
+      if (!fs.existsSync(candidate)) continue;
+      const metadata: unknown = JSON.parse(fs.readFileSync(candidate, "utf8"));
+      if (metadata && typeof metadata === "object" && "skills" in metadata && metadata.skills && typeof metadata.skills === "object" && path.basename(target) in metadata.skills) return "skills-cli";
+    }
+    const parent = path.dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+  return fs.lstatSync(target).isSymbolicLink() ? "symlink" : "copy";
+}
+function finishAdoption(root: string, state: State): void {
+  const current = path.join(root, "current");
+  if (!fs.lstatSync(current, { throwIfNoEntry: false })) fs.symlinkSync(state.bundle, current);
+  else if (fs.realpathSync(current) !== state.bundle) throw new Error("unexpected bootstrap pointer");
+  for (const link of state.links) {
+    const expected = path.join(root, "current", "skills", path.basename(link.target));
+    const existing = fs.lstatSync(link.target, { throwIfNoEntry: false });
+    if (existing?.isSymbolicLink() && fs.readlinkSync(link.target) === expected) continue;
+    if (existing) {
+      if (fs.lstatSync(link.backup, { throwIfNoEntry: false }) || fingerprint(link.target) !== state.fingerprints[path.basename(link.target)]) throw new Error(`local modification during adoption: ${link.target}`);
+      fs.mkdirSync(path.dirname(link.backup), { recursive: true });
+      fs.renameSync(link.target, link.backup);
+    } else if (!fs.lstatSync(link.backup, { throwIfNoEntry: false })) throw new Error(`missing adoption source: ${link.target}`);
+    fs.symlinkSync(expected, link.target);
+  }
+  delete state.adopting;
+}
+export interface MaintenancePorts { releases?: ReleaseSource; now?: () => number; }
+export async function maintain(options: MaintenanceOptions, ports: MaintenancePorts = {}): Promise<MaintenanceResult> {
+  const root = path.join(fs.realpathSync(options.home), ".local", "share", "knowledge-loom");
+  if (options.command !== "bootstrap" && !fs.existsSync(root)) return { status: "not-bootstrapped", installedVersion: "unknown", loadedVersion: options.loadedVersion ?? "unknown", entryPoint: path.join(root, "maintenance.cjs") };
+  fs.mkdirSync(root, { recursive: true });
+  const lock = path.join(root, "lock.git");
+  if (!fs.existsSync(path.join(lock, "HEAD")) && spawnSync("git", ["init", "--bare", lock], { timeout: 10_000 }).status !== 0) throw new Error("cannot initialize installation lock");
+  const acquired = await withVaultLock(lock, async () => maintainLocked(options, ports), options.lockWaitMs ?? 2_000);
+  if (!acquired.acquired) return { status: "busy", installedVersion: "unknown", loadedVersion: options.loadedVersion ?? "unknown", entryPoint: path.join(root, "maintenance.cjs") };
+  return acquired.value;
+}
+async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePorts): Promise<MaintenanceResult> {
+  const root = path.join(fs.realpathSync(options.home), ".local", "share", "knowledge-loom");
+  const entryPoint = path.join(root, "maintenance.cjs");
+  const stateFile = path.join(root, "state.json");
+  const result = (status: string, version: string): MaintenanceResult => ({ status, installedVersion: version, loadedVersion: options.loadedVersion ?? "unknown", entryPoint });
+  if (options.command === "bootstrap" && !fs.existsSync(stateFile)) {
+    if (!options.source || !options.targets?.length) throw new Error("bootstrap requires source and targets");
+    const version = validateBundle(options.source);
+    const links: InstallationLink[] = [];
+    for (const directory of options.targets) {
+      for (const name of SKILLS) {
+        const target = path.join(fs.realpathSync(directory), name);
+        const canonical = fs.realpathSync(target);
+        if (/[\\/](?:\.codex|\.claude)[\\/]plugins[\\/]/.test(canonical)) throw new Error(`plugin installation requires its owner to update: ${target}`);
+        if (fingerprint(target) !== fingerprint(path.join(options.source, "skills", name))) throw new Error(`local modification collision: ${target}`);
+        links.push({ target, backup: path.join(root, "backups", String(links.length), name), route: installationRoute(target) });
+
+      }
+    }
+    fs.mkdirSync(root, { recursive: true });
+    const bundle = path.join(root, "bundles", randomUUID());
+    copyBundle(options.source, bundle);
+    const runnerSource = options.bootstrapRunner ?? path.join(options.source, "dist", "maintenance.cjs");
+    const temporaryRunner = `${entryPoint}.${randomUUID()}.tmp.cjs`;
+    fs.copyFileSync(runnerSource, temporaryRunner);
+    if (spawnSync(process.execPath, [temporaryRunner, "--help"], { timeout: 10_000 }).status !== 0) throw new Error("external entry point verification failed");
+    fs.renameSync(temporaryRunner, entryPoint);
+    const fingerprints = Object.fromEntries(SKILLS.map((name) => [name, fingerprint(path.join(bundle, "skills", name))]));
+    const state: State = { schema: 1, adopting: true, links, installedVersion: version, bundle, fingerprints };
+    save(stateFile, state);
+    finishAdoption(root, state);
+    save(stateFile, state);
+    return { ...result("bootstrapped", version), installations: links };
+  }
+  if (!fs.existsSync(stateFile)) return result("not-bootstrapped", "unknown");
+  const state = JSON.parse(fs.readFileSync(stateFile, "utf8")) as State;
+  let recovered = false;
+  if (state.adopting) {
+    finishAdoption(root, state);
+    save(stateFile, state);
+    recovered = true;
+  }
+  if (state.pending) {
+    const current = fs.realpathSync(path.join(root, "current"));
+    if (current === state.pending.bundle) {
+      Object.assign(state, state.pending);
+      delete state.recovery;
+      delete state.checkRequested;
+    } else if (current !== state.bundle) throw new Error("unrecognized current bundle; recovery requires inspection");
+    delete state.pending;
+    delete state.attempt;
+    save(stateFile, state);
+    recovered = true;
+  }
+  if (state.attempt !== undefined) {
+    state.recovery = { attempts: 1, retryAt: (ports.now ?? Date.now)() + 60_000, error: "interrupted release check or staging; previous bundle retained" };
+    delete state.attempt;
+    save(stateFile, state);
+    recovered = true;
+  }
+  const report = (status: string): MaintenanceResult => {
+    const installed = state.pending && fs.realpathSync(path.join(root, "current")) === state.pending.bundle ? state.pending : state;
+    return {
+      ...result(status, installed.installedVersion),
+      restartRequired: false,
+      installations: state.links,
+      advisories: (installed.advisories ?? []).filter((advisory) => advisory.affectedVersions.includes(installed.installedVersion) || (options.loadedVersion !== undefined && advisory.affectedVersions.includes(options.loadedVersion))),
+      ...(installed.installedRevision ? { installedRevision: installed.installedRevision } : {}),
+      ...(state.lastCheck !== undefined ? { lastCheck: state.lastCheck } : {}),
+      ...(state.recovery ? { recovery: state.recovery } : {}),
+    };
+  };
+  if (options.command === "status" || options.command === "bootstrap") return report(recovered ? "recovered" : "ready");
+  const now = (ports.now ?? Date.now)();
+  if (options.pin !== undefined && options.pin !== (state.pin ?? "none")) {
+    if (!/^\d+\.\d+\.\d+$/.test(options.pin) && options.pin !== "none") throw new Error("pin must be a stable version or none");
+    if (options.pin === "none") delete state.pin;
+    else state.pin = options.pin;
+    state.checkRequested = true;
+    save(stateFile, state);
+  }
+  if (state.recovery && now < state.recovery.retryAt) return report("backoff");
+  try {
+  if (!state.checkRequested && state.lastCheck !== undefined && now - state.lastCheck < 604_800_000) return report("not-due");
+  state.attempt = now;
+  save(stateFile, state);
+  const releases = ports.releases ?? githubReleases;
+  const stable = (await releases.list()).filter((release) => release.published && !release.prerelease && /^\d+\.\d+\.\d+$/.test(release.version));
+  const compare = (a: string, b: string): number => {
+    const left = a.split(".").map(Number), right = b.split(".").map(Number);
+    for (let index = 0; index < 3; index++) if (left[index] !== right[index]) return left[index]! - right[index]!;
+    return 0;
+  };
+  let selected = state.pin ? stable.find((release) => release.version === state.pin) : stable.sort((a, b) => compare(b.version, a.version))[0];
+  if (!selected) throw new Error("no matching published stable release");
+  if (selected.version === state.installedVersion || (!state.pin && compare(selected.version, state.installedVersion) < 0)) {
+    delete state.attempt;
+    delete state.recovery;
+    delete state.checkRequested;
+    state.lastCheck = (ports.now ?? Date.now)();
+    save(stateFile, state);
+    return report("current");
+  }
+  if (releases.resolve) selected = await releases.resolve(selected);
+  if (!/^[a-f0-9]{40}$/.test(selected.revision)) throw new Error("release must resolve to a specific revision");
+  const staged = path.join(root, "bundles", randomUUID());
+  fs.mkdirSync(staged, { recursive: true });
+  await releases.stage(selected, staged);
+  if (validateBundle(staged) !== selected.version) throw new Error("release version mismatch");
+  for (const link of state.links) {
+    const name = path.basename(link.target);
+    if (!fs.lstatSync(link.target).isSymbolicLink() || fs.readlinkSync(link.target) !== path.join(root, "current", "skills", name) || fingerprint(link.target) !== state.fingerprints[name]) throw new Error(`local modification collision: ${link.target}`);
+  }
+  state.pending = { advisories: readAdvisories(staged), bundle: staged, installedVersion: selected.version, installedRevision: selected.revision, fingerprints: Object.fromEntries(SKILLS.map((name) => [name, fingerprint(path.join(staged, "skills", name))])), lastCheck: (ports.now ?? Date.now)() };
+  save(stateFile, state);
+  const pointer = path.join(root, `current.${randomUUID()}`);
+  fs.symlinkSync(staged, pointer);
+  fs.renameSync(pointer, path.join(root, "current"));
+  Object.assign(state, state.pending);
+  delete state.pending;
+  delete state.attempt;
+  delete state.recovery;
+  delete state.checkRequested;
+  state.lastCheck = (ports.now ?? Date.now)();
+  save(stateFile, state);
+  return report("updated");
+  } catch (error) {
+    delete state.attempt;
+    const attempts = Math.min((state.recovery?.attempts ?? 0) + 1, 10);
+    state.recovery = { attempts, retryAt: now + Math.min(60_000 * 2 ** (attempts - 1), 21_600_000), error: error instanceof Error ? error.message : String(error) };
+    save(stateFile, state);
+    return report("failed");
+  }
+}

--- a/src/maintenance/maintenance.ts
+++ b/src/maintenance/maintenance.ts
@@ -1,3 +1,5 @@
+import { isStableVersion, compareVersions } from "./version.js";
+import { exchangeInstallation, type TrackWriter } from "./exchange.js";
 import { spawnSync } from "node:child_process";
 import { withVaultLock } from "../knowledge-loom/vault-lock.js";
 import fs from "node:fs";
@@ -16,7 +18,7 @@ export interface MaintenanceOptions {
   pin?: string;
   lockWaitMs?: number;
 }
-interface InstallationLink { target: string; backup: string; route: "copy" | "symlink" | "skills-cli"; }
+interface InstallationLink { originalLink?: string; target: string; backup: string; route: "copy" | "symlink" | "skills-cli"; }
 interface Recovery { attempts: number; retryAt: number; error: string; }
 interface Pending { advisories: Advisory[]; bundle: string; installedVersion: string; installedRevision: string; fingerprints: Record<string, string>; lastCheck: number; }
 interface State {
@@ -67,7 +69,7 @@ function installationRoute(target: string): InstallationLink["route"] {
   }
   return fs.lstatSync(target).isSymbolicLink() ? "symlink" : "copy";
 }
-function finishAdoption(root: string, state: State): void {
+async function finishAdoption(root: string, state: State, trackWriter: TrackWriter): Promise<void> {
   const current = path.join(root, "current");
   if (!fs.lstatSync(current, { throwIfNoEntry: false })) fs.symlinkSync(state.bundle, current);
   else if (fs.realpathSync(current) !== state.bundle) throw new Error("unexpected bootstrap pointer");
@@ -75,12 +77,14 @@ function finishAdoption(root: string, state: State): void {
     const expected = path.join(root, "current", "skills", path.basename(link.target));
     const existing = fs.lstatSync(link.target, { throwIfNoEntry: false });
     if (existing?.isSymbolicLink() && fs.readlinkSync(link.target) === expected) continue;
-    if (existing) {
-      if (fs.lstatSync(link.backup, { throwIfNoEntry: false }) || fingerprint(link.target) !== state.fingerprints[path.basename(link.target)]) throw new Error(`local modification during adoption: ${link.target}`);
+    if (!existing || fingerprint(link.target) !== state.fingerprints[path.basename(link.target)] || (existing.isSymbolicLink() ? fs.readlinkSync(link.target) : undefined) !== link.originalLink) throw new Error(`local modification during adoption: ${link.target}`);
+    const prepared = fs.lstatSync(link.backup, { throwIfNoEntry: false });
+    if (prepared && (!prepared.isSymbolicLink() || fs.readlinkSync(link.backup) !== expected)) throw new Error(`adoption backup collision: ${link.backup}`);
+    if (!prepared) {
       fs.mkdirSync(path.dirname(link.backup), { recursive: true });
-      fs.renameSync(link.target, link.backup);
-    } else if (!fs.lstatSync(link.backup, { throwIfNoEntry: false })) throw new Error(`missing adoption source: ${link.target}`);
-    fs.symlinkSync(expected, link.target);
+      fs.symlinkSync(expected, link.backup);
+    }
+    await exchangeInstallation(root, link.target, link.backup, trackWriter);
   }
   delete state.adopting;
 }
@@ -91,17 +95,18 @@ export async function maintain(options: MaintenanceOptions, ports: MaintenancePo
   fs.mkdirSync(root, { recursive: true });
   const lock = path.join(root, "lock.git");
   if (!fs.existsSync(path.join(lock, "HEAD")) && spawnSync("git", ["init", "--bare", lock], { timeout: 10_000 }).status !== 0) throw new Error("cannot initialize installation lock");
-  const acquired = await withVaultLock(lock, async () => maintainLocked(options, ports), options.lockWaitMs ?? 2_000);
+  const acquired = await withVaultLock(lock, async (trackWriter) => maintainLocked(options, ports, trackWriter), options.lockWaitMs ?? 2_000);
   if (!acquired.acquired) return { status: "busy", installedVersion: "unknown", loadedVersion: options.loadedVersion ?? "unknown", entryPoint: path.join(root, "maintenance.cjs") };
   return acquired.value;
 }
-async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePorts): Promise<MaintenanceResult> {
+async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePorts, trackWriter: TrackWriter): Promise<MaintenanceResult> {
   const root = path.join(fs.realpathSync(options.home), ".local", "share", "knowledge-loom");
   const entryPoint = path.join(root, "maintenance.cjs");
   const stateFile = path.join(root, "state.json");
   const result = (status: string, version: string): MaintenanceResult => ({ status, installedVersion: version, loadedVersion: options.loadedVersion ?? "unknown", entryPoint });
   if (options.command === "bootstrap" && !fs.existsSync(stateFile)) {
     if (!options.source || !options.targets?.length) throw new Error("bootstrap requires source and targets");
+    if (spawnSync("python3", ["--version"], { timeout: 10_000 }).status !== 0) throw new Error("bootstrap requires Python 3 for atomic adoption");
     const version = validateBundle(options.source);
     const links: InstallationLink[] = [];
     for (const directory of options.targets) {
@@ -110,7 +115,7 @@ async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePor
         const canonical = fs.realpathSync(target);
         if (/[\\/](?:\.codex|\.claude)[\\/]plugins[\\/]/.test(canonical)) throw new Error(`plugin installation requires its owner to update: ${target}`);
         if (fingerprint(target) !== fingerprint(path.join(options.source, "skills", name))) throw new Error(`local modification collision: ${target}`);
-        links.push({ target, backup: path.join(root, "backups", String(links.length), name), route: installationRoute(target) });
+        links.push({ target, backup: path.join(root, "backups", String(links.length), name), route: installationRoute(target), ...(fs.lstatSync(target).isSymbolicLink() ? { originalLink: fs.readlinkSync(target) } : {}) });
 
       }
     }
@@ -125,7 +130,7 @@ async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePor
     const fingerprints = Object.fromEntries(SKILLS.map((name) => [name, fingerprint(path.join(bundle, "skills", name))]));
     const state: State = { schema: 1, adopting: true, links, installedVersion: version, bundle, fingerprints };
     save(stateFile, state);
-    finishAdoption(root, state);
+    await finishAdoption(root, state, trackWriter);
     save(stateFile, state);
     return { ...result("bootstrapped", version), installations: links };
   }
@@ -133,7 +138,7 @@ async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePor
   const state = JSON.parse(fs.readFileSync(stateFile, "utf8")) as State;
   let recovered = false;
   if (state.adopting) {
-    finishAdoption(root, state);
+    await finishAdoption(root, state, trackWriter);
     save(stateFile, state);
     recovered = true;
   }
@@ -170,7 +175,7 @@ async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePor
   if (options.command === "status" || options.command === "bootstrap") return report(recovered ? "recovered" : "ready");
   const now = (ports.now ?? Date.now)();
   if (options.pin !== undefined && options.pin !== (state.pin ?? "none")) {
-    if (!/^\d+\.\d+\.\d+$/.test(options.pin) && options.pin !== "none") throw new Error("pin must be a stable version or none");
+    if (!isStableVersion(options.pin) && options.pin !== "none") throw new Error("pin must be a stable version or none");
     if (options.pin === "none") delete state.pin;
     else state.pin = options.pin;
     state.checkRequested = true;
@@ -178,49 +183,49 @@ async function maintainLocked(options: MaintenanceOptions, ports: MaintenancePor
   }
   if (state.recovery && now < state.recovery.retryAt) return report("backoff");
   try {
-  if (!state.checkRequested && state.lastCheck !== undefined && now - state.lastCheck < 604_800_000) return report("not-due");
-  state.attempt = now;
-  save(stateFile, state);
-  const releases = ports.releases ?? githubReleases;
-  const stable = (await releases.list()).filter((release) => release.published && !release.prerelease && /^\d+\.\d+\.\d+$/.test(release.version));
-  const compare = (a: string, b: string): number => {
-    const left = a.split(".").map(Number), right = b.split(".").map(Number);
-    for (let index = 0; index < 3; index++) if (left[index] !== right[index]) return left[index]! - right[index]!;
-    return 0;
-  };
-  let selected = state.pin ? stable.find((release) => release.version === state.pin) : stable.sort((a, b) => compare(b.version, a.version))[0];
-  if (!selected) throw new Error("no matching published stable release");
-  if (selected.version === state.installedVersion || (!state.pin && compare(selected.version, state.installedVersion) < 0)) {
+    if (!state.checkRequested && state.lastCheck !== undefined && now - state.lastCheck < 604_800_000) return report("not-due");
+    state.attempt = now;
+    save(stateFile, state);
+    const releases = ports.releases ?? githubReleases;
+    const stable = (await releases.list()).filter((release) => release.published && !release.prerelease && isStableVersion(release.version));
+    let selected = state.pin ? stable.find((release) => release.version === state.pin) : stable.sort((a, b) => compareVersions(b.version, a.version))[0];
+    if (!selected) throw new Error("no matching published stable release");
+    if (releases.resolve) selected = await releases.resolve(selected);
+    if (!/^[a-f0-9]{40}$/.test(selected.revision)) throw new Error("release must resolve to a specific revision");
+    const staged = path.join(root, "bundles", randomUUID());
+    fs.mkdirSync(staged, { recursive: true });
+    await releases.stage(selected, staged);
+    if (validateBundle(staged) !== selected.version) throw new Error("release version mismatch");
+    const advisories = readAdvisories(staged);
+    if (selected.version === state.installedVersion || (!state.pin && compareVersions(selected.version, state.installedVersion) < 0)) {
+      const sameBundle = selected.version === state.installedVersion && SKILLS.every((name) => fingerprint(path.join(staged, "skills", name)) === fingerprint(path.join(state.bundle, "skills", name)));
+      fs.rmSync(staged, { recursive: true, force: true });
+      state.advisories = advisories;
+      if (sameBundle) state.installedRevision = selected.revision;
+      delete state.attempt;
+      delete state.recovery;
+      delete state.checkRequested;
+      state.lastCheck = (ports.now ?? Date.now)();
+      save(stateFile, state);
+      return report("current");
+    }
+    for (const link of state.links) {
+      const name = path.basename(link.target);
+      if (!fs.lstatSync(link.target).isSymbolicLink() || fs.readlinkSync(link.target) !== path.join(root, "current", "skills", name) || fingerprint(link.target) !== state.fingerprints[name]) throw new Error(`local modification collision: ${link.target}`);
+    }
+    state.pending = { advisories, bundle: staged, installedVersion: selected.version, installedRevision: selected.revision, fingerprints: Object.fromEntries(SKILLS.map((name) => [name, fingerprint(path.join(staged, "skills", name))])), lastCheck: (ports.now ?? Date.now)() };
+    save(stateFile, state);
+    const pointer = path.join(root, `current.${randomUUID()}`);
+    fs.symlinkSync(staged, pointer);
+    fs.renameSync(pointer, path.join(root, "current"));
+    Object.assign(state, state.pending);
+    delete state.pending;
     delete state.attempt;
     delete state.recovery;
     delete state.checkRequested;
     state.lastCheck = (ports.now ?? Date.now)();
     save(stateFile, state);
-    return report("current");
-  }
-  if (releases.resolve) selected = await releases.resolve(selected);
-  if (!/^[a-f0-9]{40}$/.test(selected.revision)) throw new Error("release must resolve to a specific revision");
-  const staged = path.join(root, "bundles", randomUUID());
-  fs.mkdirSync(staged, { recursive: true });
-  await releases.stage(selected, staged);
-  if (validateBundle(staged) !== selected.version) throw new Error("release version mismatch");
-  for (const link of state.links) {
-    const name = path.basename(link.target);
-    if (!fs.lstatSync(link.target).isSymbolicLink() || fs.readlinkSync(link.target) !== path.join(root, "current", "skills", name) || fingerprint(link.target) !== state.fingerprints[name]) throw new Error(`local modification collision: ${link.target}`);
-  }
-  state.pending = { advisories: readAdvisories(staged), bundle: staged, installedVersion: selected.version, installedRevision: selected.revision, fingerprints: Object.fromEntries(SKILLS.map((name) => [name, fingerprint(path.join(staged, "skills", name))])), lastCheck: (ports.now ?? Date.now)() };
-  save(stateFile, state);
-  const pointer = path.join(root, `current.${randomUUID()}`);
-  fs.symlinkSync(staged, pointer);
-  fs.renameSync(pointer, path.join(root, "current"));
-  Object.assign(state, state.pending);
-  delete state.pending;
-  delete state.attempt;
-  delete state.recovery;
-  delete state.checkRequested;
-  state.lastCheck = (ports.now ?? Date.now)();
-  save(stateFile, state);
-  return report("updated");
+    return report("updated");
   } catch (error) {
     delete state.attempt;
     const attempts = Math.min((state.recovery?.attempts ?? 0) + 1, 10);

--- a/src/maintenance/releases.ts
+++ b/src/maintenance/releases.ts
@@ -1,3 +1,4 @@
+import { isStableVersion } from "./version.js";
 import fs from "node:fs";
 import path from "node:path";
 import { unzipSync } from "fflate";
@@ -43,7 +44,7 @@ export const githubReleases: ReleaseSource = {
       if (!Array.isArray(data)) throw new Error("invalid release listing");
       for (const item of data) {
         const release = record(item);
-        if (typeof release.tag_name !== "string" || !/^v\d+\.\d+\.\d+$/.test(release.tag_name)) continue;
+        if (typeof release.tag_name !== "string" || (!release.tag_name.startsWith("v") || !isStableVersion(release.tag_name.slice(1)))) continue;
         releases.push({ version: release.tag_name.slice(1), revision: "", published: release.draft === false && typeof release.published_at === "string", prerelease: release.prerelease !== false });
       }
       if (data.length < 100) return releases;

--- a/src/maintenance/releases.ts
+++ b/src/maintenance/releases.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+import { unzipSync } from "fflate";
+import { SKILLS } from "./bundle.js";
+
+export interface Release { version: string; revision: string; published: boolean; prerelease: boolean; }
+export interface ReleaseSource {
+  list(): Promise<Release[]>;
+  resolve?(release: Release): Promise<Release>;
+  stage(release: Release, destination: string): Promise<void>;
+}
+const REPOSITORY = "magickaichen/knowledge-loom";
+async function download(url: string): Promise<Uint8Array> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000), headers: { Accept: "application/vnd.github+json" } });
+  if (!response.ok) throw new Error(`release request failed: HTTP ${response.status}`);
+  if (!response.body) throw new Error("empty release response");
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.length;
+      if (size > 32 * 1024 * 1024) throw new Error("release response exceeds 32 MiB");
+      chunks.push(value);
+    }
+  } finally { await reader.cancel(); }
+  return Buffer.concat(chunks);
+}
+async function json(endpoint: string): Promise<unknown> {
+  return JSON.parse(Buffer.from(await download(`https://api.github.com/repos/${REPOSITORY}/${endpoint}`)).toString("utf8"));
+}
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("invalid release response");
+  return value as Record<string, unknown>;
+}
+export const githubReleases: ReleaseSource = {
+  async list() {
+    const releases: Release[] = [];
+    for (let page = 1; page <= 10; page++) {
+      const data = await json(`releases?per_page=100&page=${page}`);
+      if (!Array.isArray(data)) throw new Error("invalid release listing");
+      for (const item of data) {
+        const release = record(item);
+        if (typeof release.tag_name !== "string" || !/^v\d+\.\d+\.\d+$/.test(release.tag_name)) continue;
+        releases.push({ version: release.tag_name.slice(1), revision: "", published: release.draft === false && typeof release.published_at === "string", prerelease: release.prerelease !== false });
+      }
+      if (data.length < 100) return releases;
+    }
+    throw new Error("release listing exceeds pagination limit");
+  },
+  async resolve(release) {
+    let reference = record(await json(`git/ref/tags/v${release.version}`));
+    for (let depth = 0; depth < 8; depth++) {
+      const object = record(reference.object);
+      if (typeof object.sha !== "string" || !/^[a-f0-9]{40}$/.test(object.sha)) throw new Error("invalid release revision");
+      if (object.type === "commit") return { ...release, revision: object.sha };
+      if (object.type !== "tag") throw new Error("release tag does not point to a commit");
+      reference = record(await json(`git/tags/${object.sha}`));
+    }
+    throw new Error("release tag nesting exceeds limit");
+  },
+  async stage(release, destination) {
+    if (!/^[a-f0-9]{40}$/.test(release.revision)) throw new Error("release must resolve to a specific revision");
+    const prefix = `knowledge-loom-${release.revision}/`;
+    let expanded = 0;
+    const files = unzipSync(await download(`https://codeload.github.com/${REPOSITORY}/zip/${release.revision}`), {
+      filter(file) {
+        if (!file.name.startsWith(prefix)) return false;
+        const relative = file.name.slice(prefix.length);
+        const allowed = relative === "package.json" || relative === "data-integrity-advisories.json" || SKILLS.some((name) => relative.startsWith(`skills/${name}/`));
+        if (!allowed || file.name.endsWith("/")) return false;
+        if (relative.split("/").some((part) => part === ".." || part === "." || part.includes("\\"))) throw new Error("unsafe release path");
+        expanded += file.originalSize;
+        if (expanded > 64 * 1024 * 1024) throw new Error("expanded release exceeds 64 MiB");
+        return true;
+      },
+    });
+    for (const [name, contents] of Object.entries(files)) {
+      const target = path.join(destination, name.slice(prefix.length));
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, contents);
+      if (target.endsWith("/scripts/knowledge-loom.mjs")) fs.chmodSync(target, 0o755);
+    }
+  },
+};

--- a/src/maintenance/runner.ts
+++ b/src/maintenance/runner.ts
@@ -1,0 +1,27 @@
+import os from "node:os";
+import { maintain, type MaintenanceOptions } from "./maintenance.js";
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "--help") {
+    console.log("maintenance bootstrap --source PATH --target PATH [--target PATH] [--home PATH]\nmaintenance status|use [--home PATH] [--loaded-version VERSION] [--pin VERSION|none]");
+    return;
+  }
+  if (command !== "bootstrap" && command !== "status" && command !== "use") throw new Error("expected bootstrap, status, or use; see --help");
+  const options: MaintenanceOptions = { command, home: os.homedir(), bootstrapRunner: process.argv[1]! };
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!value) throw new Error(`missing value: ${flag}`);
+    if (flag === "--home") options.home = value;
+    else if (flag === "--source") options.source = value;
+    else if (flag === "--target") (options.targets ??= []).push(value);
+    else if (flag === "--pin") options.pin = value;
+    else if (flag === "--loaded-version") options.loadedVersion = value;
+    else throw new Error(`unknown option: ${flag}`);
+  }
+  const result = await maintain(options);
+  console.log(JSON.stringify(result, null, 2));
+  if (["failed", "backoff", "busy", "not-bootstrapped"].includes(result.status)) process.exitCode = 1;
+}
+main().catch((error: unknown) => { console.error(error instanceof Error ? error.message : String(error)); process.exitCode = 1; });

--- a/src/maintenance/version.ts
+++ b/src/maintenance/version.ts
@@ -1,0 +1,18 @@
+/** Stable releases use canonical SemVer core numbers, bounded to exact JS integers. */
+export function parseStableVersion(value: unknown): readonly [number, number, number] | undefined {
+  if (typeof value !== "string" || !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(value)) return undefined;
+  const parts = value.split(".").map(Number);
+  if (!parts.every(Number.isSafeInteger)) return undefined;
+  return [parts[0]!, parts[1]!, parts[2]!];
+}
+
+export function isStableVersion(value: unknown): value is string {
+  return parseStableVersion(value) !== undefined;
+}
+
+export function compareVersions(a: string, b: string): number {
+  const left = parseStableVersion(a), right = parseStableVersion(b);
+  if (!left || !right) throw new Error("invalid stable version");
+  for (const index of [0, 1, 2] as const) if (left[index] !== right[index]) return left[index] - right[index];
+  return 0;
+}

--- a/tests/maintenance.test.ts
+++ b/tests/maintenance.test.ts
@@ -3,15 +3,29 @@ import { spawn, spawnSync } from "node:child_process";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 
 import { maintain } from "../src/maintenance/maintenance.ts";
 import { PACKAGE_ROOT, temporaryDirectory } from "./helpers.ts";
 
-test("explicit bootstrap keeps old skills usable through an external entry point", async (t) => {
+function installationFiles(t: TestContext): { home: string; target: string } {
   const home = temporaryDirectory(t);
   const target = path.join(home, ".agents", "skills");
   fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  return { home, target };
+}
+async function bootstrapInstallation(t: TestContext): Promise<{ home: string; target: string }> {
+  const installation = installationFiles(t);
+  await maintain({ command: "bootstrap", ...installation, source: PACKAGE_ROOT, targets: [installation.target] });
+  return installation;
+}
+async function stageRelease(release: { version: string }, destination: string): Promise<void> {
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+  fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+}
+
+test("explicit bootstrap keeps old skills usable through an external entry point", async (t) => {
+  const { home, target } = installationFiles(t);
   const result = await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
   assert.equal(result.status, "bootstrapped");
   assert.equal(result.installedVersion, "0.8.0");
@@ -23,10 +37,7 @@ test("explicit bootstrap keeps old skills usable through an external entry point
 });
 
 test("due use selects only published stable revisions at the elapsed weekly boundary", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   let lookups = 0;
   let now = Date.UTC(2026, 0, 1);
   const releases = {
@@ -35,10 +46,7 @@ test("due use selects only published stable revisions at the elapsed weekly boun
       { version: "1.0.0", revision: "b".repeat(40), published: true, prerelease: true },
       { version: "2.0.0", revision: "c".repeat(40), published: false, prerelease: false },
     ]; },
-    async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
-    },
+    stage: stageRelease,
   };
   const ports = { releases, now: () => now };
   const first = await maintain({ command: "use", home, loadedVersion: "0.8.0" }, ports);
@@ -54,17 +62,11 @@ test("due use selects only published stable revisions at the elapsed weekly boun
 });
 
 test("two runtime callers share one due lookup and installation", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   let lookups = 0;
   const ports = { releases: {
     async list() { lookups++; await new Promise((resolve) => setTimeout(resolve, 50)); return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
-    async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
-    },
+    stage: stageRelease,
   } };
   const results = await Promise.all([maintain({ command: "use", home }, ports), maintain({ command: "use", home }, ports)]);
   assert.deepEqual(results.map((result) => result.status).sort(), ["not-due", "updated"]);
@@ -72,10 +74,7 @@ test("two runtime callers share one due lookup and installation", async (t) => {
 });
 
 test("failed lookups retain last observation and back off durably", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   let now = Date.UTC(2026, 0, 1);
   let lookups = 0;
   const ports = { now: () => now, releases: {
@@ -95,9 +94,7 @@ test("failed lookups retain last observation and back off durably", async (t) =>
 });
 
 test("local edits block the whole update while manager bookkeeping and other skills survive", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const { home, target } = installationFiles(t);
   const bookkeeping = path.join(home, ".agents", ".skill-lock.json");
   fs.writeFileSync(bookkeeping, '{"version":3,"skills":{"unrelated":{"hash":"keep"}}}');
   fs.mkdirSync(path.join(target, "unrelated"));
@@ -107,10 +104,7 @@ test("local edits block the whole update while manager bookkeeping and other ski
   fs.appendFileSync(edited, "\nLocal instruction\n");
   const ports = { releases: {
     async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
-    async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
-    },
+    stage: stageRelease,
   } };
   const result = await maintain({ command: "use", home }, ports);
   assert.equal(result.status, "failed");
@@ -122,10 +116,7 @@ test("local edits block the whole update while manager bookkeeping and other ski
 });
 
 test("interruption after the atomic switch recovers the complete new bundle", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   const rename = fs.renameSync;
   const fault = t.mock.method(fs, "renameSync", (from: fs.PathLike, to: fs.PathLike) => {
     rename(from, to);
@@ -133,10 +124,7 @@ test("interruption after the atomic switch recovers the complete new bundle", as
   });
   const interrupted = await maintain({ command: "use", home }, { releases: {
     async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
-    async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
-    },
+    stage: stageRelease,
   } });
   fault.mock.restore();
   assert.equal(interrupted.installedVersion, "0.9.0");
@@ -148,15 +136,16 @@ test("interruption after the atomic switch recovers the complete new bundle", as
 });
 
 test("bootstrap resumes an interrupted adoption without losing originals", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const { home, target } = installationFiles(t);
   const symlink = fs.symlinkSync;
   const fault = t.mock.method(fs, "symlinkSync", (...args: Parameters<typeof fs.symlinkSync>) => {
     if (String(args[1]).endsWith("/use-knowledge-vault")) throw new Error("interrupted adoption");
     return symlink(...args);
   });
   await assert.rejects(maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] }), /interrupted adoption/);
+  for (const name of ["use-knowledge-vault", "init-knowledge-vault", "audit-knowledge-vault", "manage-current-focus"]) {
+    assert.equal(fs.readFileSync(path.join(target, name, "SKILL.md"), "utf8"), fs.readFileSync(path.join(PACKAGE_ROOT, "skills", name, "SKILL.md"), "utf8"));
+  }
   fault.mock.restore();
   const result = await maintain({ command: "status", home });
   assert.equal(result.status, "recovered");
@@ -164,16 +153,10 @@ test("bootstrap resumes an interrupted adoption without losing originals", async
 });
 
 test("explicit pins persist across callers and reject unpublished versions", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   const ports = { releases: {
     async list() { return ["0.8.0", "0.9.0"].map((version) => ({ version, revision: "a".repeat(40), published: true, prerelease: false })); },
-    async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
-    },
+    stage: stageRelease,
   } };
   assert.equal((await maintain({ command: "use", home, pin: "0.8.0" }, ports)).installedVersion, "0.8.0");
   assert.equal((await maintain({ command: "use", home }, ports)).installedVersion, "0.8.0");
@@ -197,15 +180,11 @@ test("old skill releases need no embedded update logic to bootstrap", async (t) 
 });
 
 test("verified release advisories apply to known loaded versions without requesting restart", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   const ports = { releases: {
     async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
     async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+      await stageRelease(release, destination);
       fs.writeFileSync(path.join(destination, "data-integrity-advisories.json"), JSON.stringify([
         { id: "fixture-advisory", affectedVersions: ["0.8.0"], message: "Verify the saved fixture before further writes.", url: "https://github.com/magickaichen/knowledge-loom/issues/46" },
       ]));
@@ -231,9 +210,7 @@ test("bootstrap detects linked installations and refuses plugin-owned caches", a
 });
 
 test("skills CLI ownership is detected and bookkeeping remains byte-identical after update", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const { home, target } = installationFiles(t);
   const lockFile = path.join(home, "skills-lock.json");
   const contents = '{"version":1,"skills":{"use-knowledge-vault":{"source":"magickaichen/knowledge-loom","sourceType":"github","computedHash":"old"},"other":{"computedHash":"keep"}}}';
   fs.writeFileSync(lockFile, contents);
@@ -241,20 +218,14 @@ test("skills CLI ownership is detected and bookkeeping remains byte-identical af
   assert.equal(bootstrap.installations?.find((item) => item.target.endsWith("use-knowledge-vault"))?.route, "skills-cli");
   const updated = await maintain({ command: "use", home }, { releases: {
     async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
-    async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
-    },
+    stage: stageRelease,
   } });
   assert.equal(updated.status, "updated");
   assert.equal(fs.readFileSync(lockFile, "utf8"), contents);
 });
 
 test("a killed staging process leaves the previous bundle and a recoverable shared lock", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   const child = spawn(process.execPath, ["--import", "tsx", "tests/support/interrupted-maintenance.ts", home], { cwd: PACKAGE_ROOT });
   t.after(() => child.kill("SIGKILL"));
   await new Promise<void>((resolve, reject) => {
@@ -274,9 +245,7 @@ test("a killed staging process leaves the previous bundle and a recoverable shar
 });
 
 test("the bootstrapped CLI runs independently of the source checkout", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const { home, target } = installationFiles(t);
   const bootstrap = spawnSync(process.execPath, [path.join(PACKAGE_ROOT, "dist", "maintenance.cjs"), "bootstrap", "--home", home, "--source", PACKAGE_ROOT, "--target", target], { encoding: "utf8", cwd: home });
   assert.equal(bootstrap.status, 0, bootstrap.stderr);
   const entry = path.join(home, ".local", "share", "knowledge-loom", "maintenance.cjs");
@@ -287,15 +256,11 @@ test("the bootstrapped CLI runs independently of the source checkout", async (t)
 });
 
 test("an incomplete staged release cannot replace the usable bundle", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   const failed = await maintain({ command: "use", home }, { releases: {
     async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
     async stage(release: { version: string }, destination: string) {
-      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+      await stageRelease(release, destination);
       fs.rmSync(path.join(destination, "skills", "init-knowledge-vault", "references", "contract-schema.md"));
     },
   } });
@@ -304,10 +269,7 @@ test("an incomplete staged release cannot replace the usable bundle", async (t) 
 });
 
 test("public use downloads a published GitHub release by its resolved immutable revision", async (t) => {
-  const home = temporaryDirectory(t);
-  const target = path.join(home, ".agents", "skills");
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target } = await bootstrapInstallation(t);
   const revision = "d".repeat(40);
   const prefix = `knowledge-loom-${revision}/`;
   const files: Zippable = { [`${prefix}package.json`]: Buffer.from('{"version":"0.9.0"}') };
@@ -338,4 +300,36 @@ test("public use downloads a published GitHub release by its resolved immutable 
   assert.equal(result.status, "updated", result.recovery?.error ?? "release should install");
   assert.equal(result.installedRevision, revision);
   assert.equal(requested.length, 4);
+});
+
+test("a pinned current release still supplies verified advisories on due use", async (t) => {
+  const { home } = await bootstrapInstallation(t);
+  const result = await maintain({ command: "use", home, pin: "0.8.0" }, { releases: {
+    async list() { return [{ version: "0.8.0", revision: "f".repeat(40), published: true, prerelease: false }]; },
+    async stage(release, destination) {
+      await stageRelease(release, destination);
+      fs.writeFileSync(path.join(destination, "data-integrity-advisories.json"), JSON.stringify([
+        { id: "current-version-advisory", affectedVersions: ["0.8.0"], message: "Inspect fixture integrity.", url: "https://github.com/magickaichen/knowledge-loom/issues/46" },
+      ]));
+    },
+  } });
+  assert.equal(result.status, "current");
+  assert.equal(result.advisories?.[0]?.id, "current-version-advisory");
+  assert.equal((await maintain({ command: "status", home })).advisories?.[0]?.id, "current-version-advisory");
+});
+
+test("interruption after one adoption exchange retains all four original skills", async (t) => {
+  const { home, target } = installationFiles(t);
+  const symlink = fs.symlinkSync;
+  const fault = t.mock.method(fs, "symlinkSync", (...args: Parameters<typeof fs.symlinkSync>) => {
+    if (String(args[1]).endsWith("/init-knowledge-vault")) throw new Error("interrupted after first exchange");
+    return symlink(...args);
+  });
+  await assert.rejects(maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] }), /interrupted after/);
+  assert.ok(fs.lstatSync(path.join(target, "use-knowledge-vault")).isSymbolicLink());
+  for (const name of ["use-knowledge-vault", "init-knowledge-vault", "audit-knowledge-vault", "manage-current-focus"]) {
+    assert.equal(fs.readFileSync(path.join(target, name, "SKILL.md"), "utf8"), fs.readFileSync(path.join(PACKAGE_ROOT, "skills", name, "SKILL.md"), "utf8"));
+  }
+  fault.mock.restore();
+  assert.equal((await maintain({ command: "status", home })).status, "recovered");
 });

--- a/tests/maintenance.test.ts
+++ b/tests/maintenance.test.ts
@@ -1,0 +1,341 @@
+import { zipSync, type Zippable } from "fflate";
+import { spawn, spawnSync } from "node:child_process";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { maintain } from "../src/maintenance/maintenance.ts";
+import { PACKAGE_ROOT, temporaryDirectory } from "./helpers.ts";
+
+test("explicit bootstrap keeps old skills usable through an external entry point", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const result = await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  assert.equal(result.status, "bootstrapped");
+  assert.equal(result.installedVersion, "0.8.0");
+  assert.equal(result.loadedVersion, "unknown");
+  assert.ok(result.entryPoint && fs.existsSync(result.entryPoint));
+  assert.ok(!result.entryPoint.startsWith(target));
+  assert.ok(fs.readFileSync(path.join(target, "use-knowledge-vault", "SKILL.md"), "utf8").includes("Use Knowledge Vault"));
+  assert.equal((await maintain({ command: "status", home })).status, "ready");
+});
+
+test("due use selects only published stable revisions at the elapsed weekly boundary", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  let lookups = 0;
+  let now = Date.UTC(2026, 0, 1);
+  const releases = {
+    async list() { lookups++; return [
+      { version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false },
+      { version: "1.0.0", revision: "b".repeat(40), published: true, prerelease: true },
+      { version: "2.0.0", revision: "c".repeat(40), published: false, prerelease: false },
+    ]; },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+    },
+  };
+  const ports = { releases, now: () => now };
+  const first = await maintain({ command: "use", home, loadedVersion: "0.8.0" }, ports);
+  assert.equal(first.installedVersion, "0.9.0");
+  assert.equal(first.loadedVersion, "0.8.0");
+  assert.equal(first.installedRevision, "a".repeat(40));
+  now += 604_800_000 - 1;
+  assert.equal((await maintain({ command: "use", home }, ports)).status, "not-due");
+  assert.equal(lookups, 1);
+  now++;
+  assert.equal((await maintain({ command: "use", home }, ports)).status, "current");
+  assert.equal(lookups, 2);
+});
+
+test("two runtime callers share one due lookup and installation", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  let lookups = 0;
+  const ports = { releases: {
+    async list() { lookups++; await new Promise((resolve) => setTimeout(resolve, 50)); return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+    },
+  } };
+  const results = await Promise.all([maintain({ command: "use", home }, ports), maintain({ command: "use", home }, ports)]);
+  assert.deepEqual(results.map((result) => result.status).sort(), ["not-due", "updated"]);
+  assert.equal(lookups, 1);
+});
+
+test("failed lookups retain last observation and back off durably", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  let now = Date.UTC(2026, 0, 1);
+  let lookups = 0;
+  const ports = { now: () => now, releases: {
+    async list() { lookups++; throw new Error("offline"); },
+    async stage() { throw new Error("must not install"); },
+  } };
+  const failed = await maintain({ command: "use", home }, ports);
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.lastCheck, undefined);
+  assert.match(failed.recovery?.error ?? "", /offline/);
+  assert.equal((await maintain({ command: "use", home }, ports)).status, "backoff");
+  assert.equal(lookups, 1);
+  now += 60_000;
+  assert.equal((await maintain({ command: "use", home }, ports)).status, "failed");
+  assert.equal(lookups, 2);
+  assert.equal((await maintain({ command: "status", home })).installedVersion, "0.8.0");
+});
+
+test("local edits block the whole update while manager bookkeeping and other skills survive", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const bookkeeping = path.join(home, ".agents", ".skill-lock.json");
+  fs.writeFileSync(bookkeeping, '{"version":3,"skills":{"unrelated":{"hash":"keep"}}}');
+  fs.mkdirSync(path.join(target, "unrelated"));
+  fs.writeFileSync(path.join(target, "unrelated", "SKILL.md"), "keep");
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const edited = path.join(target, "use-knowledge-vault", "SKILL.md");
+  fs.appendFileSync(edited, "\nLocal instruction\n");
+  const ports = { releases: {
+    async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+    },
+  } };
+  const result = await maintain({ command: "use", home }, ports);
+  assert.equal(result.status, "failed");
+  assert.match(result.recovery?.error ?? "", /local modification/);
+  assert.equal(result.installedVersion, "0.8.0");
+  assert.match(fs.readFileSync(edited, "utf8"), /Local instruction/);
+  assert.equal(fs.readFileSync(bookkeeping, "utf8"), '{"version":3,"skills":{"unrelated":{"hash":"keep"}}}');
+  assert.equal(fs.readFileSync(path.join(target, "unrelated", "SKILL.md"), "utf8"), "keep");
+});
+
+test("interruption after the atomic switch recovers the complete new bundle", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const rename = fs.renameSync;
+  const fault = t.mock.method(fs, "renameSync", (from: fs.PathLike, to: fs.PathLike) => {
+    rename(from, to);
+    if (String(to) === path.join(fs.realpathSync(home), ".local", "share", "knowledge-loom", "current")) throw new Error("simulated interruption after switch");
+  });
+  const interrupted = await maintain({ command: "use", home }, { releases: {
+    async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+    },
+  } });
+  fault.mock.restore();
+  assert.equal(interrupted.installedVersion, "0.9.0");
+  const recovered = await maintain({ command: "status", home });
+  assert.equal(recovered.installedVersion, "0.9.0");
+  assert.equal(recovered.installedRevision, "a".repeat(40));
+  assert.equal(recovered.status, "recovered");
+  assert.equal((await maintain({ command: "status", home })).status, "ready");
+});
+
+test("bootstrap resumes an interrupted adoption without losing originals", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const symlink = fs.symlinkSync;
+  const fault = t.mock.method(fs, "symlinkSync", (...args: Parameters<typeof fs.symlinkSync>) => {
+    if (String(args[1]).endsWith("/use-knowledge-vault")) throw new Error("interrupted adoption");
+    return symlink(...args);
+  });
+  await assert.rejects(maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] }), /interrupted adoption/);
+  fault.mock.restore();
+  const result = await maintain({ command: "status", home });
+  assert.equal(result.status, "recovered");
+  assert.equal(fs.readFileSync(path.join(target, "use-knowledge-vault", "SKILL.md"), "utf8"), fs.readFileSync(path.join(PACKAGE_ROOT, "skills", "use-knowledge-vault", "SKILL.md"), "utf8"));
+});
+
+test("explicit pins persist across callers and reject unpublished versions", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const ports = { releases: {
+    async list() { return ["0.8.0", "0.9.0"].map((version) => ({ version, revision: "a".repeat(40), published: true, prerelease: false })); },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+    },
+  } };
+  assert.equal((await maintain({ command: "use", home, pin: "0.8.0" }, ports)).installedVersion, "0.8.0");
+  assert.equal((await maintain({ command: "use", home }, ports)).installedVersion, "0.8.0");
+  assert.equal((await maintain({ command: "use", home, pin: "none" }, ports)).installedVersion, "0.9.0");
+  const lastCheck = (await maintain({ command: "status", home })).lastCheck;
+  const unavailable = await maintain({ command: "use", home, pin: "0.7.0" }, ports);
+  assert.equal(unavailable.status, "failed");
+  assert.equal(unavailable.lastCheck, lastCheck);
+});
+
+test("old skill releases need no embedded update logic to bootstrap", async (t) => {
+  const home = temporaryDirectory(t);
+  const old = path.join(home, "old-release");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(old, "skills"), { recursive: true });
+  fs.writeFileSync(path.join(old, "package.json"), '{"version":"0.1.0"}');
+  const target = path.join(home, ".claude", "skills");
+  fs.cpSync(path.join(old, "skills"), target, { recursive: true });
+  const result = await maintain({ command: "bootstrap", home, source: old, targets: [target], bootstrapRunner: path.join(PACKAGE_ROOT, "dist", "maintenance.cjs") });
+  assert.equal(result.installedVersion, "0.1.0");
+  assert.equal(result.status, "bootstrapped");
+});
+
+test("verified release advisories apply to known loaded versions without requesting restart", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const ports = { releases: {
+    async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+      fs.writeFileSync(path.join(destination, "data-integrity-advisories.json"), JSON.stringify([
+        { id: "fixture-advisory", affectedVersions: ["0.8.0"], message: "Verify the saved fixture before further writes.", url: "https://github.com/magickaichen/knowledge-loom/issues/46" },
+      ]));
+    },
+  } };
+  const result = await maintain({ command: "use", home, loadedVersion: "0.8.0" }, ports);
+  assert.equal(result.advisories?.[0]?.id, "fixture-advisory");
+  assert.equal(result.restartRequired, false);
+  assert.deepEqual((await maintain({ command: "status", home })).advisories, []);
+});
+
+test("bootstrap detects linked installations and refuses plugin-owned caches", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.mkdirSync(target, { recursive: true });
+  for (const name of ["use-knowledge-vault", "init-knowledge-vault", "audit-knowledge-vault", "manage-current-focus"]) fs.symlinkSync(path.join(PACKAGE_ROOT, "skills", name), path.join(target, name));
+  const result = await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  assert.ok(result.installations?.every((installation) => installation.route === "symlink"));
+  const pluginHome = temporaryDirectory(t);
+  const plugin = path.join(pluginHome, ".codex", "plugins", "cache", "knowledge-loom", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), plugin, { recursive: true });
+  await assert.rejects(maintain({ command: "bootstrap", home: pluginHome, source: PACKAGE_ROOT, targets: [plugin] }), /plugin.*owner/);
+});
+
+test("skills CLI ownership is detected and bookkeeping remains byte-identical after update", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const lockFile = path.join(home, "skills-lock.json");
+  const contents = '{"version":1,"skills":{"use-knowledge-vault":{"source":"magickaichen/knowledge-loom","sourceType":"github","computedHash":"old"},"other":{"computedHash":"keep"}}}';
+  fs.writeFileSync(lockFile, contents);
+  const bootstrap = await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  assert.equal(bootstrap.installations?.find((item) => item.target.endsWith("use-knowledge-vault"))?.route, "skills-cli");
+  const updated = await maintain({ command: "use", home }, { releases: {
+    async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+    },
+  } });
+  assert.equal(updated.status, "updated");
+  assert.equal(fs.readFileSync(lockFile, "utf8"), contents);
+});
+
+test("a killed staging process leaves the previous bundle and a recoverable shared lock", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const child = spawn(process.execPath, ["--import", "tsx", "tests/support/interrupted-maintenance.ts", home], { cwd: PACKAGE_ROOT });
+  t.after(() => child.kill("SIGKILL"));
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => { child.kill("SIGKILL"); reject(new Error("staging timeout")); }, 10_000);
+    child.once("error", reject);
+    child.stdout.once("data", () => { clearTimeout(timer); resolve(); });
+  });
+  const closed = new Promise((resolve) => child.once("close", resolve));
+  const busy = await maintain({ command: "use", home, lockWaitMs: 25 });
+  assert.equal(busy.status, "busy");
+  child.kill("SIGKILL");
+  await closed;
+  const recovered = await maintain({ command: "status", home });
+  assert.equal(recovered.installedVersion, "0.8.0");
+  assert.match(recovered.recovery?.error ?? "", /interrupted/);
+  assert.equal(recovered.status, "recovered");
+});
+
+test("the bootstrapped CLI runs independently of the source checkout", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  const bootstrap = spawnSync(process.execPath, [path.join(PACKAGE_ROOT, "dist", "maintenance.cjs"), "bootstrap", "--home", home, "--source", PACKAGE_ROOT, "--target", target], { encoding: "utf8", cwd: home });
+  assert.equal(bootstrap.status, 0, bootstrap.stderr);
+  const entry = path.join(home, ".local", "share", "knowledge-loom", "maintenance.cjs");
+  const status = spawnSync(process.execPath, [entry, "status", "--home", home, "--loaded-version", "0.7.0"], { encoding: "utf8", cwd: home, env: { ...process.env, HOME: home, NODE_PATH: "" } });
+  assert.equal(status.status, 0, status.stderr);
+  assert.equal(JSON.parse(status.stdout).loadedVersion, "0.7.0");
+  assert.equal(JSON.parse(status.stdout).installedVersion, "0.8.0");
+});
+
+test("an incomplete staged release cannot replace the usable bundle", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const failed = await maintain({ command: "use", home }, { releases: {
+    async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
+    async stage(release: { version: string }, destination: string) {
+      fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+      fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+      fs.rmSync(path.join(destination, "skills", "init-knowledge-vault", "references", "contract-schema.md"));
+    },
+  } });
+  assert.equal(failed.status, "failed");
+  assert.equal(failed.installedVersion, "0.8.0");
+});
+
+test("public use downloads a published GitHub release by its resolved immutable revision", async (t) => {
+  const home = temporaryDirectory(t);
+  const target = path.join(home, ".agents", "skills");
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
+  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const revision = "d".repeat(40);
+  const prefix = `knowledge-loom-${revision}/`;
+  const files: Zippable = { [`${prefix}package.json`]: Buffer.from('{"version":"0.9.0"}') };
+  const visit = (directory: string): void => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(file);
+      else files[prefix + path.relative(PACKAGE_ROOT, file)] = fs.readFileSync(file);
+    }
+  };
+  visit(path.join(PACKAGE_ROOT, "skills"));
+  const archive = zipSync(files);
+  const requested: string[] = [];
+  t.mock.method(globalThis, "fetch", async (input: string | URL | Request) => {
+    const url = String(input);
+    requested.push(url);
+    if (url.endsWith("releases?per_page=100&page=1")) return Response.json([
+      { tag_name: "v0.9.0", draft: false, prerelease: false, published_at: "2026-01-01T00:00:00Z" },
+      { tag_name: "v1.0.0", draft: false, prerelease: true, published_at: "2026-01-02T00:00:00Z" },
+      { tag_name: "v2.0.0", draft: true, prerelease: false, published_at: null },
+    ]);
+    if (url.endsWith("git/ref/tags/v0.9.0")) return Response.json({ object: { type: "tag", sha: "e".repeat(40) } });
+    if (url.endsWith(`git/tags/${"e".repeat(40)}`)) return Response.json({ object: { type: "commit", sha: revision } });
+    if (url === `https://codeload.github.com/magickaichen/knowledge-loom/zip/${revision}`) return new Response(new Uint8Array(archive));
+    throw new Error(`unexpected URL: ${url}`);
+  });
+  const result = await maintain({ command: "use", home });
+  assert.equal(result.status, "updated", result.recovery?.error ?? "release should install");
+  assert.equal(result.installedRevision, revision);
+  assert.equal(requested.length, 4);
+});

--- a/tests/support/interrupted-maintenance.ts
+++ b/tests/support/interrupted-maintenance.ts
@@ -1,0 +1,8 @@
+import { maintain } from "../../src/maintenance/maintenance.ts";
+await maintain({ command: "use", home: process.argv[2]! }, { releases: {
+  async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
+  async stage() {
+    process.stdout.write("STAGING\n");
+    await new Promise(() => { setInterval(() => {}, 1000); });
+  },
+} });


### PR DESCRIPTION
Knowledge Loom installations can now explicitly bootstrap an external maintenance entry point and check for published stable releases on a shared seven-day interval. Updates honor pins, validate all four skills, preserve local edits and installer bookkeeping, and switch the complete bundle atomically. Installed and caller-loaded versions remain separate; due checks also retrieve verified advisories for pinned current versions.

First adoption uses a tracked native atomic exchange, with Python 3 required on macOS or Linux. Copied, checkout-linked, and skills CLI installations are supported; plugin-owned caches remain with their owning manager. Runtime wiring and recovery steps are documented. Installation and update tests use temporary homes.

Validation: `npm run validate:npx`, including public maintenance tests for weekly boundaries, release/tag selection, pins, old-skill bootstrap, process interruption, concurrent callers, local modifications, bookkeeping, and version/advisory reporting. Standards and Spec findings were fixed and re-reviewed.

Closes #46. #47 is outside this change.
