### PR TITLE
Prepare v0.9.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "knowledge-loom",
       "source": "./",
       "description": "Keep Codex and Claude inside clear boundaries when they read or update local Markdown notes.",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "author": {
         "name": "Mike Xiao",
         "url": "https://github.com/magickaichen"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Governed local Markdown knowledge vault workflows",
   "author": {
     "name": "Mike Xiao",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## v0.9.0
+
+Knowledge Loom now provides a shared maintenance entry point for stable skill releases and vault
+freshness in Codex and Claude Code. Existing installations need a one-time
+[setup and ownership migration](https://github.com/magickaichen/knowledge-loom/blob/v0.9.0/docs/runtime-maintenance.md); publishing this release alone does
+not activate maintenance in existing sessions.
+
+### Added
+
+- Check published stable skill releases on use, with a shared seven-day interval, explicit version
+  pins, atomic bundle replacement, and recovery that preserves a usable installation.
+- Check authorized vault remotes on access at a shared 24-hour interval. Safely fast-forward clean
+  checkouts and report observed, integrated, deferred, and unavailable states separately.
+- Preserve local reads, edits, and commits during remote failures. Retain pending synchronization
+  and use bounded evidence-based reconciliation after rejected pushes, even inside the daily cache.
+- Add previewable, idempotent Codex and Claude Code setup with shared skills, explicit duplicate
+  ownership migration, external access routing, and startup context without maintenance networking.
+- Run maintenance before Claude native reads within the applicable vault. Native Skill invocation
+  checks releases; explicit routing retains vault selection and publication.
+
+### Safety and compatibility
+
+- Preserve unfinished edits, live writers, existing configuration, and installation backups.
+  Maintenance contention does not block otherwise authorized local reads.
+- Assess verified integrity advisories before affected vault mutations; keep installed versions
+  separate from instructions already loaded in a session.
+- Preserve contract schema version 1 and read-only resolver/audit behavior. Inbound synchronization
+  requires explicit contract configuration; provider-specific backup adapters remain external.
+- Keep arbitrary shell reads and opt-out tools outside automatic interception. Hosted standalone
+  invocation, independent Codex startup-hook acceptance, hot reload, and hosted semantic
+  reconciliation remain unverified; see the [runtime verification record](https://github.com/magickaichen/knowledge-loom/blob/v0.9.0/docs/runtime-verification.md).
+- Report missing Git in the runtime tool PATH as a dependency error, rather than a vault-lock conflict.
+
 ## v0.8.0
 
 `init-knowledge-vault` can now turn existing authorized work into a populated vault without first

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "knowledge-loom",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "knowledge-loom",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "2.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-loom",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Agent-neutral governance and skills for local Markdown knowledge vaults",
   "type": "module",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -21,6 +21,13 @@ export function copyFixture(name: string, destination: string): string {
   return destination;
 }
 
+/** Synthetic release metadata keeps upgrade scenarios independent of the shipping version. */
+export function copyReleaseFixture(destination: string, version: string): string {
+  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
+  fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version }));
+  return destination;
+}
+
 export function readJson<T>(relative: string): T {
   return JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT, relative), "utf8")) as T;
 }

--- a/tests/maintenance.test.ts
+++ b/tests/maintenance.test.ts
@@ -6,27 +6,29 @@ import path from "node:path";
 import test, { type TestContext } from "node:test";
 
 import { maintain } from "../src/maintenance/maintenance.ts";
-import { PACKAGE_ROOT, temporaryDirectory } from "./helpers.ts";
+import { PACKAGE_ROOT, temporaryDirectory, copyReleaseFixture } from "./helpers.ts";
 
-function installationFiles(t: TestContext): { home: string; target: string } {
+const bootstrapRunner = path.join(PACKAGE_ROOT, "dist", "maintenance.cjs");
+
+function installationFiles(t: TestContext): { home: string; target: string; source: string } {
   const home = temporaryDirectory(t);
   const target = path.join(home, ".agents", "skills");
   fs.cpSync(path.join(PACKAGE_ROOT, "skills"), target, { recursive: true });
-  return { home, target };
+  const source = copyReleaseFixture(path.join(home, "source"), "0.8.0");
+  return { home, target, source };
 }
 async function bootstrapInstallation(t: TestContext): Promise<{ home: string; target: string }> {
   const installation = installationFiles(t);
-  await maintain({ command: "bootstrap", ...installation, source: PACKAGE_ROOT, targets: [installation.target] });
+  await maintain({ command: "bootstrap", bootstrapRunner, ...installation, targets: [installation.target] });
   return installation;
 }
 async function stageRelease(release: { version: string }, destination: string): Promise<void> {
-  fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(destination, "skills"), { recursive: true });
-  fs.writeFileSync(path.join(destination, "package.json"), JSON.stringify({ version: release.version }));
+  copyReleaseFixture(destination, release.version);
 }
 
 test("explicit bootstrap keeps old skills usable through an external entry point", async (t) => {
-  const { home, target } = installationFiles(t);
-  const result = await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const { home, target, source } = installationFiles(t);
+  const result = await maintain({ command: "bootstrap", bootstrapRunner, home, source, targets: [target] });
   assert.equal(result.status, "bootstrapped");
   assert.equal(result.installedVersion, "0.8.0");
   assert.equal(result.loadedVersion, "unknown");
@@ -94,12 +96,12 @@ test("failed lookups retain last observation and back off durably", async (t) =>
 });
 
 test("local edits block the whole update while manager bookkeeping and other skills survive", async (t) => {
-  const { home, target } = installationFiles(t);
+  const { home, target, source } = installationFiles(t);
   const bookkeeping = path.join(home, ".agents", ".skill-lock.json");
   fs.writeFileSync(bookkeeping, '{"version":3,"skills":{"unrelated":{"hash":"keep"}}}');
   fs.mkdirSync(path.join(target, "unrelated"));
   fs.writeFileSync(path.join(target, "unrelated", "SKILL.md"), "keep");
-  await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  await maintain({ command: "bootstrap", bootstrapRunner, home, source, targets: [target] });
   const edited = path.join(target, "use-knowledge-vault", "SKILL.md");
   fs.appendFileSync(edited, "\nLocal instruction\n");
   const ports = { releases: {
@@ -136,13 +138,13 @@ test("interruption after the atomic switch recovers the complete new bundle", as
 });
 
 test("bootstrap resumes an interrupted adoption without losing originals", async (t) => {
-  const { home, target } = installationFiles(t);
+  const { home, target, source } = installationFiles(t);
   const symlink = fs.symlinkSync;
   const fault = t.mock.method(fs, "symlinkSync", (...args: Parameters<typeof fs.symlinkSync>) => {
     if (String(args[1]).endsWith("/use-knowledge-vault")) throw new Error("interrupted adoption");
     return symlink(...args);
   });
-  await assert.rejects(maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] }), /interrupted adoption/);
+  await assert.rejects(maintain({ command: "bootstrap", bootstrapRunner, home, source, targets: [target] }), /interrupted adoption/);
   for (const name of ["use-knowledge-vault", "init-knowledge-vault", "audit-knowledge-vault", "manage-current-focus"]) {
     assert.equal(fs.readFileSync(path.join(target, name, "SKILL.md"), "utf8"), fs.readFileSync(path.join(PACKAGE_ROOT, "skills", name, "SKILL.md"), "utf8"));
   }
@@ -174,7 +176,7 @@ test("old skill releases need no embedded update logic to bootstrap", async (t) 
   fs.writeFileSync(path.join(old, "package.json"), '{"version":"0.1.0"}');
   const target = path.join(home, ".claude", "skills");
   fs.cpSync(path.join(old, "skills"), target, { recursive: true });
-  const result = await maintain({ command: "bootstrap", home, source: old, targets: [target], bootstrapRunner: path.join(PACKAGE_ROOT, "dist", "maintenance.cjs") });
+  const result = await maintain({ command: "bootstrap", bootstrapRunner, home, source: old, targets: [target] });
   assert.equal(result.installedVersion, "0.1.0");
   assert.equal(result.status, "bootstrapped");
 });
@@ -201,20 +203,20 @@ test("bootstrap detects linked installations and refuses plugin-owned caches", a
   const target = path.join(home, ".agents", "skills");
   fs.mkdirSync(target, { recursive: true });
   for (const name of ["use-knowledge-vault", "init-knowledge-vault", "audit-knowledge-vault", "manage-current-focus"]) fs.symlinkSync(path.join(PACKAGE_ROOT, "skills", name), path.join(target, name));
-  const result = await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const result = await maintain({ command: "bootstrap", bootstrapRunner, home, source: PACKAGE_ROOT, targets: [target] });
   assert.ok(result.installations?.every((installation) => installation.route === "symlink"));
   const pluginHome = temporaryDirectory(t);
   const plugin = path.join(pluginHome, ".codex", "plugins", "cache", "knowledge-loom", "skills");
   fs.cpSync(path.join(PACKAGE_ROOT, "skills"), plugin, { recursive: true });
-  await assert.rejects(maintain({ command: "bootstrap", home: pluginHome, source: PACKAGE_ROOT, targets: [plugin] }), /plugin.*owner/);
+  await assert.rejects(maintain({ command: "bootstrap", bootstrapRunner, home: pluginHome, source: PACKAGE_ROOT, targets: [plugin] }), /plugin.*owner/);
 });
 
 test("skills CLI ownership is detected and bookkeeping remains byte-identical after update", async (t) => {
-  const { home, target } = installationFiles(t);
+  const { home, target, source } = installationFiles(t);
   const lockFile = path.join(home, "skills-lock.json");
   const contents = '{"version":1,"skills":{"use-knowledge-vault":{"source":"magickaichen/knowledge-loom","sourceType":"github","computedHash":"old"},"other":{"computedHash":"keep"}}}';
   fs.writeFileSync(lockFile, contents);
-  const bootstrap = await maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] });
+  const bootstrap = await maintain({ command: "bootstrap", bootstrapRunner, home, source, targets: [target] });
   assert.equal(bootstrap.installations?.find((item) => item.target.endsWith("use-knowledge-vault"))?.route, "skills-cli");
   const updated = await maintain({ command: "use", home }, { releases: {
     async list() { return [{ version: "0.9.0", revision: "a".repeat(40), published: true, prerelease: false }]; },
@@ -245,8 +247,8 @@ test("a killed staging process leaves the previous bundle and a recoverable shar
 });
 
 test("the bootstrapped CLI runs independently of the source checkout", async (t) => {
-  const { home, target } = installationFiles(t);
-  const bootstrap = spawnSync(process.execPath, [path.join(PACKAGE_ROOT, "dist", "maintenance.cjs"), "bootstrap", "--home", home, "--source", PACKAGE_ROOT, "--target", target], { encoding: "utf8", cwd: home });
+  const { home, target, source } = installationFiles(t);
+  const bootstrap = spawnSync(process.execPath, [path.join(PACKAGE_ROOT, "dist", "maintenance.cjs"), "bootstrap", "--home", home, "--source", source, "--target", target], { encoding: "utf8", cwd: home });
   assert.equal(bootstrap.status, 0, bootstrap.stderr);
   const entry = path.join(home, ".local", "share", "knowledge-loom", "maintenance.cjs");
   const status = spawnSync(process.execPath, [entry, "status", "--home", home, "--loaded-version", "0.7.0"], { encoding: "utf8", cwd: home, env: { ...process.env, HOME: home, NODE_PATH: "" } });
@@ -319,13 +321,13 @@ test("a pinned current release still supplies verified advisories on due use", a
 });
 
 test("interruption after one adoption exchange retains all four original skills", async (t) => {
-  const { home, target } = installationFiles(t);
+  const { home, target, source } = installationFiles(t);
   const symlink = fs.symlinkSync;
   const fault = t.mock.method(fs, "symlinkSync", (...args: Parameters<typeof fs.symlinkSync>) => {
     if (String(args[1]).endsWith("/init-knowledge-vault")) throw new Error("interrupted after first exchange");
     return symlink(...args);
   });
-  await assert.rejects(maintain({ command: "bootstrap", home, source: PACKAGE_ROOT, targets: [target] }), /interrupted after/);
+  await assert.rejects(maintain({ command: "bootstrap", bootstrapRunner, home, source, targets: [target] }), /interrupted after/);
   assert.ok(fs.lstatSync(path.join(target, "use-knowledge-vault")).isSymbolicLink());
   for (const name of ["use-knowledge-vault", "init-knowledge-vault", "audit-knowledge-vault", "manage-current-focus"]) {
     assert.equal(fs.readFileSync(path.join(target, name, "SKILL.md"), "utf8"), fs.readFileSync(path.join(PACKAGE_ROOT, "skills", name, "SKILL.md"), "utf8"));

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
-import { PACKAGE_ROOT, temporaryDirectory } from "./helpers.ts";
+import { PACKAGE_ROOT, temporaryDirectory, copyReleaseFixture } from "./helpers.ts";
 
 function cli(home: string, ...args: string[]) {
   const result = spawnSync(process.execPath, ["dist/maintenance.cjs", ...args, "--home", home], { cwd: PACKAGE_ROOT, encoding: "utf8" });
@@ -162,10 +162,11 @@ test("setup refuses a runtime directory symlink escaping the selected home befor
 });
 test("migration of an existing runtime-specific bootstrap keeps shared skills tracked by the updater", async (t) => {
   const home = fs.realpathSync(temporaryDirectory(t));
+  const source = copyReleaseFixture(path.join(home, "source"), "0.8.0");
   const legacy = path.join(home, ".codex/skills");
   fs.cpSync(path.join(PACKAGE_ROOT, "skills"), legacy, { recursive: true });
-  cli(home, "bootstrap", "--source", PACKAGE_ROOT, "--target", legacy);
-  cli(home, "setup", "--source", PACKAGE_ROOT, "--apply", "--migrate");
+  cli(home, "bootstrap", "--source", source, "--target", legacy);
+  cli(home, "setup", "--source", source, "--apply", "--migrate");
   const status = cli(home, "status");
   const shared = path.join(home, ".agents/skills/use-knowledge-vault");
   assert.ok(status.installations.some((installation: { target: string }) => installation.target === shared));
@@ -183,7 +184,8 @@ test("verified advisories return to the active runtime before vault operations a
   const { runRuntime } = await import("../src/maintenance/runtime.ts");
   const { copyFixture } = await import("./helpers.ts");
   const home = fs.realpathSync(temporaryDirectory(t));
-  cli(home, "setup", "--source", PACKAGE_ROOT, "--apply");
+  const source = copyReleaseFixture(path.join(home, "source"), "0.8.0");
+  cli(home, "setup", "--source", source, "--apply");
   const vault = copyFixture("single-proactive", path.join(home, "vault"));
   const ports = { cwd: vault, releases: { async list() { return [{ version: "0.8.0", published: true, prerelease: false, revision: "a".repeat(40) }]; }, async stage(_release: unknown, target: string) {
     fs.cpSync(path.join(PACKAGE_ROOT, "skills"), path.join(target, "skills"), { recursive: true });


### PR DESCRIPTION
Prepare v0.9.0 by synchronizing package/lockfile versions, both plugin manifests, and the Claude marketplace. The changelog covers shared release maintenance, vault synchronization, runtime setup, migration requirements, and verified capability limits. Its documentation links target the release tag so they also work in the extracted GitHub Release notes.

Upgrade tests previously used the shipping checkout as version 0.8.0, so a version bump changed their old-version fixture. They now use explicit synthetic 0.8.0 sources, preserving the existing upgrade, rollback, pin, interruption, and advisory assertions independently of future releases.

Validation: `npm run build`, `npm run validate:npx` (172 tests and isolated installation checks across 55 roots), and `scripts/check-release-version.ts v0.9.0` with release-note extraction. This PR prepares the release; tagging/publishing and local installation migration are separate steps.
